### PR TITLE
feat(compression): add Zstd/Brotli core with algorithm enum and MIME-aware skip  

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,12 +35,13 @@ argon2 = "0.5"
 hkdf = "0.12"
 sha2 = "0.10"
 
-# Compression 
+# Compression
 zstd = { version = "0.13", optional = true }
+brotli = { version = "7.0", optional = true }
 
 [features]
 default = []
-compression = ["zstd"]
+compression = ["zstd", "brotli"]
 testing = [] # exposes noop cipher — never enable in production builds
 
 [profile.release]

--- a/rust/src/api/compression/brotli_impl.rs
+++ b/rust/src/api/compression/brotli_impl.rs
@@ -1,0 +1,39 @@
+//! Brotli compression wrapper.
+
+use crate::core::error::CryptoError;
+
+pub const DEFAULT_LEVEL: u32 = 4;
+pub const MIN_LEVEL: u32 = 0;
+pub const MAX_LEVEL: u32 = 11;
+
+pub fn validate_level(level: u32) -> Result<(), CryptoError> {
+    if level > MAX_LEVEL {
+        return Err(CryptoError::InvalidParameter(format!(
+            "Brotli level must be {MIN_LEVEL}–{MAX_LEVEL}, got {level}"
+        )));
+    }
+    Ok(())
+}
+
+pub fn compress(data: &[u8], level: u32) -> Result<Vec<u8>, CryptoError> {
+    validate_level(level)?;
+    let mut output = Vec::new();
+    {
+        let params = brotli::enc::BrotliEncoderParams {
+            quality: level as i32,
+            ..Default::default()
+        };
+        let mut writer = brotli::CompressorWriter::with_params(&mut output, 4096, &params);
+        std::io::Write::write_all(&mut writer, data)
+            .map_err(|e| CryptoError::CompressionFailed(e.to_string()))?;
+    }
+    Ok(output)
+}
+
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let mut output = Vec::new();
+    let mut reader = brotli::Decompressor::new(std::io::Cursor::new(data), 4096);
+    std::io::Read::read_to_end(&mut reader, &mut output)
+        .map_err(|e| CryptoError::CompressionFailed(e.to_string()))?;
+    Ok(output)
+}

