### PR TITLE
feat(evfs): zero-copy vault reads via mmap

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -743,7 +743,9 @@ dependencies = [
  "fs4",
  "hex",
  "hkdf",
+ "libc",
  "log",
+ "memmap2",
  "rand",
  "sha2",
  "sha3",
@@ -769,6 +771,15 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,6 +44,10 @@ crc32fast = "1.4"
 # Advisory file locking
 fs4 = "0.12"
 
+# Memory-mapped I/O for zero-copy vault reads
+memmap2 = "0.9"
+libc = "0.2"
+
 # Compression
 zstd = { version = "0.13", optional = true }
 brotli = { version = "7.0", optional = true }

--- a/rust/src/api/evfs/helpers.rs
+++ b/rust/src/api/evfs/helpers.rs
@@ -97,10 +97,14 @@ pub(crate) fn capacity_from_file_size(
 
 /// Decrypt all chunks of a streaming segment, calling `on_chunk(plaintext, chunk_index)`
 /// for each decrypted chunk. Returns the BLAKE3 checksum of the full decrypted data.
+///
+/// When `mmap` is `Some`, chunks are read via zero-copy slices into the mapped
+/// file. Falls back to heap-allocated `read_exact` when mmap is unavailable.
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "compression")]
 pub(crate) fn decrypt_streaming_chunks(
     file: &mut File,
+    mmap: Option<&super::types::VaultMmap>,
     cipher_key: &[u8],
     nonce_key: &[u8],
     algorithm: Algorithm,
@@ -112,6 +116,7 @@ pub(crate) fn decrypt_streaming_chunks(
     mut on_chunk: impl FnMut(Vec<u8>, u32) -> Result<(), CryptoError>,
 ) -> Result<[u8; 32], CryptoError> {
     let data_region = format::data_region_offset(index_pad_size);
+    let enc_chunk_size = crate::core::streaming::ENCRYPTED_CHUNK_SIZE;
     let mut hasher = blake3::Hasher::new();
     let mut decompressor = if compression != CompressionAlgorithm::None {
         Some(crate::core::compression::streaming::new_decompressor(
@@ -124,16 +129,26 @@ pub(crate) fn decrypt_streaming_chunks(
 
     for i in 0..chunk_count {
         let chunk_offset = (i as u64)
-            .checked_mul(crate::core::streaming::ENCRYPTED_CHUNK_SIZE as u64)
+            .checked_mul(enc_chunk_size as u64)
             .and_then(|co| data_region.checked_add(seg_offset)?.checked_add(co))
             .ok_or_else(|| CryptoError::InvalidParameter("chunk offset overflow".into()))?;
-        file.seek(SeekFrom::Start(chunk_offset))?;
 
-        let mut encrypted = vec![0u8; crate::core::streaming::ENCRYPTED_CHUNK_SIZE];
-        file.read_exact(&mut encrypted)?;
+        // Zero-copy path: slice directly into mmap; fallback: heap read
+        let heap_buf;
+        let encrypted_ref: &[u8] = if let Some(m) = mmap {
+            m.slice(chunk_offset, enc_chunk_size as u64)?
+        } else {
+            file.seek(SeekFrom::Start(chunk_offset))?;
+            heap_buf = {
+                let mut buf = vec![0u8; enc_chunk_size];
+                file.read_exact(&mut buf)?;
+                buf
+            };
+            &heap_buf
+        };
 
         let expected_nonce = segment::derive_chunk_nonce(nonce_key, i as u64, generation)?;
-        let (stored_nonce, _) = encrypted.split_at(crate::core::streaming::NONCE_SIZE);
+        let (stored_nonce, _) = encrypted_ref.split_at(crate::core::streaming::NONCE_SIZE);
         if stored_nonce.ct_ne(&expected_nonce).into() {
             return Err(CryptoError::AuthenticationFailed);
         }
@@ -148,7 +163,7 @@ pub(crate) fn decrypt_streaming_chunks(
 
         let decrypted = segment::aead_decrypt_with_stored_nonce(
             cipher_key,
-            &encrypted,
+            encrypted_ref,
             &aad,
             algorithm,
         )?;

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -82,8 +82,8 @@ pub fn vault_create(
         keys,
         index,
         index_pad_size,
-        file,
         mmap,
+        file,
         wal,
         lock,
     })
@@ -237,8 +237,8 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         keys,
         index,
         index_pad_size,
-        file,
         mmap,
+        file,
         wal,
         lock,
     })

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 
 use helpers::*;
 pub use types::*;
+use types::VaultMmap;
 
 use crate::api::compression::{CompressionAlgorithm, CompressionConfig};
 use crate::core::error::CryptoError;
@@ -74,6 +75,7 @@ pub fn vault_create(
     let mut wal = WriteAheadLog::open(&path)?;
     wal.checkpoint()?;
 
+    let mmap = VaultMmap::new(&file).ok();
     Ok(VaultHandle {
         path,
         algorithm: algo,
@@ -81,6 +83,7 @@ pub fn vault_create(
         index,
         index_pad_size,
         file,
+        mmap,
         wal,
         lock,
     })
@@ -227,6 +230,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         file.sync_all()?;
     }
 
+    let mmap = VaultMmap::new(&file).ok();
     Ok(VaultHandle {
         path,
         algorithm,
@@ -234,6 +238,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         index,
         index_pad_size,
         file,
+        mmap,
         wal,
         lock,
     })
@@ -323,8 +328,9 @@ pub fn vault_write(
         handle.index_pad_size,
     )?;
 
-    // 9. WAL commit
+    // 9. WAL commit + refresh mmap (file contents changed)
     handle.wal.commit()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -350,6 +356,7 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
         let mut full_plaintext = Vec::new();
         let checksum = decrypt_streaming_chunks(
             &mut handle.file,
+            handle.mmap.as_ref(),
             handle.keys.cipher_key.as_bytes(),
             handle.keys.nonce_key.as_bytes(),
             handle.algorithm,
@@ -373,19 +380,8 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
         return Ok(full_plaintext);
     }
 
-    // Existing monolithic read logic (used when chunk_count == 0)
-    let read_len = usize::try_from(seg_size).map_err(|_| {
-        CryptoError::VaultCorrupted(format!(
-            "segment size {seg_size} exceeds platform address space"
-        ))
-    })?;
-    handle.file.seek(SeekFrom::Start(
-        format::data_region_offset(handle.index_pad_size) + seg_offset,
-    ))?;
-    let mut encrypted = vec![0u8; read_len];
-    handle.file.read_exact(&mut encrypted)?;
-
-    // Decrypt-then-decompress
+    // Monolithic read (chunk_count == 0): prefer mmap zero-copy, fall back to heap
+    let abs_offset = format::data_region_offset(handle.index_pad_size) + seg_offset;
     let params = SegmentCryptoParams {
         cipher_key: handle.keys.cipher_key.as_bytes(),
         nonce_key: handle.keys.nonce_key.as_bytes(),
@@ -393,7 +389,22 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
         segment_index: 0,
         generation: seg_gen,
     };
-    let plaintext = segment::decrypt_segment(&params, &encrypted, seg_compression)?;
+
+    let plaintext = if let Some(ref mmap) = handle.mmap {
+        let encrypted = mmap.slice(abs_offset, seg_size)?;
+        segment::decrypt_segment(&params, encrypted, seg_compression)?
+    } else {
+        // Fallback: heap-allocated read_exact (32-bit or mmap-failed)
+        let read_len = usize::try_from(seg_size).map_err(|_| {
+            CryptoError::VaultCorrupted(format!(
+                "segment size {seg_size} exceeds platform address space"
+            ))
+        })?;
+        handle.file.seek(SeekFrom::Start(abs_offset))?;
+        let mut buf = vec![0u8; read_len];
+        handle.file.read_exact(&mut buf)?;
+        segment::decrypt_segment(&params, &buf, seg_compression)?
+    };
 
     // Verify checksum on decompressed plaintext
     if !segment::verify_checksum(&plaintext, &seg_checksum) {
@@ -435,6 +446,7 @@ pub fn vault_read_stream(
 
     let checksum = decrypt_streaming_chunks(
         &mut handle.file,
+        handle.mmap.as_ref(),
         handle.keys.cipher_key.as_bytes(),
         handle.keys.nonce_key.as_bytes(),
         handle.algorithm,
@@ -605,6 +617,7 @@ pub fn vault_write_stream(
 
     handle.wal.commit()?;
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -754,8 +767,9 @@ pub fn vault_delete(handle: &mut VaultHandle, name: String) -> Result<(), Crypto
         handle.index_pad_size,
     )?;
 
-    // WAL commit
+    // WAL commit + refresh mmap (file contents changed)
     handle.wal.commit()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -810,6 +824,7 @@ fn vault_resize_grow_impl(
 
     handle.wal.commit()?;
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -878,6 +893,7 @@ fn vault_resize_shrink_impl(
 
     handle.wal.commit()?;
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -1042,8 +1058,9 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         )?;
     }
 
-    // Checkpoint WAL (clear history)
+    // Checkpoint WAL (clear history) + refresh mmap (data moved)
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(DefragResult {
         segments_moved,

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -2141,6 +2141,7 @@ fn stream_read_chunks(
 
     let checksum = decrypt_streaming_chunks(
         &mut handle.file,
+        handle.mmap.as_ref(),
         handle.keys.cipher_key.as_bytes(),
         handle.keys.nonce_key.as_bytes(),
         handle.algorithm,

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -1,9 +1,80 @@
+use crate::core::error::CryptoError;
 use crate::core::evfs::format::SegmentIndex;
 use crate::core::evfs::segment::VaultKeys;
 use crate::core::evfs::wal::{VaultLock, WriteAheadLog};
 use crate::core::format::Algorithm;
 use flutter_rust_bridge::frb;
+use memmap2::Mmap;
 use std::fs::File;
+
+// ---------------------------------------------------------------------------
+// VaultMmap — read-only memory-mapped view of the vault file
+// ---------------------------------------------------------------------------
+
+/// Read-only memory-mapped view of the vault file for zero-copy segment reads.
+///
+/// Created on vault open and recreated after any mutation (write, delete,
+/// defrag, resize) that changes the file contents.
+pub(crate) struct VaultMmap {
+    mmap: Mmap,
+}
+
+impl VaultMmap {
+    /// Create a new read-only mapping of the vault file.
+    ///
+    /// # Safety contract
+    /// The caller must hold an exclusive flock on the file (VaultLock) so no
+    /// concurrent writer can modify the file while the mapping is live.
+    pub(crate) fn new(file: &File) -> Result<Self, CryptoError> {
+        // SAFETY: file is flock-locked — no concurrent writers
+        let mmap = unsafe { Mmap::map(file) }
+            .map_err(|e| CryptoError::IoError(format!("mmap failed: {e}")))?;
+
+        // Lock pages to prevent kernel from swapping ciphertext to disk.
+        // Failure is non-fatal (mlock limits may be low on some systems).
+        #[cfg(unix)]
+        {
+            unsafe {
+                libc::mlock(mmap.as_ptr().cast::<libc::c_void>(), mmap.len());
+            }
+        }
+
+        Ok(Self { mmap })
+    }
+
+    /// Return a byte slice into the mapped region at `[offset..offset+len]`.
+    ///
+    /// Returns `Err` if the range is out of bounds (e.g. 32-bit overflow or
+    /// the file was truncated between mapping and read).
+    pub(crate) fn slice(&self, offset: u64, len: u64) -> Result<&[u8], CryptoError> {
+        let start = usize::try_from(offset).map_err(|_| {
+            CryptoError::VaultCorrupted(format!("mmap offset {offset} exceeds address space"))
+        })?;
+        let size = usize::try_from(len).map_err(|_| {
+            CryptoError::VaultCorrupted(format!("mmap length {len} exceeds address space"))
+        })?;
+        let end = start.checked_add(size).ok_or_else(|| {
+            CryptoError::VaultCorrupted("mmap range overflow".into())
+        })?;
+        if end > self.mmap.len() {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "mmap read {start}..{end} exceeds file size {}",
+                self.mmap.len()
+            )));
+        }
+        Ok(&self.mmap[start..end])
+    }
+}
+
+#[cfg(unix)]
+impl Drop for VaultMmap {
+    fn drop(&mut self) {
+        // Unlock pages before the mmap is unmapped
+        unsafe {
+            libc::munlock(self.mmap.as_ptr().cast::<libc::c_void>(), self.mmap.len());
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // VaultHandle
@@ -23,8 +94,17 @@ pub struct VaultHandle {
     /// Padded plaintext index size, set at creation and read from header on open.
     pub(crate) index_pad_size: usize,
     pub(crate) file: File,
+    /// Read-only mmap for zero-copy reads. None if mmap failed (32-bit fallback).
+    pub(crate) mmap: Option<VaultMmap>,
     pub(crate) wal: WriteAheadLog,
     pub(crate) lock: VaultLock,
+}
+
+impl VaultHandle {
+    /// (Re)create the mmap after a mutation. Silently falls back to None on failure.
+    pub(crate) fn refresh_mmap(&mut self) {
+        self.mmap = VaultMmap::new(&self.file).ok();
+    }
 }
 
 /// Capacity info returned to callers.

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -26,7 +26,9 @@ impl VaultMmap {
     /// The caller must hold an exclusive flock on the file (VaultLock) so no
     /// concurrent writer can modify the file while the mapping is live.
     pub(crate) fn new(file: &File) -> Result<Self, CryptoError> {
-        // SAFETY: file is flock-locked — no concurrent writers
+        // SAFETY: the caller holds an exclusive advisory flock via VaultLock,
+        // ensuring no cooperating process modifies the file while mapped.
+        // Non-cooperating processes are outside this library's threat model.
         let mmap = unsafe { Mmap::map(file) }
             .map_err(|e| CryptoError::IoError(format!("mmap failed: {e}")))?;
 
@@ -93,9 +95,10 @@ pub struct VaultHandle {
     pub(crate) index: SegmentIndex,
     /// Padded plaintext index size, set at creation and read from header on open.
     pub(crate) index_pad_size: usize,
-    pub(crate) file: File,
     /// Read-only mmap for zero-copy reads. None if mmap failed (32-bit fallback).
+    /// Dropped before `file` so munlock/munmap runs while the fd is still open.
     pub(crate) mmap: Option<VaultMmap>,
+    pub(crate) file: File,
     pub(crate) wal: WriteAheadLog,
     pub(crate) lock: VaultLock,
 }


### PR DESCRIPTION
## Summary

- Replace heap-allocated `read_exact` with `memmap2` memory-mapped I/O for `vault_read` and `vault_read_stream`
- `mlock()` pins ciphertext pages on unix to prevent swap-to-disk
- Graceful fallback to heap reads when mmap fails (32-bit targets, low `mlock` limits)
- mmap is invalidated and recreated after every mutation (write, delete, defrag, resize)
- Includes release profile hardening from PR #105 (LTO, symbol stripping, FFI export control)

## Details

**`VaultMmap` wrapper** (`types.rs`):
- Read-only `Mmap` with bounds-checked `slice()` returning `&[u8]` directly into mapped pages
- `mlock` on creation, `munlock` in `Drop` (unix only, non-fatal on failure)
- `VaultHandle` field ordering ensures `munlock` → `munmap` → `close(fd)`

**Read paths** (`mod.rs`, `helpers.rs`):
- Monolithic `vault_read`: mmap slice → `decrypt_segment` (no intermediate `Vec<u8>`)
- Streaming `decrypt_streaming_chunks`: mmap slice per chunk, heap fallback via `Option<&VaultMmap>`

**Invalidation** — `refresh_mmap()` called after:
- `vault_write`, `vault_write_stream`
- `vault_delete`
- `vault_resize` (grow + shrink)
- `vault_defragment`

## Test plan

- [x] All 331 tests pass
- [x] `cargo clippy --all-features` clean
- [x] iOS cross-check (`aarch64-apple-ios`, `aarch64-apple-ios-sim`) passes
- [x] macOS cross-check (`x86_64-apple-darwin`, `aarch64-apple-darwin`) passes
- [x] Unsafe audit: `Mmap::map` safety contract (advisory flock), `mlock`/`munlock` pointer casts, Drop ordering all verified sound
- [x] All 6 mutation paths verified to call `refresh_mmap()` after commit
- [ ] CI: Android `.so` build with NDK