### PR TITLE
Implemented ChaCha20-Poly1305 wrapper and integration tests

### DIFF
--- a/example/integration_test/chacha20_test.dart
+++ b/example/integration_test/chacha20_test.dart
@@ -1,0 +1,105 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:m_security/src/encryption/chacha20.dart';
+import 'package:m_security/src/encryption/aes_gcm.dart';
+import 'package:m_security/src/rust/api/encryption/chacha20.dart' as rust_chacha;
+import 'package:m_security/src/rust/frb_generated.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async => await RustLib.init());
+
+  group('ChaCha20-Poly1305', () {
+    test('encrypt then decrypt returns original data', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final original = Uint8List.fromList('hello ChaCha20'.codeUnits);
+      final encrypted = await service.encrypt(original);
+      final decrypted = await service.decrypt(encrypted);
+
+      expect(decrypted, equals(original));
+    });
+
+    test('wrong key throws error', () async {
+      final service1 = Chacha20Service();
+      await service1.initWithRandomKey();
+
+      final service2 = Chacha20Service();
+      await service2.initWithRandomKey();
+
+      final encrypted = await service1.encrypt(
+        Uint8List.fromList('secret data'.codeUnits),
+      );
+
+      expect(
+        () => service2.decrypt(encrypted),
+        throwsA(anything),
+      );
+    });
+
+    test('tampered data throws error', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final encrypted = await service.encrypt(
+        Uint8List.fromList('tamper test'.codeUnits),
+      );
+
+      // Flip a byte in the ciphertext
+      encrypted[encrypted.length - 1] ^= 0xFF;
+
+      expect(
+        () => service.decrypt(encrypted),
+        throwsA(anything),
+      );
+    });
+
+    test('encrypting/decrypting empty data works', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final empty = Uint8List(0);
+      final encrypted = await service.encrypt(empty);
+      final decrypted = await service.decrypt(encrypted);
+
+      expect(decrypted, equals(empty));
+    });
+
+    test('key generation returns 32 bytes', () async {
+      final key = await rust_chacha.generateChachaKey();
+      expect(key.length, equals(32));
+    });
+
+    test('same data encrypted twice gives different output', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final data = Uint8List.fromList('same data'.codeUnits);
+      final enc1 = await service.encrypt(data);
+      final enc2 = await service.encrypt(data);
+
+      expect(enc1, isNot(equals(enc2)));
+    });
+
+    test('AES-GCM ciphertext cannot be decrypted with ChaCha20', () async {
+
+      //encrypt with AES-GCM
+      final aesService = AesGcmService();
+      await aesService.initWithRandomKey();
+      final aesEncrypted = await aesService.encrypt(
+        Uint8List.fromList('cross test'.codeUnits),
+      );
+
+      final chachaService = Chacha20Service();
+      await chachaService.initWithRandomKey();
+
+      //try to decrypt with chacha
+      expect(
+        () => chachaService.decrypt(aesEncrypted),
+        throwsA(anything),
+      );
+    });
+  });
+}

--- a/integration_test/chacha20_test.dart
+++ b/integration_test/chacha20_test.dart
@@ -1,0 +1,105 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:m_security/src/encryption/chacha20.dart';
+import 'package:m_security/src/encryption/aes_gcm.dart';
+import 'package:m_security/src/rust/api/encryption/chacha20.dart' as rust_chacha;
+import 'package:m_security/src/rust/frb_generated.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async => await RustLib.init());
+
+  group('ChaCha20-Poly1305', () {
+    test('encrypt then decrypt returns original data', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final original = Uint8List.fromList('hello ChaCha20'.codeUnits);
+      final encrypted = await service.encrypt(original);
+      final decrypted = await service.decrypt(encrypted);
+
+      expect(decrypted, equals(original));
+    });
+
+    test('wrong key throws error', () async {
+      final service1 = Chacha20Service();
+      await service1.initWithRandomKey();
+
+      final service2 = Chacha20Service();
+      await service2.initWithRandomKey();
+
+      final encrypted = await service1.encrypt(
+        Uint8List.fromList('secret data'.codeUnits),
+      );
+
+      expect(
+        () => service2.decrypt(encrypted),
+        throwsA(anything),
+      );
+    });
+
+    test('tampered data throws error', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final encrypted = await service.encrypt(
+        Uint8List.fromList('tamper test'.codeUnits),
+      );
+
+      // Flip a byte in the ciphertext
+      encrypted[encrypted.length - 1] ^= 0xFF;
+
+      expect(
+        () => service.decrypt(encrypted),
+        throwsA(anything),
+      );
+    });
+
+    test('encrypting/decrypting empty data works', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final empty = Uint8List(0);
+      final encrypted = await service.encrypt(empty);
+      final decrypted = await service.decrypt(encrypted);
+
+      expect(decrypted, equals(empty));
+    });
+
+    test('key generation returns 32 bytes', () async {
+      final key = await rust_chacha.generateChachaKey();
+      expect(key.length, equals(32));
+    });
+
+    test('same data encrypted twice gives different output', () async {
+      final service = Chacha20Service();
+      await service.initWithRandomKey();
+
+      final data = Uint8List.fromList('same data'.codeUnits);
+      final enc1 = await service.encrypt(data);
+      final enc2 = await service.encrypt(data);
+
+      expect(enc1, isNot(equals(enc2)));
+    });
+
+    test('AES-GCM ciphertext cannot be decrypted with ChaCha20', () async {
+
+      //encrypt with AES-GCM
+      final aesService = AesGcmService();
+      await aesService.initWithRandomKey();
+      final aesEncrypted = await aesService.encrypt(
+        Uint8List.fromList('cross test'.codeUnits),
+      );
+
+      final chachaService = Chacha20Service();
+      await chachaService.initWithRandomKey();
+
+      //try to decrypt with chacha
+      expect(
+        () => chachaService.decrypt(aesEncrypted),
+        throwsA(anything),
+      );
+    });
+  });
+}