--- a/rust/src/api/compression/mod.rs
+++ b/rust/src/api/compression/mod.rs
@@ -1,0 +1,239 @@
+//! Compression API module — Zstd, Brotli, and MIME-aware skip.
+
+#[cfg(feature = "compression")]
+pub mod brotli_impl;
+#[cfg(feature = "compression")]
+pub mod zstd_impl;
+
+#[cfg(feature = "compression")]
+use crate::core::error::CryptoError;
+
+/// Which compression algorithm to use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompressionAlgorithm {
+    Zstd,
+    Brotli,
+    None,
+}
+
+/// Configuration for a compress operation.
+#[derive(Debug, Clone)]
+pub struct CompressionConfig {
+    pub algorithm: CompressionAlgorithm,
+    /// Compression level. Valid range depends on algorithm:
+    /// - Zstd: 1–22 (default 3)
+    /// - Brotli: 0–11 (default 4)
+    /// - None: ignored
+    pub level: Option<i32>,
+}
+
+/// Compress a byte buffer according to `config`.
+#[cfg(feature = "compression")]
+pub fn compress(data: &[u8], config: &CompressionConfig) -> Result<Vec<u8>, CryptoError> {
+    match config.algorithm {
+        CompressionAlgorithm::Zstd => {
+            let level = config.level.unwrap_or(zstd_impl::DEFAULT_LEVEL);
+            zstd_impl::compress(data, level)
+        }
+        CompressionAlgorithm::Brotli => {
+            let level = config.level.unwrap_or(brotli_impl::DEFAULT_LEVEL as i32);
+            let level = u32::try_from(level).map_err(|_| {
+                CryptoError::InvalidParameter(format!(
+                    "Brotli level must be {}–{}, got {level}",
+                    brotli_impl::MIN_LEVEL,
+                    brotli_impl::MAX_LEVEL
+                ))
+            })?;
+            brotli_impl::compress(data, level)
+        }
+        CompressionAlgorithm::None => Ok(data.to_vec()),
+    }
+}
+
+/// Decompress a byte buffer produced by the given algorithm.
+#[cfg(feature = "compression")]
+pub fn decompress(data: &[u8], algorithm: CompressionAlgorithm) -> Result<Vec<u8>, CryptoError> {
+    match algorithm {
+        CompressionAlgorithm::Zstd => zstd_impl::decompress(data),
+        CompressionAlgorithm::Brotli => brotli_impl::decompress(data),
+        CompressionAlgorithm::None => Ok(data.to_vec()),
+    }
+}
+
+/// Returns `true` when the file extension indicates already-compressed data.
+pub fn should_skip_compression(file_path: &str) -> bool {
+    const SKIP: &[&str] = &[
+        // images
+        "jpg", "jpeg", "png", "gif", "webp",
+        // video
+        "mp4", "mkv", "avi", "mov", "webm",
+        // audio
+        "mp3", "aac", "ogg", "flac",
+        // archives
+        "zip", "gz", "bz2", "xz", "zst", "br", "7z", "rar",
+    ];
+
+    file_path
+        .rsplit('.')
+        .next()
+        .map(|ext| SKIP.contains(&ext.to_ascii_lowercase().as_str()))
+        .unwrap_or(false)
+}
+
+#[cfg(all(test, feature = "compression"))]
+mod tests {
+    use super::*;
+
+    // -- roundtrip --------------------------------------------------------
+
+    #[test]
+    fn test_zstd_roundtrip() {
+        let data = b"Hello, Zstd compression roundtrip!";
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::Zstd,
+            level: None,
+        };
+        let compressed = compress(data, &config).expect("zstd compress");
+        let decompressed =
+            decompress(&compressed, CompressionAlgorithm::Zstd).expect("zstd decompress");
+        assert_eq!(decompressed, data);
+    }
+
+    #[test]
+    fn test_brotli_roundtrip() {
+        let data = b"Hello, Brotli compression roundtrip!";
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::Brotli,
+            level: None,
+        };
+        let compressed = compress(data, &config).expect("brotli compress");
+        let decompressed =
+            decompress(&compressed, CompressionAlgorithm::Brotli).expect("brotli decompress");
+        assert_eq!(decompressed, data);
+    }
+
+    // -- custom levels ----------------------------------------------------
+
+    #[test]
+    fn test_zstd_custom_level() {
+        let data = b"level test data for zstd";
+        for level in [1, 19] {
+            let config = CompressionConfig {
+                algorithm: CompressionAlgorithm::Zstd,
+                level: Some(level),
+            };
+            let compressed = compress(data, &config).expect("zstd compress");
+            let decompressed =
+                decompress(&compressed, CompressionAlgorithm::Zstd).expect("zstd decompress");
+            assert_eq!(decompressed, data);
+        }
+    }
+
+    #[test]
+    fn test_brotli_custom_level() {
+        let data = b"level test data for brotli";
+        for level in [0, 11] {
+            let config = CompressionConfig {
+                algorithm: CompressionAlgorithm::Brotli,
+                level: Some(level),
+            };
+            let compressed = compress(data, &config).expect("brotli compress");
+            let decompressed =
+                decompress(&compressed, CompressionAlgorithm::Brotli).expect("brotli decompress");
+            assert_eq!(decompressed, data);
+        }
+    }
+
+    // -- level validation -------------------------------------------------
+
+    #[test]
+    fn test_zstd_invalid_level() {
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::Zstd,
+            level: Some(0),
+        };
+        assert!(compress(b"x", &config).is_err());
+
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::Zstd,
+            level: Some(23),
+        };
+        assert!(compress(b"x", &config).is_err());
+    }
+
+    #[test]
+    fn test_brotli_invalid_level() {
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::Brotli,
+            level: Some(12),
+        };
+        assert!(compress(b"x", &config).is_err());
+
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::Brotli,
+            level: Some(-1),
+        };
+        assert!(compress(b"x", &config).is_err());
+    }
+
+    // -- None passthrough -------------------------------------------------
+
+    #[test]
+    fn test_none_passthrough() {
+        let data = b"should stay the same";
+        let config = CompressionConfig {
+            algorithm: CompressionAlgorithm::None,
+            level: None,
+        };
+        let result = compress(data, &config).expect("none compress");
+        assert_eq!(result, data);
+
+        let result = decompress(data, CompressionAlgorithm::None).expect("none decompress");
+        assert_eq!(result, data);
+    }
+
+    // -- MIME-aware skip --------------------------------------------------
+
+    #[test]
+    fn test_should_skip_compressed_extensions() {
+        assert!(should_skip_compression("photo.jpg"));
+        assert!(should_skip_compression("photo.JPEG"));
+        assert!(should_skip_compression("archive.zip"));
+        assert!(should_skip_compression("archive.ZIP"));
+        assert!(should_skip_compression("video.mp4"));
+        assert!(should_skip_compression("VIDEO.MP4"));
+        assert!(should_skip_compression("SONG.MP3"));
+    }
+
+    #[test]
+    fn test_should_not_skip_uncompressed_extensions() {
+        assert!(!should_skip_compression("notes.txt"));
+        assert!(!should_skip_compression("data.json"));
+        assert!(!should_skip_compression("report.pdf"));
+    }
+
+    // -- empty data -------------------------------------------------------
+
+    #[test]
+    fn test_empty_data() {
+        let empty: &[u8] = &[];
+
+        let config_zstd = CompressionConfig {
+            algorithm: CompressionAlgorithm::Zstd,
+            level: None,
+        };
+        let compressed = compress(empty, &config_zstd).expect("zstd compress empty");
+        let decompressed =
+            decompress(&compressed, CompressionAlgorithm::Zstd).expect("zstd decompress empty");
+        assert!(decompressed.is_empty());
+
+        let config_brotli = CompressionConfig {
+            algorithm: CompressionAlgorithm::Brotli,
+            level: None,
+        };
+        let compressed = compress(empty, &config_brotli).expect("brotli compress empty");
+        let decompressed = decompress(&compressed, CompressionAlgorithm::Brotli)
+            .expect("brotli decompress empty");
+        assert!(decompressed.is_empty());
+    }
+}

