### PR TITLE
build(release): harden profile with LTO and FFI export control

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,6 +55,10 @@ testing = [] # exposes noop cipher — never enable in production builds
 
 [profile.release]
 panic = "abort"
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+opt-level = 3
 
 [dev-dependencies]
 hex = "0.4"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,18 @@
+fn main() {
+    println!("cargo:rerun-if-changed=ffi-exports.map");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR must be set");
+
+    // ELF targets (Android, Linux): use a version script to restrict the
+    // cdylib's dynamic symbol table to FRB FFI symbols only.
+    // This hides #[no_mangle] symbols leaked by dependencies (e.g. blake3).
+    // NOTE: macOS ld is not supported — rustc generates its own -exported_symbols_list
+    // for cdylib targets, and additional flags can only add to it, not restrict it.
+    // macOS .dylib is dev-only; production .so builds are covered.
+    if matches!(target_os.as_str(), "android" | "linux") {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,--version-script={manifest_dir}/ffi-exports.map");
+    }
+}

--- a/rust/ffi-exports.map
+++ b/rust/ffi-exports.map
@@ -1,0 +1,11 @@
+/* Linker version script — only export FRB FFI symbols from the cdylib.
+   Everything else (including #[no_mangle] symbols from deps) becomes local. */
+{
+    global:
+        frb_*;
+        frbgen_m_security_*;
+        free_zero_copy_buffer_*;
+        store_dart_post_cobject;
+    local:
+        *;
+};


### PR DESCRIPTION
## Summary

- Harden release profile with `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"`, `opt-level = 3`
- Add ELF linker version script (`ffi-exports.map`) to restrict `.so` dynamic symbol table to FRB FFI surface only
- Add `build.rs` to conditionally apply the version script on Android/Linux cdylib builds

This hides `#[no_mangle]` symbols leaked by dependencies (e.g. blake3's `blake3_compress_in_place_portable`) from production `.so` binaries, so `nm -D` only shows `frb_*`/`frbgen_m_security_*` symbols.

**macOS note:** rustc generates its own `-exported_symbols_list` for cdylib targets that includes all `#[no_mangle]` symbols. This can't be overridden — macOS `.dylib` is dev-only; production ELF builds are fully covered.

## Test plan

- [x] All 331 tests pass
- [x] `cargo clippy --all-features` clean
- [x] Release build succeeds
- [x] iOS cross-check (`aarch64-apple-ios`, `aarch64-apple-ios-sim`) passes
- [x] macOS cross-check (`x86_64-apple-darwin`, `aarch64-apple-darwin`) passes
- [ ] CI: Android `.so` build with NDK — verify `nm -D` output
- [ ] CI: Linux release build — verify `nm -D` output