--- a/lib/src/encryption/chacha20.dart
+++ b/lib/src/encryption/chacha20.dart
@@ -1,0 +1,56 @@
+import 'dart:typed_data';
+import 'package:m_security/src/rust/api/encryption/chacha20.dart' as rust_chacha;
+
+class Chacha20Service {
+
+  rust_chacha.ChaCha20Poly1305Cipher? _cipher;
+
+  Future<void> initWithRandomKey() async {
+
+    final key = await rust_chacha.generateChachaKey();
+    _cipher = await rust_chacha.ChaCha20Poly1305Cipher.newInstance(key: key);
+
+  }
+
+  Future<Uint8List> encrypt(Uint8List plaintext, {Uint8List? aad}) async {
+
+    if (_cipher == null) throw Exception('Cipher not initialized');
+
+    return await _cipher!.encrypt(
+      plaintext: plaintext,
+      aad: aad ?? Uint8List(0),
+    );
+
+  }
+
+  Future<Uint8List> decrypt(Uint8List ciphertext, {Uint8List? aad}) async {
+
+    if (_cipher == null) throw Exception('Cipher not initialized');
+
+    return await _cipher!.decrypt(
+      ciphertext: ciphertext,
+      aad: aad ?? Uint8List(0),
+    );
+
+  }
+
+  Future<Uint8List> encryptString(String plaintext, {String? aad}) async {
+
+    return encrypt(
+      Uint8List.fromList(plaintext.codeUnits),
+      aad: aad != null ? Uint8List.fromList(aad.codeUnits) : null,
+    );
+
+  }
+
+  Future<String> decryptString(Uint8List ciphertext, {String? aad}) async {
+
+    final decrypted = await decrypt(
+      ciphertext,
+      aad: aad != null ? Uint8List.fromList(aad.codeUnits) : null,
+    );
+
+    return String.fromCharCodes(decrypted);
+    
+  }
+}

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -5,6 +5,7 @@
 
 import 'api/encryption.dart';
 import 'api/encryption/aes_gcm.dart';
+import 'api/encryption/chacha20.dart';
 import 'api/encryption/noop.dart';
 import 'api/hashing.dart';
 import 'api/hashing/argon2.dart';