--- a/rust/src/api/compression/zstd_impl.rs
+++ b/rust/src/api/compression/zstd_impl.rs
@@ -1,0 +1,29 @@
+//! Zstd compression wrapper.
+
+use crate::core::error::CryptoError;
+
+pub const DEFAULT_LEVEL: i32 = 3;
+// zstd treats level 0 as "use library default" — we reject it
+// to force callers to choose explicitly or use None.
+pub const MIN_LEVEL: i32 = 1;
+pub const MAX_LEVEL: i32 = 22;
+
+pub fn validate_level(level: i32) -> Result<(), CryptoError> {
+    if !(MIN_LEVEL..=MAX_LEVEL).contains(&level) {
+        return Err(CryptoError::InvalidParameter(format!(
+            "Zstd level must be {MIN_LEVEL}–{MAX_LEVEL}, got {level}"
+        )));
+    }
+    Ok(())
+}
+
+pub fn compress(data: &[u8], level: i32) -> Result<Vec<u8>, CryptoError> {
+    validate_level(level)?;
+    zstd::encode_all(std::io::Cursor::new(data), level)
+        .map_err(|e| CryptoError::CompressionFailed(e.to_string()))
+}
+
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    zstd::decode_all(std::io::Cursor::new(data))
+        .map_err(|e| CryptoError::CompressionFailed(e.to_string()))
+}

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,5 +1,6 @@
 //! Public API module (scanned by FRB for binding generation).
 
+pub mod compression;
 pub mod encryption;
 pub mod error;
 pub mod hashing;

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -29,6 +29,9 @@ pub enum CryptoError {
     #[error("Invalid parameter: {0}")]
     InvalidParameter(String),
 
+    #[error("Compression failed: {0}")]
+    CompressionFailed(String),
+
     #[error("Authentication failed")]
     AuthenticationFailed,
 }


### PR DESCRIPTION
## Summary                                                                                                         
                                                                                                                     
  - Add `CompressionAlgorithm` enum (Zstd, Brotli, None) and `CompressionConfig` struct                              
  - Implement Zstd compress/decompress wrapper (levels 1–22, default 3)
  - Implement Brotli compress/decompress wrapper (levels 0–11, default 4)
  - Add MIME-aware `should_skip_compression()` for already-compressed formats (.jpg, .mp4, .zip, etc.)
  - Add `CompressionFailed` error variant to `CryptoError`
  - Feature-gated behind `compression` flag — `cargo check` passes without it

  ## Files Changed

  | File | Action |
  |---|---|
  | `rust/src/api/compression/mod.rs` | **New** — enum, config, compress/decompress, MIME check |
  | `rust/src/api/compression/zstd_impl.rs` | **New** — Zstd wrapper with level validation |
  | `rust/src/api/compression/brotli_impl.rs` | **New** — Brotli wrapper with level validation |
  | `rust/src/api/mod.rs` | **Edit** — add `pub mod compression` |
  | `rust/Cargo.toml` | **Edit** — add `brotli` dep, update `compression` feature |
  | `rust/src/core/error.rs` | **Edit** — add `CompressionFailed` variant |

  ## Test Plan

  - [x] `test_zstd_roundtrip` — compress then decompress, verify identical
  - [x] `test_brotli_roundtrip` — same for Brotli
  - [x] `test_zstd_custom_level` — levels 1 and 19 both roundtrip
  - [x] `test_brotli_custom_level` — levels 0 and 11 both roundtrip
  - [x] `test_zstd_invalid_level` — 0 and 23 return error
  - [x] `test_brotli_invalid_level` — -1 and 12 return error
  - [x] `test_none_passthrough` — data unchanged
  - [x] `test_should_skip_compressed_extensions` — jpg, JPEG, zip, ZIP, mp4, MP3
  - [x] `test_should_not_skip_uncompressed_extensions` — txt, json, pdf
  - [x] `test_empty_data` — empty bytes roundtrip for both algorithms
  - [x] `cargo clippy --features compression --tests -D warnings` — clean
  - [x] `cargo check` without feature — clean