### PR TITLE
fix(evfs): scale segment index size with vault capacity

### DIFF
--- a/rust/src/api/evfs/helpers.rs
+++ b/rust/src/api/evfs/helpers.rs
@@ -1,7 +1,5 @@
 use crate::core::error::CryptoError;
-use crate::core::evfs::format::{
-    self, SegmentIndex, ENCRYPTED_INDEX_SIZE, PRIMARY_INDEX_OFFSET, VAULT_HEADER_SIZE,
-};
+use crate::core::evfs::format::{self, SegmentIndex, PRIMARY_INDEX_OFFSET, VAULT_HEADER_SIZE};
 use crate::core::evfs::segment::{self, VaultKeys};
 use crate::core::format::Algorithm;
 use std::fs::File;
@@ -24,8 +22,9 @@ pub(crate) fn flush_index(
     keys: &VaultKeys,
     algorithm: Algorithm,
     capacity: u64,
+    index_pad_size: usize,
 ) -> Result<(), CryptoError> {
-    let plaintext = index.to_bytes()?;
+    let plaintext = index.to_bytes(index_pad_size)?;
     let encrypted =
         segment::aead_encrypt_random_nonce(keys.index_key.as_bytes(), &plaintext, &[], algorithm)?;
 
@@ -34,7 +33,7 @@ pub(crate) fn flush_index(
     file.write_all(&encrypted)?;
 
     // Shadow
-    let shadow_off = format::shadow_index_offset(capacity)?;
+    let shadow_off = format::shadow_index_offset(capacity, index_pad_size)?;
     file.seek(SeekFrom::Start(shadow_off))?;
     file.write_all(&encrypted)?;
 
@@ -43,9 +42,23 @@ pub(crate) fn flush_index(
 }
 
 /// Read raw encrypted index bytes from a given file offset.
-pub(crate) fn read_encrypted_index(file: &mut File, offset: u64) -> Result<Vec<u8>, CryptoError> {
+///
+/// `enc_index_size` is derived from the header's `index_size` field, which
+/// is validated to be within `MIN..MAX_INDEX_PAD_SIZE` by `VaultHeader::from_bytes`.
+pub(crate) fn read_encrypted_index(
+    file: &mut File,
+    offset: u64,
+    enc_index_size: usize,
+) -> Result<Vec<u8>, CryptoError> {
+    // Defense-in-depth: reject unreasonable sizes even if header validation was bypassed
+    let max = format::encrypted_index_size(format::MAX_INDEX_PAD_SIZE);
+    if enc_index_size > max {
+        return Err(CryptoError::VaultCorrupted(format!(
+            "encrypted index size {enc_index_size} exceeds maximum {max}"
+        )));
+    }
     file.seek(SeekFrom::Start(offset))?;
-    let mut buf = vec![0u8; ENCRYPTED_INDEX_SIZE];
+    let mut buf = vec![0u8; enc_index_size];
     file.read_exact(&mut buf)?;
     Ok(buf)
 }
@@ -66,8 +79,12 @@ pub(crate) fn decrypt_index_blob(
 }
 
 /// Compute vault data capacity from file size.
-pub(crate) fn capacity_from_file_size(file_size: u64) -> Result<u64, CryptoError> {
-    let overhead = VAULT_HEADER_SIZE as u64 + 2 * ENCRYPTED_INDEX_SIZE as u64;
+pub(crate) fn capacity_from_file_size(
+    file_size: u64,
+    index_pad_size: usize,
+) -> Result<u64, CryptoError> {
+    let enc_size = format::encrypted_index_size(index_pad_size) as u64;
+    let overhead = VAULT_HEADER_SIZE as u64 + 2 * enc_size;
     file_size
         .checked_sub(overhead)
         .ok_or_else(|| CryptoError::VaultCorrupted("vault file too small".into()))

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -11,8 +11,7 @@ pub use types::*;
 use crate::api::compression::{CompressionAlgorithm, CompressionConfig};
 use crate::core::error::CryptoError;
 use crate::core::evfs::format::{
-    self, SegmentEntry, SegmentIndex, VaultHeader, DATA_REGION_OFFSET, ENCRYPTED_INDEX_SIZE,
-    PRIMARY_INDEX_OFFSET, VAULT_HEADER_SIZE,
+    self, SegmentEntry, SegmentIndex, VaultHeader, PRIMARY_INDEX_OFFSET, VAULT_HEADER_SIZE,
 };
 use crate::core::evfs::segment::{self, SegmentCryptoParams};
 use crate::core::evfs::wal::{VaultLock, WalOp, WriteAheadLog};
@@ -40,7 +39,8 @@ pub fn vault_create(
     let lock = VaultLock::acquire(&path)?;
     let keys = segment::derive_vault_keys(&key)?;
     key.zeroize();
-    let total_size = format::total_vault_size(capacity_bytes)?;
+    let index_pad_size = format::compute_index_size(capacity_bytes);
+    let total_size = format::total_vault_size(capacity_bytes, index_pad_size)?;
 
     let mut file = OpenOptions::new()
         .read(true)
@@ -52,14 +52,14 @@ pub fn vault_create(
     // Pre-allocate with CSPRNG random fill
     segment::preallocate_vault(&mut file, total_size)?;
 
-    // Write header
-    let header = VaultHeader::new(algo.to_byte());
+    // Write header (includes index_size for open to read back)
+    let header = VaultHeader::new(algo.to_byte(), index_pad_size as u32);
     file.seek(SeekFrom::Start(0))?;
     file.write_all(&header.to_bytes())?;
 
     // Create empty index and flush to primary + shadow
     let index = SegmentIndex::new(capacity_bytes);
-    flush_index(&mut file, &index, &keys, algo, capacity_bytes)?;
+    flush_index(&mut file, &index, &keys, algo, capacity_bytes, index_pad_size)?;
 
     // Create fresh WAL (checkpoint to clear any stale data)
     let mut wal = WriteAheadLog::open(&path)?;
@@ -70,6 +70,7 @@ pub fn vault_create(
         algorithm: algo,
         keys,
         index,
+        index_pad_size,
         file,
         wal,
         lock,
@@ -87,12 +88,15 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         .open(&path)
         .map_err(|e| CryptoError::IoError(format!("cannot open vault: {e}")))?;
 
-    // Read header
+    // Read header — includes index_size since dynamic index sizing
     let mut header_buf = [0u8; VAULT_HEADER_SIZE];
     file.seek(SeekFrom::Start(0))?;
     file.read_exact(&mut header_buf)?;
     let header = VaultHeader::from_bytes(&header_buf)?;
     let algorithm = Algorithm::from_byte(header.algorithm)?;
+    let index_pad_size = header.index_size as usize;
+    let enc_idx_size = format::encrypted_index_size(index_pad_size);
+    let data_off = format::data_region_offset(index_pad_size);
 
     // Derive keys
     let keys = segment::derive_vault_keys(&key)?;
@@ -100,7 +104,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
 
     // Compute capacity from file size
     let file_size = file.seek(SeekFrom::End(0))?;
-    let capacity = capacity_from_file_size(file_size)?;
+    let capacity = capacity_from_file_size(file_size, index_pad_size)?;
 
     // Defrag backup recovery: if a crash occurred during an overlapping defrag
     // move, restore the segment data from the backup file before WAL recovery.
@@ -128,7 +132,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
                     if size > 0 && size <= capacity && size <= MAX_BACKUP_SIZE {
                         let mut data = vec![0u8; size as usize];
                         if backup.read_exact(&mut data).is_ok() {
-                            file.seek(SeekFrom::Start(DATA_REGION_OFFSET + offset))?;
+                            file.seek(SeekFrom::Start(data_off + offset))?;
                             file.write_all(&data)?;
                             file.sync_all()?;
                         }
@@ -143,9 +147,9 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
     // capacity which may have changed during an interrupted resize; the
     // post-recovery reconciliation below fixes the shadow.
     if let Some(old_encrypted_index) = wal_snapshot {
-        if old_encrypted_index.len() != ENCRYPTED_INDEX_SIZE {
+        if old_encrypted_index.len() != enc_idx_size {
             return Err(CryptoError::VaultCorrupted(format!(
-                "WAL snapshot size {} != expected {ENCRYPTED_INDEX_SIZE}",
+                "WAL snapshot size {} != expected {enc_idx_size}",
                 old_encrypted_index.len()
             )));
         }
@@ -157,12 +161,12 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
 
     // Decrypt index (try primary, fall back to shadow)
     let index = {
-        let primary_bytes = read_encrypted_index(&mut file, PRIMARY_INDEX_OFFSET)?;
+        let primary_bytes = read_encrypted_index(&mut file, PRIMARY_INDEX_OFFSET, enc_idx_size)?;
         match decrypt_index_blob(&primary_bytes, &keys, algorithm) {
             Ok(idx) => idx,
             Err(_) => {
-                let shadow_off = format::shadow_index_offset(capacity)?;
-                let shadow_bytes = read_encrypted_index(&mut file, shadow_off)?;
+                let shadow_off = format::shadow_index_offset(capacity, index_pad_size)?;
+                let shadow_bytes = read_encrypted_index(&mut file, shadow_off, enc_idx_size)?;
                 let idx = decrypt_index_blob(&shadow_bytes, &keys, algorithm).map_err(|_| {
                     CryptoError::VaultCorrupted(
                         "both primary and shadow index are corrupted".into(),
@@ -179,12 +183,12 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
 
     // Post-recovery reconciliation: if an interrupted resize left the file
     // at the wrong size, fix the file and shadow to match the index.
-    let expected_total = format::total_vault_size(index.capacity)?;
+    let expected_total = format::total_vault_size(index.capacity, index_pad_size)?;
     let actual_size = file.seek(SeekFrom::End(0))?;
     if actual_size != expected_total {
         file.set_len(expected_total)?;
-        let primary_bytes = read_encrypted_index(&mut file, PRIMARY_INDEX_OFFSET)?;
-        let shadow_off = format::shadow_index_offset(index.capacity)?;
+        let primary_bytes = read_encrypted_index(&mut file, PRIMARY_INDEX_OFFSET, enc_idx_size)?;
+        let shadow_off = format::shadow_index_offset(index.capacity, index_pad_size)?;
         file.seek(SeekFrom::Start(shadow_off))?;
         file.write_all(&primary_bytes)?;
         file.sync_all()?;
@@ -195,6 +199,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         algorithm,
         keys,
         index,
+        index_pad_size,
         file,
         wal,
         lock,
@@ -234,7 +239,7 @@ pub fn vault_write(
     data.zeroize();
 
     // 3. WAL journal old index
-    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET)?;
+    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET, format::encrypted_index_size(handle.index_pad_size))?;
     handle
         .wal
         .begin(WalOp::WriteSegment, &old_encrypted_index)?;
@@ -243,7 +248,7 @@ pub fn vault_write(
     if let Some(old_entry) = handle.index.remove(&name) {
         segment::secure_erase_region(
             &mut handle.file,
-            DATA_REGION_OFFSET + old_entry.offset,
+            format::data_region_offset(handle.index_pad_size) + old_entry.offset,
             old_entry.size,
         )?;
         handle.index.deallocate(old_entry.offset, old_entry.size);
@@ -255,7 +260,7 @@ pub fn vault_write(
     // 6. Write encrypted segment at allocated offset + fsync before index update
     handle
         .file
-        .seek(SeekFrom::Start(DATA_REGION_OFFSET + offset))?;
+        .seek(SeekFrom::Start(format::data_region_offset(handle.index_pad_size) + offset))?;
     handle.file.write_all(&encrypted)?;
     handle.file.sync_all()?;
 
@@ -277,6 +282,7 @@ pub fn vault_write(
         &handle.keys,
         handle.algorithm,
         handle.index.capacity,
+        handle.index_pad_size,
     )?;
 
     // 9. WAL commit
@@ -307,7 +313,7 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
     })?;
     handle
         .file
-        .seek(SeekFrom::Start(DATA_REGION_OFFSET + seg_offset))?;
+        .seek(SeekFrom::Start(format::data_region_offset(handle.index_pad_size) + seg_offset))?;
     let mut encrypted = vec![0u8; read_len];
     handle.file.read_exact(&mut encrypted)?;
 
@@ -336,7 +342,7 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
 #[cfg(feature = "compression")]
 pub fn vault_delete(handle: &mut VaultHandle, name: String) -> Result<(), CryptoError> {
     // WAL journal old index
-    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET)?;
+    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET, format::encrypted_index_size(handle.index_pad_size))?;
     handle
         .wal
         .begin(WalOp::DeleteSegment, &old_encrypted_index)?;
@@ -349,7 +355,7 @@ pub fn vault_delete(handle: &mut VaultHandle, name: String) -> Result<(), Crypto
     // Secure erase (CSPRNG overwrite + fsync)
     segment::secure_erase_region(
         &mut handle.file,
-        DATA_REGION_OFFSET + entry.offset,
+        format::data_region_offset(handle.index_pad_size) + entry.offset,
         entry.size,
     )?;
 
@@ -363,6 +369,7 @@ pub fn vault_delete(handle: &mut VaultHandle, name: String) -> Result<(), Crypto
         &handle.keys,
         handle.algorithm,
         handle.index.capacity,
+        handle.index_pad_size,
     )?;
 
     // WAL commit
@@ -394,13 +401,13 @@ fn vault_resize_grow_impl(
     old_capacity: u64,
     new_capacity: u64,
 ) -> Result<(), CryptoError> {
-    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET)?;
+    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET, format::encrypted_index_size(handle.index_pad_size))?;
     handle.wal.begin(WalOp::UpdateIndex, &old_encrypted_index)?;
 
     // Extend file and CSPRNG-fill new space (also overwrites old shadow position)
-    let new_total = format::total_vault_size(new_capacity)?;
+    let new_total = format::total_vault_size(new_capacity, handle.index_pad_size)?;
     handle.file.set_len(new_total)?;
-    let fill_offset = DATA_REGION_OFFSET + old_capacity;
+    let fill_offset = format::data_region_offset(handle.index_pad_size) + old_capacity;
     let fill_size = new_capacity - old_capacity;
     segment::secure_erase_region(&mut handle.file, fill_offset, fill_size)?;
 
@@ -412,6 +419,7 @@ fn vault_resize_grow_impl(
         &handle.keys,
         handle.algorithm,
         new_capacity,
+        handle.index_pad_size,
     )?;
 
     handle.wal.commit()?;
@@ -442,7 +450,7 @@ fn vault_resize_shrink_impl(
     }
 
     // WAL begin — journal the current encrypted index for crash recovery.
-    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET)?;
+    let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET, format::encrypted_index_size(handle.index_pad_size))?;
     handle.wal.begin(WalOp::UpdateIndex, &old_encrypted_index)?;
 
     // Update index metadata for the new capacity.
@@ -470,10 +478,11 @@ fn vault_resize_shrink_impl(
         &handle.keys,
         handle.algorithm,
         new_capacity,
+        handle.index_pad_size,
     )?;
 
     // Truncate file to new total size.
-    let new_total = format::total_vault_size(new_capacity)?;
+    let new_total = format::total_vault_size(new_capacity, handle.index_pad_size)?;
     handle.file.set_len(new_total)?;
     handle.file.sync_all()?;
 
@@ -548,7 +557,7 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         })?;
         handle
             .file
-            .seek(SeekFrom::Start(DATA_REGION_OFFSET + m.old_offset))?;
+            .seek(SeekFrom::Start(format::data_region_offset(handle.index_pad_size) + m.old_offset))?;
         let mut buf = vec![0u8; read_len];
         handle.file.read_exact(&mut buf)?;
 
@@ -566,7 +575,7 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         }
 
         // Journal current encrypted index before mutation
-        let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET)?;
+        let old_encrypted_index = read_encrypted_index(&mut handle.file, PRIMARY_INDEX_OFFSET, format::encrypted_index_size(handle.index_pad_size))?;
         handle
             .wal
             .begin(WalOp::WriteSegment, &old_encrypted_index)?;
@@ -574,7 +583,7 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         // Write to new target offset and fsync
         handle
             .file
-            .seek(SeekFrom::Start(DATA_REGION_OFFSET + m.new_offset))?;
+            .seek(SeekFrom::Start(format::data_region_offset(handle.index_pad_size) + m.new_offset))?;
         handle.file.write_all(&buf)?;
         buf.zeroize();
         handle.file.sync_all()?;
@@ -589,6 +598,7 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
             &handle.keys,
             handle.algorithm,
             handle.index.capacity,
+            handle.index_pad_size,
         )?;
 
         // WAL commit — move is now durable
@@ -604,7 +614,7 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         if erase_end > erase_start {
             segment::secure_erase_region(
                 &mut handle.file,
-                DATA_REGION_OFFSET + erase_start,
+                format::data_region_offset(handle.index_pad_size) + erase_start,
                 erase_end - erase_start,
             )?;
         }
@@ -626,13 +636,14 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         &handle.keys,
         handle.algorithm,
         handle.index.capacity,
+        handle.index_pad_size,
     )?;
 
     // Secure-erase the free tail (CSPRNG overwrite + fsync)
     if packed_end < handle.index.capacity {
         segment::secure_erase_region(
             &mut handle.file,
-            DATA_REGION_OFFSET + packed_end,
+            format::data_region_offset(handle.index_pad_size) + packed_end,
             handle.index.capacity - packed_end,
         )?;
     }

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -1,5 +1,6 @@
 
 use super::*;
+use crate::core::evfs::format::{encrypted_index_size, MIN_INDEX_PAD_SIZE};
 
 fn test_key() -> Vec<u8> {
     vec![0xAA; 32]
@@ -81,7 +82,7 @@ fn test_open_runs_wal_recovery() {
     // Save the "good" encrypted index (containing only A)
     let good_encrypted = {
         let mut f = File::open(&path).expect("open");
-        read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET).expect("read index")
+        read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET, encrypted_index_size(MIN_INDEX_PAD_SIZE)).expect("read index")
     };
 
     // Add segment B normally (both index and data on disk)
@@ -203,7 +204,7 @@ fn test_read_tampered_segment() {
 
     // Tamper with encrypted data on disk
     let entry = handle.index.find("secret.txt").expect("find");
-    let disk_offset = DATA_REGION_OFFSET + entry.offset;
+    let disk_offset = format::data_region_offset(MIN_INDEX_PAD_SIZE) + entry.offset;
     // Flip a byte in the ciphertext (after the 12-byte nonce)
     handle
         .file
@@ -574,7 +575,7 @@ fn test_delete_secure_erase() {
 
     // Capture encrypted bytes at the segment offset
     let entry = handle.index.find("secret.txt").expect("find");
-    let disk_offset = DATA_REGION_OFFSET + entry.offset;
+    let disk_offset = format::data_region_offset(MIN_INDEX_PAD_SIZE) + entry.offset;
     let size = entry.size as usize;
     handle
         .file
@@ -875,7 +876,7 @@ fn test_resize_grow_crash_recovery() {
     // Save the "good" encrypted index (1MB capacity, contains A).
     let good_encrypted = {
         let mut f = File::open(&path).expect("open");
-        read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET).expect("read index")
+        read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET, encrypted_index_size(MIN_INDEX_PAD_SIZE)).expect("read index")
     };
 
     // Perform a real grow to 2MB.
@@ -988,7 +989,7 @@ fn test_resize_grow_crash_midway_recovers() {
     // Capture the good encrypted index before simulating a partial grow.
     {
         let mut f = File::open(&path).expect("open");
-        good_encrypted = read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET).expect("read idx");
+        good_encrypted = read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET, encrypted_index_size(MIN_INDEX_PAD_SIZE)).expect("read idx");
     }
 
     // Simulate a crash mid-grow: extend the file and CSPRNG-fill
@@ -999,10 +1000,10 @@ fn test_resize_grow_crash_midway_recovers() {
             .write(true)
             .open(&path)
             .expect("open rw");
-        let new_total = format::total_vault_size(2 * SIZE_MB).expect("size");
+        let new_total = format::total_vault_size(2 * SIZE_MB, MIN_INDEX_PAD_SIZE).expect("size");
         f.set_len(new_total).expect("extend");
-        // CSPRNG-fill overwrites old shadow position at DATA_REGION_OFFSET + SIZE_MB
-        segment::secure_erase_region(&mut f, DATA_REGION_OFFSET + SIZE_MB, SIZE_MB).expect("fill");
+        // CSPRNG-fill overwrites old shadow position at format::data_region_offset(MIN_INDEX_PAD_SIZE) + SIZE_MB
+        segment::secure_erase_region(&mut f, format::data_region_offset(MIN_INDEX_PAD_SIZE) + SIZE_MB, SIZE_MB).expect("fill");
 
         let mut wal = WriteAheadLog::open(&path).expect("wal");
         wal.begin(WalOp::UpdateIndex, &good_encrypted)
@@ -1018,7 +1019,7 @@ fn test_resize_grow_crash_midway_recovers() {
 
     // File size should match restored capacity
     let actual_size = handle.file.seek(SeekFrom::End(0)).expect("seek");
-    let expected_size = format::total_vault_size(SIZE_MB).expect("size");
+    let expected_size = format::total_vault_size(SIZE_MB, MIN_INDEX_PAD_SIZE).expect("size");
     assert_eq!(actual_size, expected_size);
 
     // Data intact
@@ -1209,7 +1210,7 @@ fn test_defragment_crash_recovery() {
     // Save pre-defrag encrypted index (the "good" state)
     let pre_defrag_index = {
         let mut f = File::open(&path).expect("open");
-        read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET).expect("read index")
+        read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET, encrypted_index_size(MIN_INDEX_PAD_SIZE)).expect("read index")
     };
 
     // Simulate crash mid-defrag: write uncommitted WAL entry
@@ -1275,7 +1276,7 @@ fn test_defragment_crash_overlapping_move_recovers() {
     let (pre_defrag_index, b_old_offset, b_size) = {
         let handle = vault_open(path.clone(), test_key()).expect("open");
         let mut f = File::open(&path).expect("open file");
-        let idx = read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET).expect("read idx");
+        let idx = read_encrypted_index(&mut f, PRIMARY_INDEX_OFFSET, encrypted_index_size(MIN_INDEX_PAD_SIZE)).expect("read idx");
         let entry = handle.index.find("b.txt").expect("B");
         let off = entry.offset;
         let sz = entry.size;
@@ -1296,7 +1297,7 @@ fn test_defragment_crash_overlapping_move_recovers() {
 
         // Read B from old position
         let mut buf = vec![0u8; b_size as usize];
-        f.seek(SeekFrom::Start(DATA_REGION_OFFSET + b_old_offset))
+        f.seek(SeekFrom::Start(format::data_region_offset(MIN_INDEX_PAD_SIZE) + b_old_offset))
             .expect("seek");
         f.read_exact(&mut buf).expect("read B");
 
@@ -1309,7 +1310,7 @@ fn test_defragment_crash_overlapping_move_recovers() {
         backup.sync_all().expect("sync backup");
 
         // Write B to new position (offset 0) — corrupts overlap zone
-        f.seek(SeekFrom::Start(DATA_REGION_OFFSET)).expect("seek 0");
+        f.seek(SeekFrom::Start(format::data_region_offset(MIN_INDEX_PAD_SIZE))).expect("seek 0");
         f.write_all(&buf).expect("write B to 0");
         f.sync_all().expect("sync");
 

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -20,6 +20,8 @@ pub struct VaultHandle {
     pub(crate) algorithm: Algorithm,
     pub(crate) keys: VaultKeys,
     pub(crate) index: SegmentIndex,
+    /// Padded plaintext index size, set at creation and read from header on open.
+    pub(crate) index_pad_size: usize,
     pub(crate) file: File,
     pub(crate) wal: WriteAheadLog,
     pub(crate) lock: VaultLock,
@@ -104,7 +106,7 @@ impl VaultHandle {
         let is_consistent = used_bytes
             .checked_add(free_list_bytes)
             .and_then(|v| v.checked_add(unallocated_bytes))
-            .map_or(false, |sum| sum == total_bytes);
+            == Some(total_bytes);
 
         VaultHealthInfo {
             total_bytes,

--- a/rust/src/core/evfs/format.rs
+++ b/rust/src/core/evfs/format.rs
@@ -14,34 +14,60 @@ pub const VAULT_HEADER_SIZE: usize = 32;
 /// Max segment name length in bytes (UTF-8).
 pub const MAX_SEGMENT_NAME_LEN: usize = 255;
 
-/// Index is always serialized to this size (zero-padded).
-/// 64KB supports approximately 200 segments + free regions.
-pub const INDEX_PAD_SIZE: usize = 64 * 1024;
+/// Minimum index padding size (64KB). One page supports ~200 segments.
+pub const MIN_INDEX_PAD_SIZE: usize = 64 * 1024;
 
-/// Encrypted index size on disk: padded plaintext + AEAD nonce (12) + tag (16).
-pub const ENCRYPTED_INDEX_SIZE: usize = INDEX_PAD_SIZE + 12 + 16;
+/// AEAD overhead added to the padded index plaintext: nonce (12) + tag (16).
+const INDEX_AEAD_OVERHEAD: usize = 12 + 16;
 
-/// Vault file layout offsets.
+/// Primary index starts immediately after the header.
 pub const PRIMARY_INDEX_OFFSET: u64 = VAULT_HEADER_SIZE as u64;
-pub const DATA_REGION_OFFSET: u64 = PRIMARY_INDEX_OFFSET + ENCRYPTED_INDEX_SIZE as u64;
 
-/// Shadow index offset depends on vault capacity.
-pub fn shadow_index_offset(capacity: u64) -> Result<u64, CryptoError> {
-    DATA_REGION_OFFSET
+// ---------------------------------------------------------------------------
+// Dynamic layout functions
+// ---------------------------------------------------------------------------
+
+/// Maximum index padding size (16MB). Caps segment count at ~50,000 for the
+/// largest vaults. Also bounds the WAL snapshot and heap allocation.
+pub const MAX_INDEX_PAD_SIZE: usize = 16 * 1024 * 1024;
+
+/// Compute index padding size from vault capacity.
+///
+/// Returns 64KB per MB of capacity, minimum 64KB, capped at 16MB.
+/// This determines how many segments a vault can hold.
+pub fn compute_index_size(capacity: u64) -> usize {
+    let mb = std::cmp::max(1, capacity / (1024 * 1024));
+    let size = (mb as usize).saturating_mul(MIN_INDEX_PAD_SIZE);
+    std::cmp::min(size, MAX_INDEX_PAD_SIZE)
+}
+
+/// Encrypted index size on disk: padded plaintext + AEAD nonce + tag.
+pub fn encrypted_index_size(index_pad_size: usize) -> usize {
+    index_pad_size + INDEX_AEAD_OVERHEAD
+}
+
+/// Data region offset: right after the primary encrypted index.
+pub fn data_region_offset(index_pad_size: usize) -> u64 {
+    PRIMARY_INDEX_OFFSET + encrypted_index_size(index_pad_size) as u64
+}
+
+/// Shadow index offset depends on vault capacity and index size.
+pub fn shadow_index_offset(capacity: u64, index_pad_size: usize) -> Result<u64, CryptoError> {
+    data_region_offset(index_pad_size)
         .checked_add(capacity)
         .ok_or_else(|| CryptoError::InvalidParameter("vault capacity overflows layout".into()))
 }
 
 /// WAL region starts after the shadow index.
-pub fn wal_region_offset(capacity: u64) -> Result<u64, CryptoError> {
-    shadow_index_offset(capacity)?
-        .checked_add(ENCRYPTED_INDEX_SIZE as u64)
+pub fn wal_region_offset(capacity: u64, index_pad_size: usize) -> Result<u64, CryptoError> {
+    shadow_index_offset(capacity, index_pad_size)?
+        .checked_add(encrypted_index_size(index_pad_size) as u64)
         .ok_or_else(|| CryptoError::InvalidParameter("vault capacity overflows layout".into()))
 }
 
 /// Total vault file size: header + 2 encrypted indices + data capacity.
-pub fn total_vault_size(capacity: u64) -> Result<u64, CryptoError> {
-    let base = VAULT_HEADER_SIZE as u64 + 2 * ENCRYPTED_INDEX_SIZE as u64;
+pub fn total_vault_size(capacity: u64, index_pad_size: usize) -> Result<u64, CryptoError> {
+    let base = VAULT_HEADER_SIZE as u64 + 2 * encrypted_index_size(index_pad_size) as u64;
     base.checked_add(capacity)
         .ok_or_else(|| CryptoError::InvalidParameter("vault size overflows".into()))
 }
@@ -52,21 +78,24 @@ pub fn total_vault_size(capacity: u64) -> Result<u64, CryptoError> {
 
 /// On-disk vault header (32 bytes).
 ///
-/// Layout: `[MAGIC(4)] [VERSION(1)] [ALGORITHM(1)] [FLAGS(2)] [RESERVED(24)]`
+/// Layout: `[MAGIC(4)] [VERSION(1)] [ALGORITHM(1)] [FLAGS(2)] [INDEX_SIZE(4)] [RESERVED(20)]`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VaultHeader {
     pub version: u8,
     /// AEAD algorithm ID (reuses `core::format::Algorithm` byte values).
     pub algorithm: u8,
     pub flags: u16,
+    /// Padded plaintext index size in bytes (64KB-aligned).
+    pub index_size: u32,
 }
 
 impl VaultHeader {
-    pub fn new(algorithm: u8) -> Self {
+    pub fn new(algorithm: u8, index_size: u32) -> Self {
         Self {
             version: VAULT_VERSION,
             algorithm,
             flags: 0,
+            index_size,
         }
     }
 
@@ -76,7 +105,8 @@ impl VaultHeader {
         buf[4] = self.version;
         buf[5] = self.algorithm;
         buf[6..8].copy_from_slice(&self.flags.to_le_bytes());
-        // bytes 8..32 reserved (zeros)
+        buf[8..12].copy_from_slice(&self.index_size.to_le_bytes());
+        // bytes 12..32 reserved (zeros)
         buf
     }
 
@@ -100,10 +130,20 @@ impl VaultHeader {
         }
         let algorithm = data[5];
         let flags = u16::from_le_bytes([data[6], data[7]]);
+        let index_size = u32::from_le_bytes([data[8], data[9], data[10], data[11]]);
+
+        let idx_usize = index_size as usize;
+        if !(MIN_INDEX_PAD_SIZE..=MAX_INDEX_PAD_SIZE).contains(&idx_usize) {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "invalid index_size in header: {index_size} (must be {MIN_INDEX_PAD_SIZE}..{MAX_INDEX_PAD_SIZE})"
+            )));
+        }
+
         Ok(Self {
             version,
             algorithm,
             flags,
+            index_size,
         })
     }
 }
@@ -265,7 +305,7 @@ impl SegmentIndex {
         }
     }
 
-    /// Serialize index to bytes, padded to `INDEX_PAD_SIZE`.
+    /// Serialize index to bytes, zero-padded to `pad_size`.
     ///
     /// Wire format:
     /// ```text
@@ -281,10 +321,10 @@ impl SegmentIndex {
     ///   -- free regions --
     ///   per region:
     ///     [offset: u64] [size: u64]
-    ///   -- zero padding to INDEX_PAD_SIZE --
+    ///   -- zero padding to pad_size --
     /// ```
-    pub fn to_bytes(&self) -> Result<Vec<u8>, CryptoError> {
-        let mut buf = Vec::with_capacity(INDEX_PAD_SIZE);
+    pub fn to_bytes(&self, pad_size: usize) -> Result<Vec<u8>, CryptoError> {
+        let mut buf = Vec::with_capacity(pad_size);
 
         let entry_count = u32::try_from(self.entries.len())
             .map_err(|_| CryptoError::VaultCorrupted("too many segment entries".into()))?;
@@ -316,14 +356,14 @@ impl SegmentIndex {
             put_u64(&mut buf, region.size);
         }
 
-        if buf.len() > INDEX_PAD_SIZE {
+        if buf.len() > pad_size {
             return Err(CryptoError::VaultCorrupted(format!(
-                "index content ({} bytes) exceeds INDEX_PAD_SIZE ({INDEX_PAD_SIZE})",
+                "index content ({} bytes) exceeds pad_size ({pad_size})",
                 buf.len()
             )));
         }
 
-        buf.resize(INDEX_PAD_SIZE, 0);
+        buf.resize(pad_size, 0);
         Ok(buf)
     }
 
@@ -339,8 +379,8 @@ impl SegmentIndex {
 
         // Sanity-cap: the smallest possible entry is ~59 bytes (1-byte name),
         // free region is 16 bytes. Reject clearly corrupted counts early.
-        let max_entries = INDEX_PAD_SIZE / 59;
-        let max_free = INDEX_PAD_SIZE / 16;
+        let max_entries = data.len() / 59;
+        let max_free = data.len() / 16;
         if entry_count > max_entries {
             return Err(CryptoError::VaultCorrupted(format!(
                 "entry count {entry_count} exceeds maximum {max_entries}"
@@ -618,23 +658,44 @@ mod tests {
 
     #[test]
     fn test_vault_header_roundtrip() {
-        let header = VaultHeader::new(0x01);
+        let header = VaultHeader::new(0x01, MIN_INDEX_PAD_SIZE as u32);
         let bytes = header.to_bytes();
         let parsed = VaultHeader::from_bytes(&bytes).expect("parse");
         assert_eq!(header, parsed);
     }
 
     #[test]
+    fn test_vault_header_roundtrip_large_index() {
+        let index_size = compute_index_size(5 * 1024 * 1024) as u32;
+        let header = VaultHeader::new(0x02, index_size);
+        let bytes = header.to_bytes();
+        let parsed = VaultHeader::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed.index_size, index_size);
+        assert_eq!(header, parsed);
+    }
+
+    #[test]
     fn test_vault_header_invalid_magic() {
-        let mut bytes = VaultHeader::new(0x01).to_bytes();
+        let mut bytes = VaultHeader::new(0x01, MIN_INDEX_PAD_SIZE as u32).to_bytes();
         bytes[0] = b'X';
         assert!(VaultHeader::from_bytes(&bytes).is_err());
     }
 
     #[test]
     fn test_vault_header_invalid_version() {
-        let mut bytes = VaultHeader::new(0x01).to_bytes();
+        let mut bytes = VaultHeader::new(0x01, MIN_INDEX_PAD_SIZE as u32).to_bytes();
         bytes[4] = 99;
+        assert!(VaultHeader::from_bytes(&bytes).is_err());
+    }
+
+    #[test]
+    fn test_vault_header_zero_index_size_rejected() {
+        let mut bytes = VaultHeader::new(0x01, MIN_INDEX_PAD_SIZE as u32).to_bytes();
+        // Zero out index_size at bytes 8..12
+        bytes[8] = 0;
+        bytes[9] = 0;
+        bytes[10] = 0;
+        bytes[11] = 0;
         assert!(VaultHeader::from_bytes(&bytes).is_err());
     }
 
@@ -726,7 +787,7 @@ mod tests {
     #[test]
     fn test_segment_index_roundtrip() {
         let idx = make_test_index();
-        let bytes = idx.to_bytes().expect("serialize");
+        let bytes = idx.to_bytes(compute_index_size(idx.capacity)).expect("serialize");
         let parsed = SegmentIndex::from_bytes(&bytes).expect("parse");
 
         assert_eq!(parsed.entries.len(), 2);
@@ -764,7 +825,7 @@ mod tests {
             )
             .expect("entry"),
         );
-        let bytes = idx.to_bytes().expect("serialize");
+        let bytes = idx.to_bytes(compute_index_size(idx.capacity)).expect("serialize");
         let parsed = SegmentIndex::from_bytes(&bytes).expect("parse");
         assert_eq!(parsed.next_generation, 42);
         assert_eq!(parsed.entries[0].generation, 41);
@@ -793,7 +854,7 @@ mod tests {
                 .expect("entry"),
             );
         }
-        let bytes = idx.to_bytes().expect("serialize");
+        let bytes = idx.to_bytes(compute_index_size(idx.capacity)).expect("serialize");
         let parsed = SegmentIndex::from_bytes(&bytes).expect("parse");
         assert_eq!(parsed.entries[0].compression, CompressionAlgorithm::Zstd);
         assert_eq!(parsed.entries[1].compression, CompressionAlgorithm::Brotli);
@@ -815,7 +876,7 @@ mod tests {
             offset: 1000,
             size: 300,
         });
-        let bytes = idx.to_bytes().expect("serialize");
+        let bytes = idx.to_bytes(compute_index_size(idx.capacity)).expect("serialize");
         let parsed = SegmentIndex::from_bytes(&bytes).expect("parse");
         assert_eq!(parsed.free_regions.len(), 3);
         assert_eq!(
@@ -843,20 +904,22 @@ mod tests {
 
     #[test]
     fn test_segment_index_padded_size() {
-        // Empty index
+        // Empty index — small capacity gets MIN_INDEX_PAD_SIZE
         let idx = SegmentIndex::new(1024);
-        let bytes = idx.to_bytes().expect("serialize");
-        assert_eq!(bytes.len(), INDEX_PAD_SIZE);
+        let pad = compute_index_size(idx.capacity);
+        let bytes = idx.to_bytes(pad).expect("serialize");
+        assert_eq!(bytes.len(), MIN_INDEX_PAD_SIZE);
 
-        // Index with entries + free regions
+        // Index with entries + free regions (1MB capacity → 64KB index)
         let idx = make_test_index();
-        let bytes = idx.to_bytes().expect("serialize");
-        assert_eq!(bytes.len(), INDEX_PAD_SIZE);
+        let pad = compute_index_size(idx.capacity);
+        let bytes = idx.to_bytes(pad).expect("serialize");
+        assert_eq!(bytes.len(), MIN_INDEX_PAD_SIZE);
     }
 
     #[test]
-    fn test_segment_index_overflow() {
-        let mut idx = SegmentIndex::new(u64::MAX);
+    fn test_segment_index_overflow_min_pad() {
+        let mut idx = SegmentIndex::new(512 * 1024); // 512KB → MIN_INDEX_PAD_SIZE
         // Each entry with a 255-byte name uses 2 + 255 + 8 + 8 + 8 + 32 + 1 = 314 bytes.
         // Index header is 32 bytes. (65536 - 32) / 314 ≈ 208 entries max.
         for i in 0..210 {
@@ -873,7 +936,7 @@ mod tests {
                 .expect("entry"),
             );
         }
-        assert!(idx.to_bytes().is_err());
+        assert!(idx.to_bytes(MIN_INDEX_PAD_SIZE).is_err());
     }
 
     // -- SegmentIndex lookup / mutation --------------------------------------
@@ -1082,34 +1145,65 @@ mod tests {
 
     #[test]
     fn test_layout_offsets() {
+        let idx_size = MIN_INDEX_PAD_SIZE;
+        let enc_size = encrypted_index_size(idx_size);
+
         // Primary index immediately after header
         assert_eq!(PRIMARY_INDEX_OFFSET, VAULT_HEADER_SIZE as u64);
 
-        // Data region after primary index
-        assert_eq!(
-            DATA_REGION_OFFSET,
-            PRIMARY_INDEX_OFFSET + ENCRYPTED_INDEX_SIZE as u64
-        );
+        // Data region after primary encrypted index
+        let data_off = data_region_offset(idx_size);
+        assert_eq!(data_off, PRIMARY_INDEX_OFFSET + enc_size as u64);
 
         let cap = 10 * 1024 * 1024; // 10MB
-        let shadow = shadow_index_offset(cap).expect("shadow");
-        let wal = wal_region_offset(cap).expect("wal");
+        let idx_10mb = compute_index_size(cap);
+        let enc_10mb = encrypted_index_size(idx_10mb);
+        let shadow = shadow_index_offset(cap, idx_10mb).expect("shadow");
+        let wal = wal_region_offset(cap, idx_10mb).expect("wal");
 
         // Shadow index after data region
-        assert_eq!(shadow, DATA_REGION_OFFSET + cap);
+        assert_eq!(shadow, data_region_offset(idx_10mb) + cap);
 
         // WAL after shadow index
-        assert_eq!(wal, shadow + ENCRYPTED_INDEX_SIZE as u64);
+        assert_eq!(wal, shadow + enc_10mb as u64);
 
         // No overlapping regions
-        assert!(shadow > DATA_REGION_OFFSET);
+        assert!(shadow > data_region_offset(idx_10mb));
         assert!(wal > shadow);
     }
 
     #[test]
     fn test_layout_overflow() {
-        assert!(shadow_index_offset(u64::MAX).is_err());
-        assert!(wal_region_offset(u64::MAX).is_err());
+        assert!(shadow_index_offset(u64::MAX, MIN_INDEX_PAD_SIZE).is_err());
+        assert!(wal_region_offset(u64::MAX, MIN_INDEX_PAD_SIZE).is_err());
+    }
+
+    // -- compute_index_size -------------------------------------------------
+
+    #[test]
+    fn test_compute_index_size_minimum() {
+        // Capacities below 1MB all get MIN_INDEX_PAD_SIZE
+        assert_eq!(compute_index_size(0), MIN_INDEX_PAD_SIZE);
+        assert_eq!(compute_index_size(1), MIN_INDEX_PAD_SIZE);
+        assert_eq!(compute_index_size(512 * 1024), MIN_INDEX_PAD_SIZE);
+        assert_eq!(compute_index_size(1024 * 1024), MIN_INDEX_PAD_SIZE);
+    }
+
+    #[test]
+    fn test_compute_index_size_scales() {
+        let mb = 1024 * 1024;
+        assert_eq!(compute_index_size(5 * mb), 5 * MIN_INDEX_PAD_SIZE);
+        assert_eq!(compute_index_size(10 * mb), 10 * MIN_INDEX_PAD_SIZE);
+        assert_eq!(compute_index_size(50 * mb), 50 * MIN_INDEX_PAD_SIZE);
+    }
+
+    #[test]
+    fn test_compute_index_size_boundary() {
+        let mb = 1024 * 1024;
+        // Just over 1MB → 1 page (integer division truncates)
+        assert_eq!(compute_index_size(mb + 1), MIN_INDEX_PAD_SIZE);
+        // 2MB → 2 pages
+        assert_eq!(compute_index_size(2 * mb), 2 * MIN_INDEX_PAD_SIZE);
     }
 
     // -- Zero-size allocation -----------------------------------------------

--- a/rust/src/core/evfs/wal.rs
+++ b/rust/src/core/evfs/wal.rs
@@ -15,10 +15,10 @@ const ENTRY_HEADER_SIZE: usize = 5;
 /// WAL entry footer: crc32(4) + committed(1) = 5 bytes.
 const ENTRY_FOOTER_SIZE: usize = 5;
 
-/// Max snapshot size (256KB). The encrypted index is ~65KB; this leaves
-/// generous headroom while rejecting clearly corrupt `data_len` values
-/// that would cause OOM allocations.
-const MAX_SNAPSHOT_SIZE: usize = 256 * 1024;
+/// Max snapshot size: must accommodate the largest possible encrypted index.
+/// MAX_INDEX_PAD_SIZE (16MB) + AEAD overhead (28B), rounded up.
+/// Rejects clearly corrupt `data_len` values that would cause OOM.
+const MAX_SNAPSHOT_SIZE: usize = 16 * 1024 * 1024 + 1024;
 
 // ---------------------------------------------------------------------------
 // WalOp


### PR DESCRIPTION
  Replace fixed 64KB INDEX_PAD_SIZE with capacity-proportional index.
  Header stores index_size (bytes 8-11) so vault_open reads it back.

  - compute_index_size(): 64KB per MB, min 64KB, max 16MB cap
  - VaultHeader gains index_size field (u32)
  - Layout functions (shadow_index_offset, wal_region_offset, total_vault_size, data_region_offset) take dynamic index_pad_size
  - VaultHandle stores index_pad_size for all operations
  - SegmentIndex::to_bytes(pad_size) accepts dynamic pad size
  - read_encrypted_index validates allocation size (OOM guard)
  - WAL MAX_SNAPSHOT_SIZE aligned to MAX_INDEX_PAD_SIZE + overhead
  - 5 new tests: header roundtrip, compute_index_size edge cases
  - 284/284 tests pass, clippy clean