@@ -70,7 +71,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 2044205325;
+  int get rustContentHash => -750396704;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -100,6 +101,25 @@ abstract class RustLibApi extends BaseApi {
   Future<Aes256GcmCipher> crateApiEncryptionAesGcmAes256GcmCipherNew({
     required List<int> key,
   });
+
+  Future<void> crateApiEncryptionChacha20ChaCha20Poly1305CipherAlgorithmId({
+    required ChaCha20Poly1305Cipher that,
+  });
+
+  Future<Uint8List> crateApiEncryptionChacha20ChaCha20Poly1305CipherDecrypt({
+    required ChaCha20Poly1305Cipher that,
+    required List<int> ciphertext,
+    required List<int> aad,
+  });
+
+  Future<Uint8List> crateApiEncryptionChacha20ChaCha20Poly1305CipherEncrypt({
+    required ChaCha20Poly1305Cipher that,
+    required List<int> plaintext,
+    required List<int> aad,
+  });
+
+  Future<ChaCha20Poly1305Cipher>
+  crateApiEncryptionChacha20ChaCha20Poly1305CipherNew({required List<int> key});
 
   Future<void> crateApiEncryptionNoopNoopEncryptionAlgorithmId({
     required NoopEncryption that,
@@ -141,6 +161,10 @@ abstract class RustLibApi extends BaseApi {
 
   Future<HasherHandle> crateApiHashingCreateBlake3();
 
+  Future<CipherHandle> crateApiEncryptionCreateChacha20Poly1305({
+    required List<int> key,
+  });
+
   Future<CipherHandle> crateApiEncryptionCreateNoopEncryption();
 
   Future<HasherHandle> crateApiHashingCreateSha3();
@@ -164,6 +188,10 @@ abstract class RustLibApi extends BaseApi {
   Future<Uint8List> crateApiEncryptionGenerateAes256GcmKey();
 
   Future<Uint8List> crateApiEncryptionAesGcmGenerateAesKey();
+
+  Future<Uint8List> crateApiEncryptionGenerateChacha20Poly1305Key();
+
+  Future<Uint8List> crateApiEncryptionChacha20GenerateChachaKey();
 
   Future<String> crateApiHashingHasherAlgorithmId({
     required HasherHandle handle,
@@ -208,6 +236,15 @@ abstract class RustLibApi extends BaseApi {
 
   CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_Aes256GcmCipherPtr;
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_ChaCha20Poly1305Cipher;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_ChaCha20Poly1305Cipher;
+
+  CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_ChaCha20Poly1305CipherPtr;
 
   RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_CipherHandle;
@@ -392,6 +429,165 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "Aes256GcmCipher_new", argNames: ["key"]);
 
   @override
+  Future<void> crateApiEncryptionChacha20ChaCha20Poly1305CipherAlgorithmId({
+    required ChaCha20Poly1305Cipher that,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+            that,
+            serializer,
+          );
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 5,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_unit,
+          decodeErrorData: null,
+        ),
+        constMeta:
+            kCrateApiEncryptionChacha20ChaCha20Poly1305CipherAlgorithmIdConstMeta,
+        argValues: [that],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiEncryptionChacha20ChaCha20Poly1305CipherAlgorithmIdConstMeta =>
+      const TaskConstMeta(
+        debugName: "ChaCha20Poly1305Cipher_algorithm_id",
+        argNames: ["that"],
+      );
+
+  @override
+  Future<Uint8List> crateApiEncryptionChacha20ChaCha20Poly1305CipherDecrypt({
+    required ChaCha20Poly1305Cipher that,
+    required List<int> ciphertext,
+    required List<int> aad,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+            that,
+            serializer,
+          );
+          sse_encode_list_prim_u_8_loose(ciphertext, serializer);
+          sse_encode_list_prim_u_8_loose(aad, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 6,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+          decodeErrorData: sse_decode_crypto_error,
+        ),
+        constMeta:
+            kCrateApiEncryptionChacha20ChaCha20Poly1305CipherDecryptConstMeta,
+        argValues: [that, ciphertext, aad],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiEncryptionChacha20ChaCha20Poly1305CipherDecryptConstMeta =>
+      const TaskConstMeta(
+        debugName: "ChaCha20Poly1305Cipher_decrypt",
+        argNames: ["that", "ciphertext", "aad"],
+      );
+
+  @override
+  Future<Uint8List> crateApiEncryptionChacha20ChaCha20Poly1305CipherEncrypt({
+    required ChaCha20Poly1305Cipher that,
+    required List<int> plaintext,
+    required List<int> aad,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+            that,
+            serializer,
+          );
+          sse_encode_list_prim_u_8_loose(plaintext, serializer);
+          sse_encode_list_prim_u_8_loose(aad, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 7,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+          decodeErrorData: sse_decode_crypto_error,
+        ),
+        constMeta:
+            kCrateApiEncryptionChacha20ChaCha20Poly1305CipherEncryptConstMeta,
+        argValues: [that, plaintext, aad],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiEncryptionChacha20ChaCha20Poly1305CipherEncryptConstMeta =>
+      const TaskConstMeta(
+        debugName: "ChaCha20Poly1305Cipher_encrypt",
+        argNames: ["that", "plaintext", "aad"],
+      );
+
+  @override
+  Future<ChaCha20Poly1305Cipher>
+  crateApiEncryptionChacha20ChaCha20Poly1305CipherNew({
+    required List<int> key,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_prim_u_8_loose(key, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 8,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher,
+          decodeErrorData: sse_decode_crypto_error,
+        ),
+        constMeta:
+            kCrateApiEncryptionChacha20ChaCha20Poly1305CipherNewConstMeta,
+        argValues: [key],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta
+  get kCrateApiEncryptionChacha20ChaCha20Poly1305CipherNewConstMeta =>
+      const TaskConstMeta(
+        debugName: "ChaCha20Poly1305Cipher_new",
+        argNames: ["key"],
+      );
+
+  @override
   Future<void> crateApiEncryptionNoopNoopEncryptionAlgorithmId({
     required NoopEncryption that,
   }) {
@@ -406,7 +602,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 5,
+            funcId: 9,
             port: port_,
           );
         },
@@ -446,7 +642,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 6,
+            funcId: 10,
             port: port_,
           );
         },
@@ -486,7 +682,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 7,
+            funcId: 11,
             port: port_,
           );
         },
@@ -521,7 +717,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 8,
+            funcId: 12,
             port: port_,
           );
         },
@@ -558,7 +754,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 9,
+            funcId: 13,
             port: port_,
           );
         },
@@ -593,7 +789,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 10,
+            funcId: 14,
             port: port_,
           );
         },
@@ -624,7 +820,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 11,
+            funcId: 15,
             port: port_,
           );
         },
@@ -654,7 +850,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 12,
+            funcId: 16,
             port: port_,
           );
         },
@@ -682,7 +878,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 13,
+            funcId: 17,
             port: port_,
           );
         },
@@ -702,6 +898,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "create_blake3", argNames: []);
 
   @override
+  Future<CipherHandle> crateApiEncryptionCreateChacha20Poly1305({
+    required List<int> key,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_list_prim_u_8_loose(key, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 18,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData:
+              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
+          decodeErrorData: sse_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEncryptionCreateChacha20Poly1305ConstMeta,
+        argValues: [key],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEncryptionCreateChacha20Poly1305ConstMeta =>
+      const TaskConstMeta(
+        debugName: "create_chacha20_poly1305",
+        argNames: ["key"],
+      );
+
+  @override
   Future<CipherHandle> crateApiEncryptionCreateNoopEncryption() {
     return handler.executeNormal(
       NormalTask(
@@ -710,7 +940,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 14,
+            funcId: 19,
             port: port_,
           );
         },
@@ -738,7 +968,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 15,
+            funcId: 20,
             port: port_,
           );
         },
@@ -776,7 +1006,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 16,
+            funcId: 21,
             port: port_,
           );
         },
@@ -815,7 +1045,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 17,
+            funcId: 22,
             port: port_,
           );
         },
@@ -850,7 +1080,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 18,
+            funcId: 23,
             port: port_,
           );
         },
@@ -880,7 +1110,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 19,
+            funcId: 24,
             port: port_,
           );
         },
@@ -907,7 +1137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 20,
+            funcId: 25,
             port: port_,
           );
         },
@@ -926,6 +1156,63 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "generate_aes_key", argNames: []);
 
   @override
+  Future<Uint8List> crateApiEncryptionGenerateChacha20Poly1305Key() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 26,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+          decodeErrorData: sse_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEncryptionGenerateChacha20Poly1305KeyConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEncryptionGenerateChacha20Poly1305KeyConstMeta =>
+      const TaskConstMeta(
+        debugName: "generate_chacha20_poly1305_key",
+        argNames: [],
+      );
+
+  @override
+  Future<Uint8List> crateApiEncryptionChacha20GenerateChachaKey() {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 27,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+          decodeErrorData: sse_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEncryptionChacha20GenerateChachaKeyConstMeta,
+        argValues: [],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEncryptionChacha20GenerateChachaKeyConstMeta =>
+      const TaskConstMeta(debugName: "generate_chacha_key", argNames: []);
+
+  @override
   Future<String> crateApiHashingHasherAlgorithmId({
     required HasherHandle handle,
   }) {
@@ -940,7 +1227,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 21,
+            funcId: 28,
             port: port_,
           );
         },
@@ -976,7 +1263,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 22,
+            funcId: 29,
             port: port_,
           );
         },
@@ -1007,7 +1294,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 23,
+            funcId: 30,
             port: port_,
           );
         },
@@ -1042,7 +1329,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 24,
+            funcId: 31,
             port: port_,
           );
         },
@@ -1078,7 +1365,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           sse_encode_opt_list_prim_u_8_strict(salt, serializer);
           sse_encode_list_prim_u_8_loose(info, serializer);
           sse_encode_usize(outputLen, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 25)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 32)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1112,7 +1399,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 26,
+            funcId: 33,
             port: port_,
           );
         },
@@ -1143,7 +1430,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_list_prim_u_8_loose(ikm, serializer);
           sse_encode_opt_list_prim_u_8_strict(salt, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 27)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 34)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_list_prim_u_8_strict,
@@ -1169,7 +1456,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 28,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1194,6 +1481,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   RustArcDecrementStrongCountFnType
   get rust_arc_decrement_strong_count_Aes256GcmCipher => wire
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher;
+
+  RustArcIncrementStrongCountFnType
+  get rust_arc_increment_strong_count_ChaCha20Poly1305Cipher => wire
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher;
+
+  RustArcDecrementStrongCountFnType
+  get rust_arc_decrement_strong_count_ChaCha20Poly1305Cipher => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher;
 
   RustArcIncrementStrongCountFnType
   get rust_arc_increment_strong_count_CipherHandle => wire
@@ -1226,6 +1521,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return Aes256GcmCipherImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return ChaCha20Poly1305CipherImpl.frbInternalDcoDecode(
+      raw as List<dynamic>,
+    );
   }
 
   @protected
@@ -1265,6 +1571,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return ChaCha20Poly1305CipherImpl.frbInternalDcoDecode(
+      raw as List<dynamic>,
+    );
+  }
+
+  @protected
   CipherHandle
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     dynamic raw,
@@ -1298,6 +1615,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return Aes256GcmCipherImpl.frbInternalDcoDecode(raw as List<dynamic>);
+  }
+
+  @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    dynamic raw,
+  ) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return ChaCha20Poly1305CipherImpl.frbInternalDcoDecode(
+      raw as List<dynamic>,
+    );
   }
 
   @protected
@@ -1424,6 +1752,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return ChaCha20Poly1305CipherImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   CipherHandle
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -1472,6 +1812,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return ChaCha20Poly1305CipherImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
   CipherHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -1514,6 +1866,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     return Aes256GcmCipherImpl.frbInternalSseDecode(
+      sse_decode_usize(deserializer),
+      sse_decode_i_32(deserializer),
+    );
+  }
+
+  @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    return ChaCha20Poly1305CipherImpl.frbInternalSseDecode(
       sse_decode_usize(deserializer),
       sse_decode_i_32(deserializer),
     );
@@ -1677,6 +2041,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as ChaCha20Poly1305CipherImpl).frbInternalSseEncode(move: true),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
     SseSerializer serializer,
@@ -1729,6 +2106,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   @protected
   void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as ChaCha20Poly1305CipherImpl).frbInternalSseEncode(move: false),
+      serializer,
+    );
+  }
+
+  @protected
+  void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
     SseSerializer serializer,
@@ -1775,6 +2165,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_usize(
       (self as Aes256GcmCipherImpl).frbInternalSseEncode(move: null),
+      serializer,
+    );
+  }
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_usize(
+      (self as ChaCha20Poly1305CipherImpl).frbInternalSseEncode(move: null),
       serializer,
     );
   }
@@ -1969,6 +2372,58 @@ class Aes256GcmCipherImpl extends RustOpaque implements Aes256GcmCipher {
     plaintext: plaintext,
     aad: aad,
   );
+}
+
+@sealed
+class ChaCha20Poly1305CipherImpl extends RustOpaque
+    implements ChaCha20Poly1305Cipher {
+  // Not to be used by end users
+  ChaCha20Poly1305CipherImpl.frbInternalDcoDecode(List<dynamic> wire)
+    : super.frbInternalDcoDecode(wire, _kStaticData);
+
+  // Not to be used by end users
+  ChaCha20Poly1305CipherImpl.frbInternalSseDecode(
+    BigInt ptr,
+    int externalSizeOnNative,
+  ) : super.frbInternalSseDecode(ptr, externalSizeOnNative, _kStaticData);
+
+  static final _kStaticData = RustArcStaticData(
+    rustArcIncrementStrongCount: RustLib
+        .instance
+        .api
+        .rust_arc_increment_strong_count_ChaCha20Poly1305Cipher,
+    rustArcDecrementStrongCount: RustLib
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_ChaCha20Poly1305Cipher,
+    rustArcDecrementStrongCountPtr: RustLib
+        .instance
+        .api
+        .rust_arc_decrement_strong_count_ChaCha20Poly1305CipherPtr,
+  );
+
+  Future<void> algorithmId() => RustLib.instance.api
+      .crateApiEncryptionChacha20ChaCha20Poly1305CipherAlgorithmId(that: this);
+
+  Future<Uint8List> decrypt({
+    required List<int> ciphertext,
+    required List<int> aad,
+  }) => RustLib.instance.api
+      .crateApiEncryptionChacha20ChaCha20Poly1305CipherDecrypt(
+        that: this,
+        ciphertext: ciphertext,
+        aad: aad,
+      );
+
+  Future<Uint8List> encrypt({
+    required List<int> plaintext,
+    required List<int> aad,
+  }) => RustLib.instance.api
+      .crateApiEncryptionChacha20ChaCha20Poly1305CipherEncrypt(
+        that: this,
+        plaintext: plaintext,
+        aad: aad,
+      );
 }
 
 @sealed

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -5,6 +5,7 @@
 
 import 'api/encryption.dart';
 import 'api/encryption/aes_gcm.dart';
+import 'api/encryption/chacha20.dart';
 import 'api/encryption/noop.dart';
 import 'api/hashing.dart';
 import 'api/hashing/argon2.dart';
@@ -29,6 +30,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipherPtr;
 
   CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_ChaCha20Poly1305CipherPtr => wire
+      ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305CipherPtr;
+
+  CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_CipherHandlePtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandlePtr;
 
@@ -43,6 +48,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Aes256GcmCipher
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    dynamic raw,
+  );
+
+  @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     dynamic raw,
   );
 
@@ -71,6 +82,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    dynamic raw,
+  );
+
+  @protected
   CipherHandle
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     dynamic raw,
@@ -91,6 +108,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Aes256GcmCipher
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    dynamic raw,
+  );
+
+  @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     dynamic raw,
   );
 
@@ -149,6 +172,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   CipherHandle
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -173,6 +202,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   CipherHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -193,6 +228,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Aes256GcmCipher
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     SseDeserializer deserializer,
   );
 
@@ -256,6 +297,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
     SseSerializer serializer,
@@ -284,6 +332,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
     SseSerializer serializer,
@@ -307,6 +362,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
     Aes256GcmCipher self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
     SseSerializer serializer,
   );
 
@@ -417,6 +479,40 @@ class RustLibWire implements BaseWire {
       );
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipherPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305CipherPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_m_security_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher',
+      );
+  late final _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher =
+      _rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305CipherPtr
+          .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ffi.Pointer<ffi.Void> ptr,
+  ) {
+    return _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+      ptr,
+    );
+  }
+
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305CipherPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<ffi.Void>)>>(
+        'frbgen_m_security_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher',
+      );
+  late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher =
+      _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305CipherPtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
 
   void

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -8,6 +8,7 @@
 
 import 'api/encryption.dart';
 import 'api/encryption/aes_gcm.dart';
+import 'api/encryption/chacha20.dart';
 import 'api/encryption/noop.dart';
 import 'api/hashing.dart';
 import 'api/hashing/argon2.dart';
@@ -31,6 +32,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher;
 
   CrossPlatformFinalizerArg
+  get rust_arc_decrement_strong_count_ChaCha20Poly1305CipherPtr => wire
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher;
+
+  CrossPlatformFinalizerArg
   get rust_arc_decrement_strong_count_CipherHandlePtr => wire
       .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle;
 
@@ -45,6 +50,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Aes256GcmCipher
   dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    dynamic raw,
+  );
+
+  @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     dynamic raw,
   );
 
@@ -73,6 +84,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    dynamic raw,
+  );
+
+  @protected
   CipherHandle
   dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     dynamic raw,
@@ -93,6 +110,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Aes256GcmCipher
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    dynamic raw,
+  );
+
+  @protected
+  ChaCha20Poly1305Cipher
+  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     dynamic raw,
   );
 
@@ -151,6 +174,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   CipherHandle
   sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -175,6 +204,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   CipherHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -195,6 +230,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   Aes256GcmCipher
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  ChaCha20Poly1305Cipher
+  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     SseDeserializer deserializer,
   );
 
@@ -258,6 +299,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
     SseSerializer serializer,
@@ -286,6 +334,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void
+  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
   sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
     SseSerializer serializer,
@@ -309,6 +364,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
     Aes256GcmCipher self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void
+  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    ChaCha20Poly1305Cipher self,
     SseSerializer serializer,
   );
 
@@ -395,6 +457,22 @@ class RustLibWire implements BaseWire {
       );
 
   void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+        ptr,
+      );
+
+  void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    int ptr,
+  ) => wasmModule
+      .rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+        ptr,
+      );
+
+  void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     int ptr,
   ) => wasmModule
@@ -456,6 +534,16 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
 
   external void
   rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAes256GcmCipher(
+    int ptr,
+  );
+
+  external void
+  rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+    int ptr,
+  );
+
+  external void
+  rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
     int ptr,
   );
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -26,6 +26,7 @@
 // Section: imports
 
 use crate::api::encryption::aes_gcm::*;
+use crate::api::encryption::chacha20::*;
 use crate::api::encryption::noop::*;
 use crate::api::encryption::*;
 use crate::api::hashing::*;
@@ -42,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2044205325;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -750396704;
 
 // Section: executor
 
@@ -240,6 +241,205 @@ fn wire__crate__api__encryption__aes_gcm__Aes256GcmCipher_new_impl(
             move |context| {
                 transform_result_sse::<_, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::aes_gcm::Aes256GcmCipher::new(api_key)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_algorithm_id_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ChaCha20Poly1305Cipher_algorithm_id",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
+            >>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, ()>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok = Result::<_, ()>::Ok({
+                        crate::api::encryption::chacha20::ChaCha20Poly1305Cipher::algorithm_id(
+                            &*api_that_guard,
+                        );
+                    })?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_decrypt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ChaCha20Poly1305Cipher_decrypt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
+            >>::sse_decode(&mut deserializer);
+            let api_ciphertext = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_aad = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok =
+                        crate::api::encryption::chacha20::ChaCha20Poly1305Cipher::decrypt(
+                            &*api_that_guard,
+                            &api_ciphertext,
+                            &api_aad,
+                        )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_encrypt_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ChaCha20Poly1305Cipher_encrypt",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_that = <RustOpaqueMoi<
+                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
+            >>::sse_decode(&mut deserializer);
+            let api_plaintext = <Vec<u8>>::sse_decode(&mut deserializer);
+            let api_aad = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                    let mut api_that_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_that, 0, false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_that_guard = Some(api_that.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_that_guard = api_that_guard.unwrap();
+                    let output_ok =
+                        crate::api::encryption::chacha20::ChaCha20Poly1305Cipher::encrypt(
+                            &*api_that_guard,
+                            &api_plaintext,
+                            &api_aad,
+                        )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_new_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "ChaCha20Poly1305Cipher_new",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_key = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                    let output_ok =
+                        crate::api::encryption::chacha20::ChaCha20Poly1305Cipher::new(api_key)?;
                     Ok(output_ok)
                 })())
             }
@@ -619,6 +819,39 @@ fn wire__crate__api__hashing__create_blake3_impl(
         },
     )
 }
+fn wire__crate__api__encryption__create_chacha20_poly1305_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "create_chacha20_poly1305",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_key = <Vec<u8>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                    let output_ok = crate::api::encryption::create_chacha20_poly1305(api_key)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__encryption__create_noop_encryption_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -909,6 +1142,70 @@ fn wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(
             move |context| {
                 transform_result_sse::<_, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::aes_gcm::generate_aes_key()?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_chacha20_poly1305_key",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                    let output_ok = crate::api::encryption::generate_chacha20_poly1305_key()?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__encryption__chacha20__generate_chacha_key_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "generate_chacha_key",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            deserializer.end();
+            move |context| {
+                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                    let output_ok = crate::api::encryption::chacha20::generate_chacha_key()?;
                     Ok(output_ok)
                 })())
             }
@@ -1266,6 +1563,9 @@ flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Aes256GcmCipher>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
+    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>
+);
+flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
     flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>
 );
 flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
@@ -1282,6 +1582,16 @@ impl SseDecode for Aes256GcmCipher {
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <RustOpaqueMoi<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Aes256GcmCipher>,
+        >>::sse_decode(deserializer);
+        return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for ChaCha20Poly1305Cipher {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
     }
@@ -1319,6 +1629,18 @@ impl SseDecode for NoopEncryption {
 
 impl SseDecode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Aes256GcmCipher>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <usize>::sse_decode(deserializer);
+        return decode_rust_opaque_moi(inner);
+    }
+}
+
+impl SseDecode
+    for RustOpaqueMoi<
+        flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
+    >
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -1515,79 +1837,121 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        5 => wire__crate__api__encryption__noop__NoopEncryption_algorithm_id_impl(
+        5 => wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_algorithm_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        6 => wire__crate__api__encryption__noop__NoopEncryption_decrypt_impl(
+        6 => wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_decrypt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        7 => wire__crate__api__encryption__noop__NoopEncryption_encrypt_impl(
+        7 => wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_encrypt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        8 => {
+        8 => wire__crate__api__encryption__chacha20__ChaCha20Poly1305Cipher_new_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        9 => wire__crate__api__encryption__noop__NoopEncryption_algorithm_id_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        10 => wire__crate__api__encryption__noop__NoopEncryption_decrypt_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        11 => wire__crate__api__encryption__noop__NoopEncryption_encrypt_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        12 => {
             wire__crate__api__hashing__argon2__argon2id_hash_impl(port, ptr, rust_vec_len, data_len)
         }
-        9 => wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
+        13 => wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        10 => wire__crate__api__hashing__argon2__argon2id_verify_impl(
+        14 => wire__crate__api__hashing__argon2__argon2id_verify_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        11 => wire__crate__api__hashing__blake3_hash_impl(port, ptr, rust_vec_len, data_len),
-        12 => {
+        15 => wire__crate__api__hashing__blake3_hash_impl(port, ptr, rust_vec_len, data_len),
+        16 => {
             wire__crate__api__encryption__create_aes256_gcm_impl(port, ptr, rust_vec_len, data_len)
         }
-        13 => wire__crate__api__hashing__create_blake3_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__encryption__create_noop_encryption_impl(
+        17 => wire__crate__api__hashing__create_blake3_impl(port, ptr, rust_vec_len, data_len),
+        18 => wire__crate__api__encryption__create_chacha20_poly1305_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        15 => wire__crate__api__hashing__create_sha3_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__encryption__decrypt_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__encryption__encrypt_impl(port, ptr, rust_vec_len, data_len),
-        18 => wire__crate__api__encryption__encryption_algorithm_id_impl(
+        19 => wire__crate__api__encryption__create_noop_encryption_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        19 => wire__crate__api__encryption__generate_aes256_gcm_key_impl(
+        20 => wire__crate__api__hashing__create_sha3_impl(port, ptr, rust_vec_len, data_len),
+        21 => wire__crate__api__encryption__decrypt_impl(port, ptr, rust_vec_len, data_len),
+        22 => wire__crate__api__encryption__encrypt_impl(port, ptr, rust_vec_len, data_len),
+        23 => wire__crate__api__encryption__encryption_algorithm_id_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        20 => wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(
+        24 => wire__crate__api__encryption__generate_aes256_gcm_key_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        21 => {
+        25 => wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        26 => wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        27 => wire__crate__api__encryption__chacha20__generate_chacha_key_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        28 => {
             wire__crate__api__hashing__hasher_algorithm_id_impl(port, ptr, rust_vec_len, data_len)
         }
-        22 => wire__crate__api__hashing__hasher_finalize_impl(port, ptr, rust_vec_len, data_len),
-        23 => wire__crate__api__hashing__hasher_reset_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__hashing__hasher_update_impl(port, ptr, rust_vec_len, data_len),
-        26 => wire__crate__api__kdf__hkdf__hkdf_expand_impl(port, ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__hashing__sha3_hash_impl(port, ptr, rust_vec_len, data_len),
+        29 => wire__crate__api__hashing__hasher_finalize_impl(port, ptr, rust_vec_len, data_len),
+        30 => wire__crate__api__hashing__hasher_reset_impl(port, ptr, rust_vec_len, data_len),
+        31 => wire__crate__api__hashing__hasher_update_impl(port, ptr, rust_vec_len, data_len),
+        33 => wire__crate__api__kdf__hkdf__hkdf_expand_impl(port, ptr, rust_vec_len, data_len),
+        35 => wire__crate__api__hashing__sha3_hash_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1600,8 +1964,8 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        25 => wire__crate__api__kdf__hkdf__hkdf_derive_impl(ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__kdf__hkdf__hkdf_extract_impl(ptr, rust_vec_len, data_len),
+        32 => wire__crate__api__kdf__hkdf__hkdf_derive_impl(ptr, rust_vec_len, data_len),
+        34 => wire__crate__api__kdf__hkdf__hkdf_extract_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -1619,6 +1983,26 @@ impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive for FrbWrapper<
 
 impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<Aes256GcmCipher>> for Aes256GcmCipher {
     fn into_into_dart(self) -> FrbWrapper<Aes256GcmCipher> {
+        self.into()
+    }
+}
+
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for FrbWrapper<ChaCha20Poly1305Cipher> {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+            .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for FrbWrapper<ChaCha20Poly1305Cipher>
+{
+}
+
+impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<ChaCha20Poly1305Cipher>>
+    for ChaCha20Poly1305Cipher
+{
+    fn into_into_dart(self) -> FrbWrapper<ChaCha20Poly1305Cipher> {
         self.into()
     }
 }
@@ -1742,6 +2126,18 @@ impl SseEncode for Aes256GcmCipher {
     }
 }
 
+impl SseEncode for ChaCha20Poly1305Cipher {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <RustOpaqueMoi<
+            flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
+        >>::sse_encode(
+            flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self),
+            serializer,
+        );
+    }
+}
+
 impl SseEncode for CipherHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -1765,6 +2161,19 @@ impl SseEncode for NoopEncryption {
 
 impl SseEncode
     for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Aes256GcmCipher>>
+{
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        let (ptr, size) = self.sse_encode_raw();
+        <usize>::sse_encode(ptr, serializer);
+        <i32>::sse_encode(size, serializer);
+    }
+}
+
+impl SseEncode
+    for RustOpaqueMoi<
+        flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>,
+    >
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -1940,6 +2349,7 @@ mod io {
 
     use super::*;
     use crate::api::encryption::aes_gcm::*;
+    use crate::api::encryption::chacha20::*;
     use crate::api::encryption::noop::*;
     use crate::api::encryption::*;
     use crate::api::hashing::*;
@@ -1966,6 +2376,20 @@ mod io {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Aes256GcmCipher>>::decrement_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>>::increment_strong_count(ptr as _);
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>>::decrement_strong_count(ptr as _);
     }
 
     #[unsafe(no_mangle)]
@@ -2023,6 +2447,7 @@ mod web {
 
     use super::*;
     use crate::api::encryption::aes_gcm::*;
+    use crate::api::encryption::chacha20::*;
     use crate::api::encryption::noop::*;
     use crate::api::encryption::*;
     use crate::api::hashing::*;
@@ -2051,6 +2476,20 @@ mod web {
         ptr: *const std::ffi::c_void,
     ) {
         MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<Aes256GcmCipher>>::decrement_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>>::increment_strong_count(ptr as _);
+    }
+
+    #[wasm_bindgen]
+    pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerChaCha20Poly1305Cipher(
+        ptr: *const std::ffi::c_void,
+    ) {
+        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<ChaCha20Poly1305Cipher>>::decrement_strong_count(ptr as _);
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION

# Summary
- Add ChaCha20-Poly1305 dart wrapper 
- Provides methods: `encrypt`, `decrypt`, `encryptString`, `decryptString`

## Tests (7 total)
- Encrypt/decrypt roundtrip
- Wrong key detection throws exception
- Tampered data throws exception
- Encrypt/decrypt empty data works
- Key generation returns 32 bytes
- same input encrypted twice gives different ciphertext
- AES-GCM ciphertext cannot be decrypted with ChaCha20
