### PR TITLE
Zero-copy FFI optimization (v0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## v0.3.3 - 2026-03-27
 
 ### Added
 
+- Zero-copy vault reads via `memmap2` memory-mapped I/O — `vault_read` and `vault_read_stream` now slice directly into mapped file pages instead of allocating heap buffers with `read_exact`.
+- `VaultMmap` wrapper with `mlock()` on unix to pin ciphertext pages in RAM and prevent swap-to-disk. Graceful fallback to heap reads when mmap fails (32-bit targets, low `mlock` limits).
+- mmap invalidation/recreation after every vault mutation (write, delete, defrag, resize).
+- ELF linker version script (`ffi-exports.map`) restricting Android/Linux `.so` dynamic symbol table to FRB FFI symbols only — hides `#[no_mangle]` symbols leaked by dependencies.
+- `build.rs` for conditional version script application on Android/Linux cdylib builds.
+
 ### Changed
 
-### Fixed
+- Switched all 50 FRB functions from SSE to CST+DCO codec via `full_dep: true` — `Vec<u8>` returns now use `allo-isolate` `ExternalTypedData` (pointer transfer, no memcpy) instead of SSE serialization.
+- Release profile hardened: `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"`, `opt-level = 3`.
+- `VaultHandle` field order: `mmap` before `file` so `munlock`/`munmap` runs while the fd is still open.
+
+### Security
+
+- Symbol stripping removes internal Rust function names from release binaries — `nm -D` shows only FRB entry points and libc on ELF targets.
+- `mlock()` prevents OS from swapping mmap'd ciphertext pages to disk swap.
+- Fewer intermediate `Vec<u8>` copies means shorter plaintext residency in memory.
+- ZeroizeOnDrop behavior preserved — no regression from zero-copy refactoring.
 
 ## [v0.3.2](https://github.com/MicroClub-USTHB/M-Security/releases/tag/v0.3.2) - 2026-03-26
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Built and maintained by the **Dev Department** of [MicroClub](https://github.com
 | **Password Hashing**     | Argon2id               | PHC winner, Mobile and Desktop presets                      |
 | **Key Derivation**       | HKDF-SHA256            | RFC 5869, extract-then-expand with domain separation        |
 | **Encrypted VFS (EVFS)** | `.vault` container     | Named segments, WAL recovery, shadow index, secure deletion |
+| **Zero-Copy I/O**        | mmap + DCO codec       | Memory-mapped vault reads, zero-copy Rust-to-Dart transfers |
 
 **Security by design:**
 
@@ -38,6 +39,8 @@ Built and maintained by the **Dev Department** of [MicroClub](https://github.com
 - AEAD tag verification prevents silent decryption of tampered data
 - `panic = "abort"` in release profile, preventing undefined behavior from panics crossing FFI
 - `clippy::unwrap_used = "deny"`, ensuring all operations return `Result<T, CryptoError>`
+- Release builds strip all symbols except FRB entry points (LTO + ELF version script)
+- `mlock()` pins mmap'd ciphertext pages to prevent swap-to-disk (unix)
 
 ## Installation
 
@@ -45,7 +48,7 @@ Add to your `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  m_security: ^0.3.2
+  m_security: ^0.3.3
 ```
 
 Then run:
@@ -329,13 +332,13 @@ hkdf_expand(prk, info, output_len)          -> Result<Vec<u8>>
 
 ## Testing
 
-**Rust unit tests** (317 tests including EVFS streaming and defrag):
+**Rust unit tests** (331 tests including EVFS streaming and defrag):
 
 ```bash
 cd rust && cargo test
 ```
 
-**Dart integration tests** (63 tests across all features, requires a running device/simulator):
+**Dart integration tests** (76 tests across all features, requires a running device/simulator):
 
 ```bash
 cd example
@@ -351,7 +354,7 @@ flutter test integration_test/
 | Dart SDK            | ^3.10.8 |
 | Flutter SDK         | >=3.3.0 |
 
-**Rust crates:** `aes-gcm` 0.10, `chacha20poly1305` 0.10, `blake3` 1.8, `sha3` 0.10, `argon2` 0.5, `hkdf` 0.12, `zstd` 0.13, `brotli` 7.0, `zeroize` 1.8
+**Rust crates:** `aes-gcm` 0.10, `chacha20poly1305` 0.10, `blake3` 1.8, `sha3` 0.10, `argon2` 0.5, `hkdf` 0.12, `zstd` 0.13, `brotli` 7.0, `zeroize` 1.8, `memmap2` 0.9
 
 ## Roadmap
 
@@ -362,6 +365,7 @@ flutter test integration_test/
 | **Encrypted Virtual File System (EVFS)** | `.vault` container with named segments, WAL recovery, shadow index, secure deletion | v0.3.0  |
 | **EVFS v2: Defrag & resize**             | Online defragmentation, vault resizing, health diagnostics                          | v0.3.1  |
 | **EVFS v3: Streaming I/O**                | Constant-memory streaming reads/writes, per-chunk AEAD, progress callbacks          | v0.3.2  |
+| **Zero-copy FFI optimization**           | mmap vault reads, DCO codec, release profile hardening, symbol stripping            | v0.3.3  |
 | **EVFS v2: Key rotation**                | Re-encrypt vault with new master key                                                | Planned |
 | **Stealth storage**                      | Ephemeral secrets in Rust-managed memory with derived-path obfuscation              | Planned |
 | **Hardware key wrap**                    | Master key in Secure Enclave (iOS) / KeyStore (Android) with biometric unlock       | Planned |

--- a/flutter_rust_bridge.yaml
+++ b/flutter_rust_bridge.yaml
@@ -2,5 +2,6 @@ rust_input: crate::api
 rust_root: rust/
 dart_output: lib/src/rust
 enable_lifetime: true
+full_dep: true
 rust_features:
   - compression

--- a/lib/src/rust/api/encryption.dart
+++ b/lib/src/rust/api/encryption.dart
@@ -64,5 +64,5 @@ Future<String> encryptionAlgorithmId({required CipherHandle cipher}) => RustLib
     .api
     .crateApiEncryptionEncryptionAlgorithmId(cipher: cipher);
 
-// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
+// Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
 abstract class CipherHandle implements RustOpaqueInterface {}

--- a/lib/src/rust/api/evfs/types.dart
+++ b/lib/src/rust/api/evfs/types.dart
@@ -6,9 +6,11 @@
 import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `eq`, `fmt`
+// These functions are ignored because they are not marked as `pub`: `new`, `refresh_mmap`, `slice`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultMmap`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `drop`, `eq`, `fmt`
 
-// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
+// Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
 abstract class VaultHandle implements RustOpaqueInterface {
   /// Compute health information from the in-memory index only (no file I/O or WAL writes).
   Future<VaultHealthInfo> health();

--- a/lib/src/rust/api/hashing.dart
+++ b/lib/src/rust/api/hashing.dart
@@ -50,5 +50,5 @@ Future<Uint8List> blake3Hash({required List<int> data}) =>
 Future<Uint8List> sha3Hash({required List<int> data}) =>
     RustLib.instance.api.crateApiHashingSha3Hash(data: data);
 
-// Rust type: RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
+// Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
 abstract class HasherHandle implements RustOpaqueInterface {}

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -336,20 +336,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            that,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 1,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                that,
+              );
+          return wire.wire__crate__api__evfs__types__VaultHandle_health(
+            port_,
+            arg0,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_vault_health_info,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_vault_health_info,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiEvfsTypesVaultHandleHealthConstMeta,
@@ -370,19 +367,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(password, serializer);
-          sse_encode_argon_2_preset(preset, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 2,
-            port: port_,
+          var arg0 = cst_encode_String(password);
+          var arg1 = cst_encode_argon_2_preset(preset);
+          return wire.wire__crate__api__hashing__argon2__argon2id_hash(
+            port_,
+            arg0,
+            arg1,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_String,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingArgon2Argon2IdHashConstMeta,
         argValues: [password, preset],
@@ -406,20 +401,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(password, serializer);
-          sse_encode_String(salt, serializer);
-          sse_encode_argon_2_preset(preset, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 3,
-            port: port_,
-          );
+          var arg0 = cst_encode_String(password);
+          var arg1 = cst_encode_String(salt);
+          var arg2 = cst_encode_argon_2_preset(preset);
+          return wire
+              .wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+                port_,
+                arg0,
+                arg1,
+                arg2,
+              );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_String,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingArgon2Argon2IdHashWithSaltConstMeta,
         argValues: [password, salt, preset],
@@ -442,19 +437,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(phcHash, serializer);
-          sse_encode_String(password, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 4,
-            port: port_,
+          var arg0 = cst_encode_String(phcHash);
+          var arg1 = cst_encode_String(password);
+          return wire.wire__crate__api__hashing__argon2__argon2id_verify(
+            port_,
+            arg0,
+            arg1,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingArgon2Argon2IdVerifyConstMeta,
         argValues: [phcHash, password],
@@ -474,17 +467,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 5,
-            port: port_,
-          );
+          var arg0 = cst_encode_list_prim_u_8_loose(data);
+          return wire.wire__crate__api__hashing__blake3_hash(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiHashingBlake3HashConstMeta,
@@ -505,19 +492,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(data, serializer);
-          sse_encode_box_autoadd_compression_config(config, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 6,
-            port: port_,
+          var arg0 = cst_encode_list_prim_u_8_loose(data);
+          var arg1 = cst_encode_box_autoadd_compression_config(config);
+          return wire.wire__crate__api__compression__compress(
+            port_,
+            arg0,
+            arg1,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiCompressionCompressConstMeta,
         argValues: [data, config],
@@ -536,18 +521,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_u_8(byte, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 7,
-            port: port_,
-          );
+          var arg0 = cst_encode_u_8(byte);
+          return wire
+              .wire__crate__api__compression__compression_algorithm_from_u8(
+                port_,
+                arg0,
+              );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_compression_algorithm,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_compression_algorithm,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiCompressionCompressionAlgorithmFromU8ConstMeta,
         argValues: [byte],
@@ -569,17 +552,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_compression_algorithm(that, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 8,
-            port: port_,
-          );
+          var arg0 = cst_encode_compression_algorithm(that);
+          return wire
+              .wire__crate__api__compression__compression_algorithm_to_u8(
+                port_,
+                arg0,
+              );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_u_8,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_u_8,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiCompressionCompressionAlgorithmToU8ConstMeta,
@@ -602,19 +583,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(key, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 9,
-            port: port_,
+          var arg0 = cst_encode_list_prim_u_8_loose(key);
+          return wire.wire__crate__api__encryption__create_aes256_gcm(
+            port_,
+            arg0,
           );
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
-          decodeErrorData: sse_decode_crypto_error,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionCreateAes256GcmConstMeta,
         argValues: [key],
@@ -631,17 +609,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 10,
-            port: port_,
-          );
+          return wire.wire__crate__api__hashing__create_blake3(port_);
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiHashingCreateBlake3ConstMeta,
@@ -661,19 +633,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(key, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 11,
-            port: port_,
+          var arg0 = cst_encode_list_prim_u_8_loose(key);
+          return wire.wire__crate__api__encryption__create_chacha20_poly1305(
+            port_,
+            arg0,
           );
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
-          decodeErrorData: sse_decode_crypto_error,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionCreateChacha20Poly1305ConstMeta,
         argValues: [key],
@@ -693,17 +662,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 12,
-            port: port_,
+          return wire.wire__crate__api__encryption__create_noop_encryption(
+            port_,
           );
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiEncryptionCreateNoopEncryptionConstMeta,
@@ -721,17 +686,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 13,
-            port: port_,
-          );
+          return wire.wire__crate__api__hashing__create_sha3(port_);
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiHashingCreateSha3ConstMeta,
@@ -752,19 +711,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(data, serializer);
-          sse_encode_compression_algorithm(algorithm, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 14,
-            port: port_,
+          var arg0 = cst_encode_list_prim_u_8_loose(data);
+          var arg1 = cst_encode_compression_algorithm(algorithm);
+          return wire.wire__crate__api__compression__decompress(
+            port_,
+            arg0,
+            arg1,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiCompressionDecompressConstMeta,
         argValues: [data, algorithm],
@@ -788,23 +745,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-            cipher,
-            serializer,
-          );
-          sse_encode_list_prim_u_8_loose(ciphertext, serializer);
-          sse_encode_list_prim_u_8_loose(aad, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 15,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                cipher,
+              );
+          var arg1 = cst_encode_list_prim_u_8_loose(ciphertext);
+          var arg2 = cst_encode_list_prim_u_8_loose(aad);
+          return wire.wire__crate__api__encryption__decrypt(
+            port_,
+            arg0,
+            arg1,
+            arg2,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionDecryptConstMeta,
         argValues: [cipher, ciphertext, aad],
@@ -827,23 +783,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-            cipher,
-            serializer,
-          );
-          sse_encode_list_prim_u_8_loose(plaintext, serializer);
-          sse_encode_list_prim_u_8_loose(aad, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 16,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                cipher,
+              );
+          var arg1 = cst_encode_list_prim_u_8_loose(plaintext);
+          var arg2 = cst_encode_list_prim_u_8_loose(aad);
+          return wire.wire__crate__api__encryption__encrypt(
+            port_,
+            arg0,
+            arg1,
+            arg2,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionEncryptConstMeta,
         argValues: [cipher, plaintext, aad],
@@ -864,20 +819,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-            cipher,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 17,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                cipher,
+              );
+          return wire.wire__crate__api__encryption__encryption_algorithm_id(
+            port_,
+            arg0,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_String,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiEncryptionEncryptionAlgorithmIdConstMeta,
@@ -898,17 +850,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 18,
-            port: port_,
+          return wire.wire__crate__api__encryption__generate_aes256_gcm_key(
+            port_,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionGenerateAes256GcmKeyConstMeta,
         argValues: [],
@@ -925,17 +873,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 19,
-            port: port_,
+          return wire.wire__crate__api__encryption__aes_gcm__generate_aes_key(
+            port_,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionAesGcmGenerateAesKeyConstMeta,
         argValues: [],
@@ -952,17 +896,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 20,
-            port: port_,
-          );
+          return wire
+              .wire__crate__api__encryption__generate_chacha20_poly1305_key(
+                port_,
+              );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionGenerateChacha20Poly1305KeyConstMeta,
         argValues: [],
@@ -982,17 +923,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 21,
-            port: port_,
-          );
+          return wire
+              .wire__crate__api__encryption__chacha20__generate_chacha_key(
+                port_,
+              );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEncryptionChacha20GenerateChachaKeyConstMeta,
         argValues: [],
@@ -1011,21 +949,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 22,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+                handle,
+              );
+          return wire.wire__crate__api__hashing__hasher_algorithm_id(
+            port_,
+            arg0,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_String,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_String,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingHasherAlgorithmIdConstMeta,
         argValues: [handle],
@@ -1047,21 +982,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 23,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+                handle,
+              );
+          return wire.wire__crate__api__hashing__hasher_finalize(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingHasherFinalizeConstMeta,
         argValues: [handle],
@@ -1078,21 +1007,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 24,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+                handle,
+              );
+          return wire.wire__crate__api__hashing__hasher_reset(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingHasherResetConstMeta,
         argValues: [handle],
@@ -1112,22 +1035,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 25,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+                handle,
+              );
+          var arg1 = cst_encode_list_prim_u_8_loose(data);
+          return wire.wire__crate__api__hashing__hasher_update(
+            port_,
+            arg0,
+            arg1,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiHashingHasherUpdateConstMeta,
         argValues: [handle, data],
@@ -1152,16 +1073,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(ikm, serializer);
-          sse_encode_opt_list_prim_u_8_strict(salt, serializer);
-          sse_encode_list_prim_u_8_loose(info, serializer);
-          sse_encode_usize(outputLen, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 26)!;
+          var arg0 = cst_encode_list_prim_u_8_loose(ikm);
+          var arg1 = cst_encode_opt_list_prim_u_8_strict(salt);
+          var arg2 = cst_encode_list_prim_u_8_loose(info);
+          var arg3 = cst_encode_usize(outputLen);
+          return wire.wire__crate__api__kdf__hkdf__hkdf_derive(
+            arg0,
+            arg1,
+            arg2,
+            arg3,
+          );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiKdfHkdfHkdfDeriveConstMeta,
         argValues: [ikm, salt, info, outputLen],
@@ -1184,20 +1109,19 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(prk, serializer);
-          sse_encode_list_prim_u_8_loose(info, serializer);
-          sse_encode_usize(outputLen, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 27,
-            port: port_,
+          var arg0 = cst_encode_list_prim_u_8_loose(prk);
+          var arg1 = cst_encode_list_prim_u_8_loose(info);
+          var arg2 = cst_encode_usize(outputLen);
+          return wire.wire__crate__api__kdf__hkdf__hkdf_expand(
+            port_,
+            arg0,
+            arg1,
+            arg2,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiKdfHkdfHkdfExpandConstMeta,
         argValues: [prk, info, outputLen],
@@ -1219,14 +1143,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeSync(
       SyncTask(
         callFfi: () {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(ikm, serializer);
-          sse_encode_opt_list_prim_u_8_strict(salt, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 28)!;
+          var arg0 = cst_encode_list_prim_u_8_loose(ikm);
+          var arg1 = cst_encode_opt_list_prim_u_8_strict(salt);
+          return wire.wire__crate__api__kdf__hkdf__hkdf_extract(arg0, arg1);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiKdfHkdfHkdfExtractConstMeta,
         argValues: [ikm, salt],
@@ -1243,17 +1166,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_list_prim_u_8_loose(data, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 29,
-            port: port_,
-          );
+          var arg0 = cst_encode_list_prim_u_8_loose(data);
+          return wire.wire__crate__api__hashing__sha3_hash(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiHashingSha3HashConstMeta,
@@ -1273,17 +1190,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(filePath, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 30,
-            port: port_,
+          var arg0 = cst_encode_String(filePath);
+          return wire.wire__crate__api__compression__should_skip_compression(
+            port_,
+            arg0,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_bool,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_bool,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiCompressionShouldSkipCompressionConstMeta,
@@ -1311,25 +1225,27 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-              cipher,
-              serializer,
-            );
-            sse_encode_box_autoadd_compression_config(compression, serializer);
-            sse_encode_String(inputPath, serializer);
-            sse_encode_String(outputPath, serializer);
-            sse_encode_StreamSink_f_64_Sse(progressSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 31,
-              port: port_,
-            );
+            var arg0 =
+                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                  cipher,
+                );
+            var arg1 = cst_encode_box_autoadd_compression_config(compression);
+            var arg2 = cst_encode_String(inputPath);
+            var arg3 = cst_encode_String(outputPath);
+            var arg4 = cst_encode_StreamSink_f_64_Dco(progressSink);
+            return wire
+                .wire__crate__api__streaming__stream_compress_encrypt_file(
+                  port_,
+                  arg0,
+                  arg1,
+                  arg2,
+                  arg3,
+                  arg4,
+                );
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_crypto_error,
+          codec: DcoCodec(
+            decodeSuccessData: dco_decode_unit,
+            decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiStreamingStreamCompressEncryptFileConstMeta,
           argValues: [cipher, compression, inputPath, outputPath, progressSink],
@@ -1363,24 +1279,25 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-              cipher,
-              serializer,
-            );
-            sse_encode_String(inputPath, serializer);
-            sse_encode_String(outputPath, serializer);
-            sse_encode_StreamSink_f_64_Sse(progressSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 32,
-              port: port_,
-            );
+            var arg0 =
+                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                  cipher,
+                );
+            var arg1 = cst_encode_String(inputPath);
+            var arg2 = cst_encode_String(outputPath);
+            var arg3 = cst_encode_StreamSink_f_64_Dco(progressSink);
+            return wire
+                .wire__crate__api__streaming__stream_decrypt_decompress_file(
+                  port_,
+                  arg0,
+                  arg1,
+                  arg2,
+                  arg3,
+                );
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_crypto_error,
+          codec: DcoCodec(
+            decodeSuccessData: dco_decode_unit,
+            decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiStreamingStreamDecryptDecompressFileConstMeta,
           argValues: [cipher, inputPath, outputPath, progressSink],
@@ -1408,24 +1325,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-              cipher,
-              serializer,
-            );
-            sse_encode_String(inputPath, serializer);
-            sse_encode_String(outputPath, serializer);
-            sse_encode_StreamSink_f_64_Sse(progressSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 33,
-              port: port_,
+            var arg0 =
+                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                  cipher,
+                );
+            var arg1 = cst_encode_String(inputPath);
+            var arg2 = cst_encode_String(outputPath);
+            var arg3 = cst_encode_StreamSink_f_64_Dco(progressSink);
+            return wire.wire__crate__api__streaming__stream_decrypt_file(
+              port_,
+              arg0,
+              arg1,
+              arg2,
+              arg3,
             );
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_crypto_error,
+          codec: DcoCodec(
+            decodeSuccessData: dco_decode_unit,
+            decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiStreamingStreamDecryptFileConstMeta,
           argValues: [cipher, inputPath, outputPath, progressSink],
@@ -1453,24 +1370,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-              cipher,
-              serializer,
-            );
-            sse_encode_String(inputPath, serializer);
-            sse_encode_String(outputPath, serializer);
-            sse_encode_StreamSink_f_64_Sse(progressSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 34,
-              port: port_,
+            var arg0 =
+                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+                  cipher,
+                );
+            var arg1 = cst_encode_String(inputPath);
+            var arg2 = cst_encode_String(outputPath);
+            var arg3 = cst_encode_StreamSink_f_64_Dco(progressSink);
+            return wire.wire__crate__api__streaming__stream_encrypt_file(
+              port_,
+              arg0,
+              arg1,
+              arg2,
+              arg3,
             );
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_crypto_error,
+          codec: DcoCodec(
+            decodeSuccessData: dco_decode_unit,
+            decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiStreamingStreamEncryptFileConstMeta,
           argValues: [cipher, inputPath, outputPath, progressSink],
@@ -1497,23 +1414,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
-              hasher,
-              serializer,
-            );
-            sse_encode_String(filePath, serializer);
-            sse_encode_StreamSink_f_64_Sse(progressSink, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 35,
-              port: port_,
+            var arg0 =
+                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+                  hasher,
+                );
+            var arg1 = cst_encode_String(filePath);
+            var arg2 = cst_encode_StreamSink_f_64_Dco(progressSink);
+            return wire.wire__crate__api__streaming__stream_hash_file(
+              port_,
+              arg0,
+              arg1,
+              arg2,
             );
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_crypto_error,
+          codec: DcoCodec(
+            decodeSuccessData: dco_decode_unit,
+            decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiStreamingStreamHashFileConstMeta,
           argValues: [hasher, filePath, progressSink],
@@ -1537,20 +1453,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 36,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          return wire.wire__crate__api__evfs__vault_capacity(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_vault_capacity_info,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_vault_capacity_info,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiEvfsVaultCapacityConstMeta,
@@ -1568,21 +1478,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 37,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          return wire.wire__crate__api__evfs__vault_close(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultCloseConstMeta,
         argValues: [handle],
@@ -1604,22 +1508,22 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(path, serializer);
-          sse_encode_list_prim_u_8_loose(key, serializer);
-          sse_encode_String(algorithm, serializer);
-          sse_encode_u_64(capacityBytes, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 38,
-            port: port_,
+          var arg0 = cst_encode_String(path);
+          var arg1 = cst_encode_list_prim_u_8_loose(key);
+          var arg2 = cst_encode_String(algorithm);
+          var arg3 = cst_encode_u_64(capacityBytes);
+          return wire.wire__crate__api__evfs__vault_create(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
           );
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
-          decodeErrorData: sse_decode_crypto_error,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultCreateConstMeta,
         argValues: [path, key, algorithm, capacityBytes],
@@ -1640,21 +1544,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 39,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          return wire.wire__crate__api__evfs__vault_defragment(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_defrag_result,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_defrag_result,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultDefragmentConstMeta,
         argValues: [handle],
@@ -1674,22 +1572,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_String(name, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 40,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_String(name);
+          return wire.wire__crate__api__evfs__vault_delete(port_, arg0, arg1);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultDeleteConstMeta,
         argValues: [handle, name],
@@ -1710,20 +1602,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 41,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          return wire.wire__crate__api__evfs__vault_health(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_vault_health_info,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_vault_health_info,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiEvfsVaultHealthConstMeta,
@@ -1741,20 +1627,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 42,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          return wire.wire__crate__api__evfs__vault_list(port_, arg0);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_String,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_String,
           decodeErrorData: null,
         ),
         constMeta: kCrateApiEvfsVaultListConstMeta,
@@ -1775,20 +1655,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_String(path, serializer);
-          sse_encode_list_prim_u_8_loose(key, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 43,
-            port: port_,
-          );
+          var arg0 = cst_encode_String(path);
+          var arg1 = cst_encode_list_prim_u_8_loose(key);
+          return wire.wire__crate__api__evfs__vault_open(port_, arg0, arg1);
         },
-        codec: SseCodec(
+        codec: DcoCodec(
           decodeSuccessData:
-              sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
-          decodeErrorData: sse_decode_crypto_error,
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultOpenConstMeta,
         argValues: [path, key],
@@ -1808,22 +1682,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_String(name, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 44,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_String(name);
+          return wire.wire__crate__api__evfs__vault_read(port_, arg0, arg1);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultReadConstMeta,
         argValues: [handle, name],
@@ -1848,25 +1716,26 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_String(name, serializer);
-          sse_encode_bool(verifyChecksum, serializer);
-          sse_encode_StreamSink_list_prim_u_8_strict_Sse(sink, serializer);
-          sse_encode_StreamSink_f_64_Sse(onProgress, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 45,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_String(name);
+          var arg2 = cst_encode_bool(verifyChecksum);
+          var arg3 = cst_encode_StreamSink_list_prim_u_8_strict_Dco(sink);
+          var arg4 = cst_encode_StreamSink_f_64_Dco(onProgress);
+          return wire.wire__crate__api__evfs__vault_read_stream(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
+            arg4,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultReadStreamConstMeta,
         argValues: [handle, name, verifyChecksum, sink, onProgress],
@@ -1889,22 +1758,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_u_64(newCapacity, serializer);
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 46,
-            port: port_,
-          );
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_u_64(newCapacity);
+          return wire.wire__crate__api__evfs__vault_resize(port_, arg0, arg1);
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultResizeConstMeta,
         argValues: [handle, newCapacity],
@@ -1928,27 +1791,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
-          final serializer = SseSerializer(generalizedFrbRustBinding);
-          sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-            handle,
-            serializer,
-          );
-          sse_encode_String(name, serializer);
-          sse_encode_list_prim_u_8_loose(data, serializer);
-          sse_encode_opt_box_autoadd_compression_config(
-            compression,
-            serializer,
-          );
-          pdeCallFfi(
-            generalizedFrbRustBinding,
-            serializer,
-            funcId: 47,
-            port: port_,
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_String(name);
+          var arg2 = cst_encode_list_prim_u_8_loose(data);
+          var arg3 = cst_encode_opt_box_autoadd_compression_config(compression);
+          return wire.wire__crate__api__evfs__vault_write(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
           );
         },
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_unit,
-          decodeErrorData: sse_decode_crypto_error,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultWriteConstMeta,
         argValues: [handle, name, data, compression],
@@ -1973,24 +1833,24 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       handler.executeNormal(
         NormalTask(
           callFfi: (port_) {
-            final serializer = SseSerializer(generalizedFrbRustBinding);
-            sse_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-              handle,
-              serializer,
-            );
-            sse_encode_String(name, serializer);
-            sse_encode_String(filePath, serializer);
-            sse_encode_StreamSink_f_64_Sse(onProgress, serializer);
-            pdeCallFfi(
-              generalizedFrbRustBinding,
-              serializer,
-              funcId: 48,
-              port: port_,
+            var arg0 =
+                cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                  handle,
+                );
+            var arg1 = cst_encode_String(name);
+            var arg2 = cst_encode_String(filePath);
+            var arg3 = cst_encode_StreamSink_f_64_Dco(onProgress);
+            return wire.wire__crate__api__evfs__vault_write_file(
+              port_,
+              arg0,
+              arg1,
+              arg2,
+              arg3,
             );
           },
-          codec: SseCodec(
-            decodeSuccessData: sse_decode_unit,
-            decodeErrorData: sse_decode_crypto_error,
+          codec: DcoCodec(
+            decodeSuccessData: dco_decode_unit,
+            decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiEvfsVaultWriteFileConstMeta,
           argValues: [handle, name, filePath, onProgress],
@@ -2127,13 +1987,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<double> dco_decode_StreamSink_f_64_Sse(dynamic raw) {
+  RustStreamSink<double> dco_decode_StreamSink_f_64_Dco(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     throw UnimplementedError();
   }
 
   @protected
-  RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Sse(
+  RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Dco(
     dynamic raw,
   ) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
@@ -2486,7 +2346,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<double> sse_decode_StreamSink_f_64_Sse(
+  RustStreamSink<double> sse_decode_StreamSink_f_64_Dco(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -2494,7 +2354,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Sse(
+  RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Dco(
     SseDeserializer deserializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
@@ -2771,6 +2631,154 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as CipherHandleImpl).frbInternalCstEncode(move: true);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as HasherHandleImpl).frbInternalCstEncode(move: true);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as VaultHandleImpl).frbInternalCstEncode(move: true);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as VaultHandleImpl).frbInternalCstEncode(move: false);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as CipherHandleImpl).frbInternalCstEncode(move: false);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as HasherHandleImpl).frbInternalCstEncode(move: false);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as VaultHandleImpl).frbInternalCstEncode(move: false);
+  }
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as CipherHandleImpl).frbInternalCstEncode();
+  }
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as HasherHandleImpl).frbInternalCstEncode();
+  }
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    // ignore: invalid_use_of_internal_member
+    return (raw as VaultHandleImpl).frbInternalCstEncode();
+  }
+
+  @protected
+  int cst_encode_argon_2_preset(Argon2Preset raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_32(raw.index);
+  }
+
+  @protected
+  bool cst_encode_bool(bool raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
+  int cst_encode_compression_algorithm(CompressionAlgorithm raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_32(raw.index);
+  }
+
+  @protected
+  double cst_encode_f_64(double raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
+  int cst_encode_i_32(int raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
+  int cst_encode_u_32(int raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
+  int cst_encode_u_8(int raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
+  void cst_encode_unit(void raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
   void sse_encode_AnyhowException(
     AnyhowException self,
     SseSerializer serializer,
@@ -2910,16 +2918,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_StreamSink_f_64_Sse(
+  void sse_encode_StreamSink_f_64_Dco(
     RustStreamSink<double> self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(
       self.setupAndSerialize(
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_f_64,
-          decodeErrorData: sse_decode_AnyhowException,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_f_64,
+          decodeErrorData: dco_decode_AnyhowException,
         ),
       ),
       serializer,
@@ -2927,16 +2935,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
-  void sse_encode_StreamSink_list_prim_u_8_strict_Sse(
+  void sse_encode_StreamSink_list_prim_u_8_strict_Dco(
     RustStreamSink<Uint8List> self,
     SseSerializer serializer,
   ) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_String(
       self.setupAndSerialize(
-        codec: SseCodec(
-          decodeSuccessData: sse_decode_list_prim_u_8_strict,
-          decodeErrorData: sse_decode_AnyhowException,
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_AnyhowException,
         ),
       ),
       serializer,

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -104,10 +104,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<double> dco_decode_StreamSink_f_64_Sse(dynamic raw);
+  RustStreamSink<double> dco_decode_StreamSink_f_64_Dco(dynamic raw);
 
   @protected
-  RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Sse(
+  RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Dco(
     dynamic raw,
   );
 
@@ -247,12 +247,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<double> sse_decode_StreamSink_f_64_Sse(
+  RustStreamSink<double> sse_decode_StreamSink_f_64_Dco(
     SseDeserializer deserializer,
   );
 
   @protected
-  RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Sse(
+  RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Dco(
     SseDeserializer deserializer,
   );
 
@@ -337,6 +337,356 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   VaultHealthInfo sse_decode_vault_health_info(SseDeserializer deserializer);
 
   @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_AnyhowException(
+    AnyhowException raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_StreamSink_f_64_Dco(
+    RustStreamSink<double> raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_String(
+      raw.setupAndSerialize(
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_f_64,
+          decodeErrorData: dco_decode_AnyhowException,
+        ),
+      ),
+    );
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict>
+  cst_encode_StreamSink_list_prim_u_8_strict_Dco(
+    RustStreamSink<Uint8List> raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_String(
+      raw.setupAndSerialize(
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_AnyhowException,
+        ),
+      ),
+    );
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_String(String raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_list_prim_u_8_strict(utf8.encoder.convert(raw));
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_compression_config>
+  cst_encode_box_autoadd_compression_config(CompressionConfig raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ptr = wire.cst_new_box_autoadd_compression_config();
+    cst_api_fill_to_wire_compression_config(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<ffi.Int32> cst_encode_box_autoadd_i_32(int raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return wire.cst_new_box_autoadd_i_32(cst_encode_i_32(raw));
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_String> cst_encode_list_String(List<String> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_String(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      ans.ref.ptr[i] = cst_encode_String(raw[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_loose> cst_encode_list_prim_u_8_loose(
+    List<int> raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_prim_u_8_loose(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_list_prim_u_8_strict(
+    Uint8List raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_prim_u_8_strict(raw.length);
+    ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_compression_config>
+  cst_encode_opt_box_autoadd_compression_config(CompressionConfig? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null
+        ? ffi.nullptr
+        : cst_encode_box_autoadd_compression_config(raw);
+  }
+
+  @protected
+  ffi.Pointer<ffi.Int32> cst_encode_opt_box_autoadd_i_32(int? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_box_autoadd_i_32(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict>
+  cst_encode_opt_list_prim_u_8_strict(Uint8List? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_list_prim_u_8_strict(raw);
+  }
+
+  @protected
+  int cst_encode_u_64(BigInt raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.toSigned(64).toInt();
+  }
+
+  @protected
+  int cst_encode_usize(BigInt raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.toSigned(64).toInt();
+  }
+
+  @protected
+  void cst_api_fill_to_wire_box_autoadd_compression_config(
+    CompressionConfig apiObj,
+    ffi.Pointer<wire_cst_compression_config> wireObj,
+  ) {
+    cst_api_fill_to_wire_compression_config(apiObj, wireObj.ref);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_compression_config(
+    CompressionConfig apiObj,
+    wire_cst_compression_config wireObj,
+  ) {
+    wireObj.algorithm = cst_encode_compression_algorithm(apiObj.algorithm);
+    wireObj.level = cst_encode_opt_box_autoadd_i_32(apiObj.level);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_crypto_error(
+    CryptoError apiObj,
+    wire_cst_crypto_error wireObj,
+  ) {
+    if (apiObj is CryptoError_InvalidKeyLength) {
+      var pre_expected = cst_encode_usize(apiObj.expected);
+      var pre_actual = cst_encode_usize(apiObj.actual);
+      wireObj.tag = 0;
+      wireObj.kind.InvalidKeyLength.expected = pre_expected;
+      wireObj.kind.InvalidKeyLength.actual = pre_actual;
+      return;
+    }
+    if (apiObj is CryptoError_InvalidNonce) {
+      wireObj.tag = 1;
+      return;
+    }
+    if (apiObj is CryptoError_EncryptionFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 2;
+      wireObj.kind.EncryptionFailed.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_DecryptionFailed) {
+      wireObj.tag = 3;
+      return;
+    }
+    if (apiObj is CryptoError_HashingFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 4;
+      wireObj.kind.HashingFailed.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_KdfFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 5;
+      wireObj.kind.KdfFailed.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_IoError) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 6;
+      wireObj.kind.IoError.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_InvalidParameter) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 7;
+      wireObj.kind.InvalidParameter.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_CompressionFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 8;
+      wireObj.kind.CompressionFailed.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_AuthenticationFailed) {
+      wireObj.tag = 9;
+      return;
+    }
+    if (apiObj is CryptoError_VaultFull) {
+      var pre_needed = cst_encode_u_64(apiObj.needed);
+      var pre_available = cst_encode_u_64(apiObj.available);
+      wireObj.tag = 10;
+      wireObj.kind.VaultFull.needed = pre_needed;
+      wireObj.kind.VaultFull.available = pre_available;
+      return;
+    }
+    if (apiObj is CryptoError_VaultLocked) {
+      wireObj.tag = 11;
+      return;
+    }
+    if (apiObj is CryptoError_SegmentNotFound) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 12;
+      wireObj.kind.SegmentNotFound.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_VaultCorrupted) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 13;
+      wireObj.kind.VaultCorrupted.field0 = pre_field0;
+      return;
+    }
+  }
+
+  @protected
+  void cst_api_fill_to_wire_defrag_result(
+    DefragResult apiObj,
+    wire_cst_defrag_result wireObj,
+  ) {
+    wireObj.segments_moved = cst_encode_u_32(apiObj.segmentsMoved);
+    wireObj.bytes_reclaimed = cst_encode_u_64(apiObj.bytesReclaimed);
+    wireObj.free_regions_before = cst_encode_u_32(apiObj.freeRegionsBefore);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_vault_capacity_info(
+    VaultCapacityInfo apiObj,
+    wire_cst_vault_capacity_info wireObj,
+  ) {
+    wireObj.total_bytes = cst_encode_u_64(apiObj.totalBytes);
+    wireObj.used_bytes = cst_encode_u_64(apiObj.usedBytes);
+    wireObj.free_list_bytes = cst_encode_u_64(apiObj.freeListBytes);
+    wireObj.unallocated_bytes = cst_encode_u_64(apiObj.unallocatedBytes);
+    wireObj.segment_count = cst_encode_usize(apiObj.segmentCount);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_vault_health_info(
+    VaultHealthInfo apiObj,
+    wire_cst_vault_health_info wireObj,
+  ) {
+    wireObj.total_bytes = cst_encode_u_64(apiObj.totalBytes);
+    wireObj.used_bytes = cst_encode_u_64(apiObj.usedBytes);
+    wireObj.free_list_bytes = cst_encode_u_64(apiObj.freeListBytes);
+    wireObj.unallocated_bytes = cst_encode_u_64(apiObj.unallocatedBytes);
+    wireObj.segment_count = cst_encode_u_32(apiObj.segmentCount);
+    wireObj.free_region_count = cst_encode_u_32(apiObj.freeRegionCount);
+    wireObj.largest_free_block = cst_encode_u_64(apiObj.largestFreeBlock);
+    wireObj.fragmentation_ratio = cst_encode_f_64(apiObj.fragmentationRatio);
+    wireObj.is_consistent = cst_encode_bool(apiObj.isConsistent);
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int cst_encode_argon_2_preset(Argon2Preset raw);
+
+  @protected
+  bool cst_encode_bool(bool raw);
+
+  @protected
+  int cst_encode_compression_algorithm(CompressionAlgorithm raw);
+
+  @protected
+  double cst_encode_f_64(double raw);
+
+  @protected
+  int cst_encode_i_32(int raw);
+
+  @protected
+  int cst_encode_u_32(int raw);
+
+  @protected
+  int cst_encode_u_8(int raw);
+
+  @protected
+  void cst_encode_unit(void raw);
+
+  @protected
   void sse_encode_AnyhowException(
     AnyhowException self,
     SseSerializer serializer,
@@ -413,13 +763,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_StreamSink_f_64_Sse(
+  void sse_encode_StreamSink_f_64_Dco(
     RustStreamSink<double> self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_StreamSink_list_prim_u_8_strict_Sse(
+  void sse_encode_StreamSink_list_prim_u_8_strict_Dco(
     RustStreamSink<Uint8List> self,
     SseSerializer serializer,
   );
@@ -523,6 +873,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
 // Section: wire_class
 
+// ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names
+// AUTO GENERATED FILE, DO NOT EDIT.
+//
+// Generated by `package:ffigen`.
+// ignore_for_file: type=lint, unused_import
+
+/// generated by flutter_rust_bridge
 class RustLibWire implements BaseWire {
   factory RustLibWire.fromExternalLibrary(ExternalLibrary lib) =>
       RustLibWire(lib.ffiDynamicLibrary);
@@ -534,6 +891,1190 @@ class RustLibWire implements BaseWire {
   /// The symbols are looked up in [dynamicLibrary].
   RustLibWire(ffi.DynamicLibrary dynamicLibrary)
     : _lookup = dynamicLibrary.lookup;
+
+  /// The symbols are looked up with [lookup].
+  RustLibWire.fromLookup(
+    ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) lookup,
+  ) : _lookup = lookup;
+
+  void store_dart_post_cobject(DartPostCObjectFnType ptr) {
+    return _store_dart_post_cobject(ptr);
+  }
+
+  late final _store_dart_post_cobjectPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
+        'store_dart_post_cobject',
+      );
+  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
+      .asFunction<void Function(DartPostCObjectFnType)>();
+
+  void wire__crate__api__evfs__types__VaultHandle_health(int port_, int that) {
+    return _wire__crate__api__evfs__types__VaultHandle_health(port_, that);
+  }
+
+  late final _wire__crate__api__evfs__types__VaultHandle_healthPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__types__VaultHandle_health',
+      );
+  late final _wire__crate__api__evfs__types__VaultHandle_health =
+      _wire__crate__api__evfs__types__VaultHandle_healthPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__hashing__argon2__argon2id_hash(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> password,
+    int preset,
+  ) {
+    return _wire__crate__api__hashing__argon2__argon2id_hash(
+      port_,
+      password,
+      preset,
+    );
+  }
+
+  late final _wire__crate__api__hashing__argon2__argon2id_hashPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Int32,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__hashing__argon2__argon2id_hash');
+  late final _wire__crate__api__hashing__argon2__argon2id_hash =
+      _wire__crate__api__hashing__argon2__argon2id_hashPtr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>, int)
+          >();
+
+  void wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> password,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> salt,
+    int preset,
+  ) {
+    return _wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+      port_,
+      password,
+      salt,
+      preset,
+    );
+  }
+
+  late final _wire__crate__api__hashing__argon2__argon2id_hash_with_saltPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Int32,
+          )
+        >
+      >(
+        'frbgen_m_security_wire__crate__api__hashing__argon2__argon2id_hash_with_salt',
+      );
+  late final _wire__crate__api__hashing__argon2__argon2id_hash_with_salt =
+      _wire__crate__api__hashing__argon2__argon2id_hash_with_saltPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              int,
+            )
+          >();
+
+  void wire__crate__api__hashing__argon2__argon2id_verify(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> phc_hash,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> password,
+  ) {
+    return _wire__crate__api__hashing__argon2__argon2id_verify(
+      port_,
+      phc_hash,
+      password,
+    );
+  }
+
+  late final _wire__crate__api__hashing__argon2__argon2id_verifyPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__hashing__argon2__argon2id_verify');
+  late final _wire__crate__api__hashing__argon2__argon2id_verify =
+      _wire__crate__api__hashing__argon2__argon2id_verifyPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__hashing__blake3_hash(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
+  ) {
+    return _wire__crate__api__hashing__blake3_hash(port_, data);
+  }
+
+  late final _wire__crate__api__hashing__blake3_hashPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__hashing__blake3_hash');
+  late final _wire__crate__api__hashing__blake3_hash =
+      _wire__crate__api__hashing__blake3_hashPtr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_loose>)
+          >();
+
+  void wire__crate__api__compression__compress(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
+    ffi.Pointer<wire_cst_compression_config> config,
+  ) {
+    return _wire__crate__api__compression__compress(port_, data, config);
+  }
+
+  late final _wire__crate__api__compression__compressPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_compression_config>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__compression__compress');
+  late final _wire__crate__api__compression__compress =
+      _wire__crate__api__compression__compressPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_compression_config>,
+            )
+          >();
+
+  void wire__crate__api__compression__compression_algorithm_from_u8(
+    int port_,
+    int byte,
+  ) {
+    return _wire__crate__api__compression__compression_algorithm_from_u8(
+      port_,
+      byte,
+    );
+  }
+
+  late final _wire__crate__api__compression__compression_algorithm_from_u8Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Uint8)>>(
+        'frbgen_m_security_wire__crate__api__compression__compression_algorithm_from_u8',
+      );
+  late final _wire__crate__api__compression__compression_algorithm_from_u8 =
+      _wire__crate__api__compression__compression_algorithm_from_u8Ptr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__compression__compression_algorithm_to_u8(
+    int port_,
+    int that,
+  ) {
+    return _wire__crate__api__compression__compression_algorithm_to_u8(
+      port_,
+      that,
+    );
+  }
+
+  late final _wire__crate__api__compression__compression_algorithm_to_u8Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Int32)>>(
+        'frbgen_m_security_wire__crate__api__compression__compression_algorithm_to_u8',
+      );
+  late final _wire__crate__api__compression__compression_algorithm_to_u8 =
+      _wire__crate__api__compression__compression_algorithm_to_u8Ptr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__encryption__create_aes256_gcm(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> key,
+  ) {
+    return _wire__crate__api__encryption__create_aes256_gcm(port_, key);
+  }
+
+  late final _wire__crate__api__encryption__create_aes256_gcmPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__encryption__create_aes256_gcm');
+  late final _wire__crate__api__encryption__create_aes256_gcm =
+      _wire__crate__api__encryption__create_aes256_gcmPtr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_loose>)
+          >();
+
+  void wire__crate__api__hashing__create_blake3(int port_) {
+    return _wire__crate__api__hashing__create_blake3(port_);
+  }
+
+  late final _wire__crate__api__hashing__create_blake3Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__hashing__create_blake3',
+      );
+  late final _wire__crate__api__hashing__create_blake3 =
+      _wire__crate__api__hashing__create_blake3Ptr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__encryption__create_chacha20_poly1305(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> key,
+  ) {
+    return _wire__crate__api__encryption__create_chacha20_poly1305(port_, key);
+  }
+
+  late final _wire__crate__api__encryption__create_chacha20_poly1305Ptr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >(
+        'frbgen_m_security_wire__crate__api__encryption__create_chacha20_poly1305',
+      );
+  late final _wire__crate__api__encryption__create_chacha20_poly1305 =
+      _wire__crate__api__encryption__create_chacha20_poly1305Ptr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_loose>)
+          >();
+
+  void wire__crate__api__encryption__create_noop_encryption(int port_) {
+    return _wire__crate__api__encryption__create_noop_encryption(port_);
+  }
+
+  late final _wire__crate__api__encryption__create_noop_encryptionPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__encryption__create_noop_encryption',
+      );
+  late final _wire__crate__api__encryption__create_noop_encryption =
+      _wire__crate__api__encryption__create_noop_encryptionPtr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__hashing__create_sha3(int port_) {
+    return _wire__crate__api__hashing__create_sha3(port_);
+  }
+
+  late final _wire__crate__api__hashing__create_sha3Ptr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__hashing__create_sha3',
+      );
+  late final _wire__crate__api__hashing__create_sha3 =
+      _wire__crate__api__hashing__create_sha3Ptr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__compression__decompress(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
+    int algorithm,
+  ) {
+    return _wire__crate__api__compression__decompress(port_, data, algorithm);
+  }
+
+  late final _wire__crate__api__compression__decompressPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Int32,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__compression__decompress');
+  late final _wire__crate__api__compression__decompress =
+      _wire__crate__api__compression__decompressPtr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_loose>, int)
+          >();
+
+  void wire__crate__api__encryption__decrypt(
+    int port_,
+    int cipher,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> ciphertext,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> aad,
+  ) {
+    return _wire__crate__api__encryption__decrypt(
+      port_,
+      cipher,
+      ciphertext,
+      aad,
+    );
+  }
+
+  late final _wire__crate__api__encryption__decryptPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__encryption__decrypt');
+  late final _wire__crate__api__encryption__decrypt =
+      _wire__crate__api__encryption__decryptPtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            )
+          >();
+
+  void wire__crate__api__encryption__encrypt(
+    int port_,
+    int cipher,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> plaintext,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> aad,
+  ) {
+    return _wire__crate__api__encryption__encrypt(
+      port_,
+      cipher,
+      plaintext,
+      aad,
+    );
+  }
+
+  late final _wire__crate__api__encryption__encryptPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__encryption__encrypt');
+  late final _wire__crate__api__encryption__encrypt =
+      _wire__crate__api__encryption__encryptPtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            )
+          >();
+
+  void wire__crate__api__encryption__encryption_algorithm_id(
+    int port_,
+    int cipher,
+  ) {
+    return _wire__crate__api__encryption__encryption_algorithm_id(
+      port_,
+      cipher,
+    );
+  }
+
+  late final _wire__crate__api__encryption__encryption_algorithm_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__encryption__encryption_algorithm_id',
+      );
+  late final _wire__crate__api__encryption__encryption_algorithm_id =
+      _wire__crate__api__encryption__encryption_algorithm_idPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__encryption__generate_aes256_gcm_key(int port_) {
+    return _wire__crate__api__encryption__generate_aes256_gcm_key(port_);
+  }
+
+  late final _wire__crate__api__encryption__generate_aes256_gcm_keyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__encryption__generate_aes256_gcm_key',
+      );
+  late final _wire__crate__api__encryption__generate_aes256_gcm_key =
+      _wire__crate__api__encryption__generate_aes256_gcm_keyPtr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__encryption__aes_gcm__generate_aes_key(int port_) {
+    return _wire__crate__api__encryption__aes_gcm__generate_aes_key(port_);
+  }
+
+  late final _wire__crate__api__encryption__aes_gcm__generate_aes_keyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__encryption__aes_gcm__generate_aes_key',
+      );
+  late final _wire__crate__api__encryption__aes_gcm__generate_aes_key =
+      _wire__crate__api__encryption__aes_gcm__generate_aes_keyPtr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__encryption__generate_chacha20_poly1305_key(int port_) {
+    return _wire__crate__api__encryption__generate_chacha20_poly1305_key(port_);
+  }
+
+  late final _wire__crate__api__encryption__generate_chacha20_poly1305_keyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__encryption__generate_chacha20_poly1305_key',
+      );
+  late final _wire__crate__api__encryption__generate_chacha20_poly1305_key =
+      _wire__crate__api__encryption__generate_chacha20_poly1305_keyPtr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__encryption__chacha20__generate_chacha_key(int port_) {
+    return _wire__crate__api__encryption__chacha20__generate_chacha_key(port_);
+  }
+
+  late final _wire__crate__api__encryption__chacha20__generate_chacha_keyPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+        'frbgen_m_security_wire__crate__api__encryption__chacha20__generate_chacha_key',
+      );
+  late final _wire__crate__api__encryption__chacha20__generate_chacha_key =
+      _wire__crate__api__encryption__chacha20__generate_chacha_keyPtr
+          .asFunction<void Function(int)>();
+
+  void wire__crate__api__hashing__hasher_algorithm_id(int port_, int handle) {
+    return _wire__crate__api__hashing__hasher_algorithm_id(port_, handle);
+  }
+
+  late final _wire__crate__api__hashing__hasher_algorithm_idPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__hashing__hasher_algorithm_id',
+      );
+  late final _wire__crate__api__hashing__hasher_algorithm_id =
+      _wire__crate__api__hashing__hasher_algorithm_idPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__hashing__hasher_finalize(int port_, int handle) {
+    return _wire__crate__api__hashing__hasher_finalize(port_, handle);
+  }
+
+  late final _wire__crate__api__hashing__hasher_finalizePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__hashing__hasher_finalize',
+      );
+  late final _wire__crate__api__hashing__hasher_finalize =
+      _wire__crate__api__hashing__hasher_finalizePtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__hashing__hasher_reset(int port_, int handle) {
+    return _wire__crate__api__hashing__hasher_reset(port_, handle);
+  }
+
+  late final _wire__crate__api__hashing__hasher_resetPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__hashing__hasher_reset',
+      );
+  late final _wire__crate__api__hashing__hasher_reset =
+      _wire__crate__api__hashing__hasher_resetPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__hashing__hasher_update(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
+  ) {
+    return _wire__crate__api__hashing__hasher_update(port_, handle, data);
+  }
+
+  late final _wire__crate__api__hashing__hasher_updatePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__hashing__hasher_update');
+  late final _wire__crate__api__hashing__hasher_update =
+      _wire__crate__api__hashing__hasher_updatePtr
+          .asFunction<
+            void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_loose>)
+          >();
+
+  WireSyncRust2DartDco wire__crate__api__kdf__hkdf__hkdf_derive(
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> ikm,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> salt,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> info,
+    int output_len,
+  ) {
+    return _wire__crate__api__kdf__hkdf__hkdf_derive(
+      ikm,
+      salt,
+      info,
+      output_len,
+    );
+  }
+
+  late final _wire__crate__api__kdf__hkdf__hkdf_derivePtr =
+      _lookup<
+        ffi.NativeFunction<
+          WireSyncRust2DartDco Function(
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.UintPtr,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__kdf__hkdf__hkdf_derive');
+  late final _wire__crate__api__kdf__hkdf__hkdf_derive =
+      _wire__crate__api__kdf__hkdf__hkdf_derivePtr
+          .asFunction<
+            WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              int,
+            )
+          >();
+
+  void wire__crate__api__kdf__hkdf__hkdf_expand(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> prk,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> info,
+    int output_len,
+  ) {
+    return _wire__crate__api__kdf__hkdf__hkdf_expand(
+      port_,
+      prk,
+      info,
+      output_len,
+    );
+  }
+
+  late final _wire__crate__api__kdf__hkdf__hkdf_expandPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.UintPtr,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__kdf__hkdf__hkdf_expand');
+  late final _wire__crate__api__kdf__hkdf__hkdf_expand =
+      _wire__crate__api__kdf__hkdf__hkdf_expandPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              int,
+            )
+          >();
+
+  WireSyncRust2DartDco wire__crate__api__kdf__hkdf__hkdf_extract(
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> ikm,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> salt,
+  ) {
+    return _wire__crate__api__kdf__hkdf__hkdf_extract(ikm, salt);
+  }
+
+  late final _wire__crate__api__kdf__hkdf__hkdf_extractPtr =
+      _lookup<
+        ffi.NativeFunction<
+          WireSyncRust2DartDco Function(
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__kdf__hkdf__hkdf_extract');
+  late final _wire__crate__api__kdf__hkdf__hkdf_extract =
+      _wire__crate__api__kdf__hkdf__hkdf_extractPtr
+          .asFunction<
+            WireSyncRust2DartDco Function(
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__hashing__sha3_hash(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
+  ) {
+    return _wire__crate__api__hashing__sha3_hash(port_, data);
+  }
+
+  late final _wire__crate__api__hashing__sha3_hashPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__hashing__sha3_hash');
+  late final _wire__crate__api__hashing__sha3_hash =
+      _wire__crate__api__hashing__sha3_hashPtr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_loose>)
+          >();
+
+  void wire__crate__api__compression__should_skip_compression(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> file_path,
+  ) {
+    return _wire__crate__api__compression__should_skip_compression(
+      port_,
+      file_path,
+    );
+  }
+
+  late final _wire__crate__api__compression__should_skip_compressionPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >(
+        'frbgen_m_security_wire__crate__api__compression__should_skip_compression',
+      );
+  late final _wire__crate__api__compression__should_skip_compression =
+      _wire__crate__api__compression__should_skip_compressionPtr
+          .asFunction<
+            void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
+          >();
+
+  void wire__crate__api__streaming__stream_compress_encrypt_file(
+    int port_,
+    int cipher,
+    ffi.Pointer<wire_cst_compression_config> compression,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
+  ) {
+    return _wire__crate__api__streaming__stream_compress_encrypt_file(
+      port_,
+      cipher,
+      compression,
+      input_path,
+      output_path,
+      progress_sink,
+    );
+  }
+
+  late final _wire__crate__api__streaming__stream_compress_encrypt_filePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_compression_config>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >(
+        'frbgen_m_security_wire__crate__api__streaming__stream_compress_encrypt_file',
+      );
+  late final _wire__crate__api__streaming__stream_compress_encrypt_file =
+      _wire__crate__api__streaming__stream_compress_encrypt_filePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_compression_config>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__streaming__stream_decrypt_decompress_file(
+    int port_,
+    int cipher,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
+  ) {
+    return _wire__crate__api__streaming__stream_decrypt_decompress_file(
+      port_,
+      cipher,
+      input_path,
+      output_path,
+      progress_sink,
+    );
+  }
+
+  late final _wire__crate__api__streaming__stream_decrypt_decompress_filePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >(
+        'frbgen_m_security_wire__crate__api__streaming__stream_decrypt_decompress_file',
+      );
+  late final _wire__crate__api__streaming__stream_decrypt_decompress_file =
+      _wire__crate__api__streaming__stream_decrypt_decompress_filePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__streaming__stream_decrypt_file(
+    int port_,
+    int cipher,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
+  ) {
+    return _wire__crate__api__streaming__stream_decrypt_file(
+      port_,
+      cipher,
+      input_path,
+      output_path,
+      progress_sink,
+    );
+  }
+
+  late final _wire__crate__api__streaming__stream_decrypt_filePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__streaming__stream_decrypt_file');
+  late final _wire__crate__api__streaming__stream_decrypt_file =
+      _wire__crate__api__streaming__stream_decrypt_filePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__streaming__stream_encrypt_file(
+    int port_,
+    int cipher,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
+  ) {
+    return _wire__crate__api__streaming__stream_encrypt_file(
+      port_,
+      cipher,
+      input_path,
+      output_path,
+      progress_sink,
+    );
+  }
+
+  late final _wire__crate__api__streaming__stream_encrypt_filePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__streaming__stream_encrypt_file');
+  late final _wire__crate__api__streaming__stream_encrypt_file =
+      _wire__crate__api__streaming__stream_encrypt_filePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__streaming__stream_hash_file(
+    int port_,
+    int hasher,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> file_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
+  ) {
+    return _wire__crate__api__streaming__stream_hash_file(
+      port_,
+      hasher,
+      file_path,
+      progress_sink,
+    );
+  }
+
+  late final _wire__crate__api__streaming__stream_hash_filePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__streaming__stream_hash_file');
+  late final _wire__crate__api__streaming__stream_hash_file =
+      _wire__crate__api__streaming__stream_hash_filePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__evfs__vault_capacity(int port_, int handle) {
+    return _wire__crate__api__evfs__vault_capacity(port_, handle);
+  }
+
+  late final _wire__crate__api__evfs__vault_capacityPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__vault_capacity',
+      );
+  late final _wire__crate__api__evfs__vault_capacity =
+      _wire__crate__api__evfs__vault_capacityPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__evfs__vault_close(int port_, int handle) {
+    return _wire__crate__api__evfs__vault_close(port_, handle);
+  }
+
+  late final _wire__crate__api__evfs__vault_closePtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__vault_close',
+      );
+  late final _wire__crate__api__evfs__vault_close =
+      _wire__crate__api__evfs__vault_closePtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__evfs__vault_create(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> path,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> key,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> algorithm,
+    int capacity_bytes,
+  ) {
+    return _wire__crate__api__evfs__vault_create(
+      port_,
+      path,
+      key,
+      algorithm,
+      capacity_bytes,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_createPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Uint64,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_create');
+  late final _wire__crate__api__evfs__vault_create =
+      _wire__crate__api__evfs__vault_createPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              int,
+            )
+          >();
+
+  void wire__crate__api__evfs__vault_defragment(int port_, int handle) {
+    return _wire__crate__api__evfs__vault_defragment(port_, handle);
+  }
+
+  late final _wire__crate__api__evfs__vault_defragmentPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__vault_defragment',
+      );
+  late final _wire__crate__api__evfs__vault_defragment =
+      _wire__crate__api__evfs__vault_defragmentPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__evfs__vault_delete(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
+  ) {
+    return _wire__crate__api__evfs__vault_delete(port_, handle, name);
+  }
+
+  late final _wire__crate__api__evfs__vault_deletePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_delete');
+  late final _wire__crate__api__evfs__vault_delete =
+      _wire__crate__api__evfs__vault_deletePtr
+          .asFunction<
+            void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
+          >();
+
+  void wire__crate__api__evfs__vault_health(int port_, int handle) {
+    return _wire__crate__api__evfs__vault_health(port_, handle);
+  }
+
+  late final _wire__crate__api__evfs__vault_healthPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__vault_health',
+      );
+  late final _wire__crate__api__evfs__vault_health =
+      _wire__crate__api__evfs__vault_healthPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__evfs__vault_list(int port_, int handle) {
+    return _wire__crate__api__evfs__vault_list(port_, handle);
+  }
+
+  late final _wire__crate__api__evfs__vault_listPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__vault_list',
+      );
+  late final _wire__crate__api__evfs__vault_list =
+      _wire__crate__api__evfs__vault_listPtr
+          .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__evfs__vault_open(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> path,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> key,
+  ) {
+    return _wire__crate__api__evfs__vault_open(port_, path, key);
+  }
+
+  late final _wire__crate__api__evfs__vault_openPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_open');
+  late final _wire__crate__api__evfs__vault_open =
+      _wire__crate__api__evfs__vault_openPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            )
+          >();
+
+  void wire__crate__api__evfs__vault_read(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
+  ) {
+    return _wire__crate__api__evfs__vault_read(port_, handle, name);
+  }
+
+  late final _wire__crate__api__evfs__vault_readPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_read');
+  late final _wire__crate__api__evfs__vault_read =
+      _wire__crate__api__evfs__vault_readPtr
+          .asFunction<
+            void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
+          >();
+
+  void wire__crate__api__evfs__vault_read_stream(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
+    bool verify_checksum,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> sink,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> on_progress,
+  ) {
+    return _wire__crate__api__evfs__vault_read_stream(
+      port_,
+      handle,
+      name,
+      verify_checksum,
+      sink,
+      on_progress,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_read_streamPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Bool,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_read_stream');
+  late final _wire__crate__api__evfs__vault_read_stream =
+      _wire__crate__api__evfs__vault_read_streamPtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              bool,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__evfs__vault_resize(
+    int port_,
+    int handle,
+    int new_capacity,
+  ) {
+    return _wire__crate__api__evfs__vault_resize(port_, handle, new_capacity);
+  }
+
+  late final _wire__crate__api__evfs__vault_resizePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(ffi.Int64, ffi.UintPtr, ffi.Uint64)
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_resize');
+  late final _wire__crate__api__evfs__vault_resize =
+      _wire__crate__api__evfs__vault_resizePtr
+          .asFunction<void Function(int, int, int)>();
+
+  void wire__crate__api__evfs__vault_write(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
+    ffi.Pointer<wire_cst_compression_config> compression,
+  ) {
+    return _wire__crate__api__evfs__vault_write(
+      port_,
+      handle,
+      name,
+      data,
+      compression,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_writePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_compression_config>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_write');
+  late final _wire__crate__api__evfs__vault_write =
+      _wire__crate__api__evfs__vault_writePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_compression_config>,
+            )
+          >();
+
+  void wire__crate__api__evfs__vault_write_file(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> file_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> on_progress,
+  ) {
+    return _wire__crate__api__evfs__vault_write_file(
+      port_,
+      handle,
+      name,
+      file_path,
+      on_progress,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_write_filePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_write_file');
+  late final _wire__crate__api__evfs__vault_write_file =
+      _wire__crate__api__evfs__vault_write_filePtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
 
   void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
@@ -636,4 +2177,291 @@ class RustLibWire implements BaseWire {
   late final _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle =
       _rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandlePtr
           .asFunction<void Function(ffi.Pointer<ffi.Void>)>();
+
+  ffi.Pointer<wire_cst_compression_config>
+  cst_new_box_autoadd_compression_config() {
+    return _cst_new_box_autoadd_compression_config();
+  }
+
+  late final _cst_new_box_autoadd_compression_configPtr =
+      _lookup<
+        ffi.NativeFunction<ffi.Pointer<wire_cst_compression_config> Function()>
+      >('frbgen_m_security_cst_new_box_autoadd_compression_config');
+  late final _cst_new_box_autoadd_compression_config =
+      _cst_new_box_autoadd_compression_configPtr
+          .asFunction<ffi.Pointer<wire_cst_compression_config> Function()>();
+
+  ffi.Pointer<ffi.Int32> cst_new_box_autoadd_i_32(int value) {
+    return _cst_new_box_autoadd_i_32(value);
+  }
+
+  late final _cst_new_box_autoadd_i_32Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Int32> Function(ffi.Int32)>>(
+        'frbgen_m_security_cst_new_box_autoadd_i_32',
+      );
+  late final _cst_new_box_autoadd_i_32 = _cst_new_box_autoadd_i_32Ptr
+      .asFunction<ffi.Pointer<ffi.Int32> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_String> cst_new_list_String(int len) {
+    return _cst_new_list_String(len);
+  }
+
+  late final _cst_new_list_StringPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_String> Function(ffi.Int32)
+        >
+      >('frbgen_m_security_cst_new_list_String');
+  late final _cst_new_list_String = _cst_new_list_StringPtr
+      .asFunction<ffi.Pointer<wire_cst_list_String> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_prim_u_8_loose> cst_new_list_prim_u_8_loose(
+    int len,
+  ) {
+    return _cst_new_list_prim_u_8_loose(len);
+  }
+
+  late final _cst_new_list_prim_u_8_loosePtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_prim_u_8_loose> Function(ffi.Int32)
+        >
+      >('frbgen_m_security_cst_new_list_prim_u_8_loose');
+  late final _cst_new_list_prim_u_8_loose = _cst_new_list_prim_u_8_loosePtr
+      .asFunction<ffi.Pointer<wire_cst_list_prim_u_8_loose> Function(int)>();
+
+  ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_new_list_prim_u_8_strict(
+    int len,
+  ) {
+    return _cst_new_list_prim_u_8_strict(len);
+  }
+
+  late final _cst_new_list_prim_u_8_strictPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_prim_u_8_strict> Function(ffi.Int32)
+        >
+      >('frbgen_m_security_cst_new_list_prim_u_8_strict');
+  late final _cst_new_list_prim_u_8_strict = _cst_new_list_prim_u_8_strictPtr
+      .asFunction<ffi.Pointer<wire_cst_list_prim_u_8_strict> Function(int)>();
+
+  int dummy_method_to_enforce_bundling() {
+    return _dummy_method_to_enforce_bundling();
+  }
+
+  late final _dummy_method_to_enforce_bundlingPtr =
+      _lookup<ffi.NativeFunction<ffi.Int64 Function()>>(
+        'dummy_method_to_enforce_bundling',
+      );
+  late final _dummy_method_to_enforce_bundling =
+      _dummy_method_to_enforce_bundlingPtr.asFunction<int Function()>();
 }
+
+typedef DartPort = ffi.Int64;
+typedef DartDartPort = int;
+typedef DartPostCObjectFnTypeFunction =
+    ffi.Bool Function(DartPort port_id, ffi.Pointer<ffi.Void> message);
+typedef DartDartPostCObjectFnTypeFunction =
+    bool Function(DartDartPort port_id, ffi.Pointer<ffi.Void> message);
+typedef DartPostCObjectFnType =
+    ffi.Pointer<ffi.NativeFunction<DartPostCObjectFnTypeFunction>>;
+
+final class wire_cst_list_prim_u_8_strict extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint8> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_list_prim_u_8_loose extends ffi.Struct {
+  external ffi.Pointer<ffi.Uint8> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_compression_config extends ffi.Struct {
+  @ffi.Int32()
+  external int algorithm;
+
+  external ffi.Pointer<ffi.Int32> level;
+}
+
+final class wire_cst_list_String extends ffi.Struct {
+  external ffi.Pointer<ffi.Pointer<wire_cst_list_prim_u_8_strict>> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_CryptoError_InvalidKeyLength extends ffi.Struct {
+  @ffi.UintPtr()
+  external int expected;
+
+  @ffi.UintPtr()
+  external int actual;
+}
+
+final class wire_cst_CryptoError_EncryptionFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_HashingFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_KdfFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_IoError extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_InvalidParameter extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_CompressionFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_VaultFull extends ffi.Struct {
+  @ffi.Uint64()
+  external int needed;
+
+  @ffi.Uint64()
+  external int available;
+}
+
+final class wire_cst_CryptoError_SegmentNotFound extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_VaultCorrupted extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class CryptoErrorKind extends ffi.Union {
+  external wire_cst_CryptoError_InvalidKeyLength InvalidKeyLength;
+
+  external wire_cst_CryptoError_EncryptionFailed EncryptionFailed;
+
+  external wire_cst_CryptoError_HashingFailed HashingFailed;
+
+  external wire_cst_CryptoError_KdfFailed KdfFailed;
+
+  external wire_cst_CryptoError_IoError IoError;
+
+  external wire_cst_CryptoError_InvalidParameter InvalidParameter;
+
+  external wire_cst_CryptoError_CompressionFailed CompressionFailed;
+
+  external wire_cst_CryptoError_VaultFull VaultFull;
+
+  external wire_cst_CryptoError_SegmentNotFound SegmentNotFound;
+
+  external wire_cst_CryptoError_VaultCorrupted VaultCorrupted;
+}
+
+final class wire_cst_crypto_error extends ffi.Struct {
+  @ffi.Int32()
+  external int tag;
+
+  external CryptoErrorKind kind;
+}
+
+final class wire_cst_defrag_result extends ffi.Struct {
+  @ffi.Uint32()
+  external int segments_moved;
+
+  @ffi.Uint64()
+  external int bytes_reclaimed;
+
+  @ffi.Uint32()
+  external int free_regions_before;
+}
+
+final class wire_cst_vault_capacity_info extends ffi.Struct {
+  @ffi.Uint64()
+  external int total_bytes;
+
+  @ffi.Uint64()
+  external int used_bytes;
+
+  @ffi.Uint64()
+  external int free_list_bytes;
+
+  @ffi.Uint64()
+  external int unallocated_bytes;
+
+  @ffi.UintPtr()
+  external int segment_count;
+}
+
+final class wire_cst_vault_health_info extends ffi.Struct {
+  @ffi.Uint64()
+  external int total_bytes;
+
+  @ffi.Uint64()
+  external int used_bytes;
+
+  @ffi.Uint64()
+  external int free_list_bytes;
+
+  @ffi.Uint64()
+  external int unallocated_bytes;
+
+  @ffi.Uint32()
+  external int segment_count;
+
+  @ffi.Uint32()
+  external int free_region_count;
+
+  @ffi.Uint64()
+  external int largest_free_block;
+
+  @ffi.Double()
+  external double fragmentation_ratio;
+
+  @ffi.Bool()
+  external bool is_consistent;
+}
+
+const int DEFAULT_LEVEL = 3;
+
+const int MIN_LEVEL = 1;
+
+const int MAX_LEVEL = 22;
+
+const int VAULT_VERSION = 1;
+
+const int VAULT_HEADER_SIZE = 32;
+
+const int MAX_SEGMENT_NAME_LEN = 255;
+
+const int MIN_INDEX_PAD_SIZE = 65536;
+
+const int PRIMARY_INDEX_OFFSET = 32;
+
+const int MAX_INDEX_PAD_SIZE = 16777216;
+
+const int VAULT_CHUNK_AAD_SIZE = 17;
+
+const int FORMAT_VERSION = 1;
+
+const int HEADER_SIZE = 6;
+
+const int CHUNK_SIZE = 65536;
+
+const int NONCE_SIZE = 12;
+
+const int TAG_SIZE = 16;
+
+const int ENCRYPTED_CHUNK_SIZE = 65564;
+
+const int STREAM_VERSION = 1;
+
+const int STREAM_HEADER_SIZE = 16;
+
+const int AAD_SIZE = 9;

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -106,10 +106,10 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<double> dco_decode_StreamSink_f_64_Sse(dynamic raw);
+  RustStreamSink<double> dco_decode_StreamSink_f_64_Dco(dynamic raw);
 
   @protected
-  RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Sse(
+  RustStreamSink<Uint8List> dco_decode_StreamSink_list_prim_u_8_strict_Dco(
     dynamic raw,
   );
 
@@ -249,12 +249,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<double> sse_decode_StreamSink_f_64_Sse(
+  RustStreamSink<double> sse_decode_StreamSink_f_64_Dco(
     SseDeserializer deserializer,
   );
 
   @protected
-  RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Sse(
+  RustStreamSink<Uint8List> sse_decode_StreamSink_list_prim_u_8_strict_Dco(
     SseDeserializer deserializer,
   );
 
@@ -339,6 +339,294 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   VaultHealthInfo sse_decode_vault_health_info(SseDeserializer deserializer);
 
   @protected
+  String cst_encode_AnyhowException(AnyhowException raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    throw UnimplementedError();
+  }
+
+  @protected
+  String cst_encode_StreamSink_f_64_Dco(RustStreamSink<double> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_String(
+      raw.setupAndSerialize(
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_f_64,
+          decodeErrorData: dco_decode_AnyhowException,
+        ),
+      ),
+    );
+  }
+
+  @protected
+  String cst_encode_StreamSink_list_prim_u_8_strict_Dco(
+    RustStreamSink<Uint8List> raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_String(
+      raw.setupAndSerialize(
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeErrorData: dco_decode_AnyhowException,
+        ),
+      ),
+    );
+  }
+
+  @protected
+  String cst_encode_String(String raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw;
+  }
+
+  @protected
+  JSAny cst_encode_box_autoadd_compression_config(CompressionConfig raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_compression_config(raw);
+  }
+
+  @protected
+  int cst_encode_box_autoadd_i_32(int raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_32(raw);
+  }
+
+  @protected
+  JSAny cst_encode_compression_config(CompressionConfig raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_compression_algorithm(raw.algorithm),
+      cst_encode_opt_box_autoadd_i_32(raw.level),
+    ].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_crypto_error(CryptoError raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    if (raw is CryptoError_InvalidKeyLength) {
+      return [
+        0,
+        cst_encode_usize(raw.expected),
+        cst_encode_usize(raw.actual),
+      ].jsify()!;
+    }
+    if (raw is CryptoError_InvalidNonce) {
+      return [1].jsify()!;
+    }
+    if (raw is CryptoError_EncryptionFailed) {
+      return [2, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_DecryptionFailed) {
+      return [3].jsify()!;
+    }
+    if (raw is CryptoError_HashingFailed) {
+      return [4, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_KdfFailed) {
+      return [5, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_IoError) {
+      return [6, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_InvalidParameter) {
+      return [7, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_CompressionFailed) {
+      return [8, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_AuthenticationFailed) {
+      return [9].jsify()!;
+    }
+    if (raw is CryptoError_VaultFull) {
+      return [
+        10,
+        cst_encode_u_64(raw.needed),
+        cst_encode_u_64(raw.available),
+      ].jsify()!;
+    }
+    if (raw is CryptoError_VaultLocked) {
+      return [11].jsify()!;
+    }
+    if (raw is CryptoError_SegmentNotFound) {
+      return [12, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_VaultCorrupted) {
+      return [13, cst_encode_String(raw.field0)].jsify()!;
+    }
+
+    throw Exception('unreachable');
+  }
+
+  @protected
+  JSAny cst_encode_defrag_result(DefragResult raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_u_32(raw.segmentsMoved),
+      cst_encode_u_64(raw.bytesReclaimed),
+      cst_encode_u_32(raw.freeRegionsBefore),
+    ].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_list_String(List<String> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.map(cst_encode_String).toList().jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_list_prim_u_8_loose(List<int> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_list_prim_u_8_strict(Uint8List raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.jsify()!;
+  }
+
+  @protected
+  JSAny? cst_encode_opt_box_autoadd_compression_config(CompressionConfig? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_box_autoadd_compression_config(raw);
+  }
+
+  @protected
+  int? cst_encode_opt_box_autoadd_i_32(int? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_box_autoadd_i_32(raw);
+  }
+
+  @protected
+  JSAny? cst_encode_opt_list_prim_u_8_strict(Uint8List? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_list_prim_u_8_strict(raw);
+  }
+
+  @protected
+  JSAny cst_encode_u_64(BigInt raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return castNativeBigInt(raw);
+  }
+
+  @protected
+  JSAny cst_encode_usize(BigInt raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return castNativeBigInt(raw);
+  }
+
+  @protected
+  JSAny cst_encode_vault_capacity_info(VaultCapacityInfo raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_u_64(raw.totalBytes),
+      cst_encode_u_64(raw.usedBytes),
+      cst_encode_u_64(raw.freeListBytes),
+      cst_encode_u_64(raw.unallocatedBytes),
+      cst_encode_usize(raw.segmentCount),
+    ].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_vault_health_info(VaultHealthInfo raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_u_64(raw.totalBytes),
+      cst_encode_u_64(raw.usedBytes),
+      cst_encode_u_64(raw.freeListBytes),
+      cst_encode_u_64(raw.unallocatedBytes),
+      cst_encode_u_32(raw.segmentCount),
+      cst_encode_u_32(raw.freeRegionCount),
+      cst_encode_u_64(raw.largestFreeBlock),
+      cst_encode_f_64(raw.fragmentationRatio),
+      cst_encode_bool(raw.isConsistent),
+    ].jsify()!;
+  }
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
+    CipherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
+    HasherHandle raw,
+  );
+
+  @protected
+  int
+  cst_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    VaultHandle raw,
+  );
+
+  @protected
+  int cst_encode_argon_2_preset(Argon2Preset raw);
+
+  @protected
+  bool cst_encode_bool(bool raw);
+
+  @protected
+  int cst_encode_compression_algorithm(CompressionAlgorithm raw);
+
+  @protected
+  double cst_encode_f_64(double raw);
+
+  @protected
+  int cst_encode_i_32(int raw);
+
+  @protected
+  int cst_encode_u_32(int raw);
+
+  @protected
+  int cst_encode_u_8(int raw);
+
+  @protected
+  void cst_encode_unit(void raw);
+
+  @protected
   void sse_encode_AnyhowException(
     AnyhowException self,
     SseSerializer serializer,
@@ -415,13 +703,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void sse_encode_StreamSink_f_64_Sse(
+  void sse_encode_StreamSink_f_64_Dco(
     RustStreamSink<double> self,
     SseSerializer serializer,
   );
 
   @protected
-  void sse_encode_StreamSink_list_prim_u_8_strict_Sse(
+  void sse_encode_StreamSink_list_prim_u_8_strict_Dco(
     RustStreamSink<Uint8List> self,
     SseSerializer serializer,
   );
@@ -528,6 +816,393 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 class RustLibWire implements BaseWire {
   RustLibWire.fromExternalLibrary(ExternalLibrary lib);
 
+  void wire__crate__api__evfs__types__VaultHandle_health(
+    NativePortType port_,
+    int that,
+  ) =>
+      wasmModule.wire__crate__api__evfs__types__VaultHandle_health(port_, that);
+
+  void wire__crate__api__hashing__argon2__argon2id_hash(
+    NativePortType port_,
+    String password,
+    int preset,
+  ) => wasmModule.wire__crate__api__hashing__argon2__argon2id_hash(
+    port_,
+    password,
+    preset,
+  );
+
+  void wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+    NativePortType port_,
+    String password,
+    String salt,
+    int preset,
+  ) => wasmModule.wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+    port_,
+    password,
+    salt,
+    preset,
+  );
+
+  void wire__crate__api__hashing__argon2__argon2id_verify(
+    NativePortType port_,
+    String phc_hash,
+    String password,
+  ) => wasmModule.wire__crate__api__hashing__argon2__argon2id_verify(
+    port_,
+    phc_hash,
+    password,
+  );
+
+  void wire__crate__api__hashing__blake3_hash(
+    NativePortType port_,
+    JSAny data,
+  ) => wasmModule.wire__crate__api__hashing__blake3_hash(port_, data);
+
+  void wire__crate__api__compression__compress(
+    NativePortType port_,
+    JSAny data,
+    JSAny config,
+  ) => wasmModule.wire__crate__api__compression__compress(port_, data, config);
+
+  void wire__crate__api__compression__compression_algorithm_from_u8(
+    NativePortType port_,
+    int byte,
+  ) => wasmModule.wire__crate__api__compression__compression_algorithm_from_u8(
+    port_,
+    byte,
+  );
+
+  void wire__crate__api__compression__compression_algorithm_to_u8(
+    NativePortType port_,
+    int that,
+  ) => wasmModule.wire__crate__api__compression__compression_algorithm_to_u8(
+    port_,
+    that,
+  );
+
+  void wire__crate__api__encryption__create_aes256_gcm(
+    NativePortType port_,
+    JSAny key,
+  ) => wasmModule.wire__crate__api__encryption__create_aes256_gcm(port_, key);
+
+  void wire__crate__api__hashing__create_blake3(NativePortType port_) =>
+      wasmModule.wire__crate__api__hashing__create_blake3(port_);
+
+  void wire__crate__api__encryption__create_chacha20_poly1305(
+    NativePortType port_,
+    JSAny key,
+  ) => wasmModule.wire__crate__api__encryption__create_chacha20_poly1305(
+    port_,
+    key,
+  );
+
+  void wire__crate__api__encryption__create_noop_encryption(
+    NativePortType port_,
+  ) => wasmModule.wire__crate__api__encryption__create_noop_encryption(port_);
+
+  void wire__crate__api__hashing__create_sha3(NativePortType port_) =>
+      wasmModule.wire__crate__api__hashing__create_sha3(port_);
+
+  void wire__crate__api__compression__decompress(
+    NativePortType port_,
+    JSAny data,
+    int algorithm,
+  ) => wasmModule.wire__crate__api__compression__decompress(
+    port_,
+    data,
+    algorithm,
+  );
+
+  void wire__crate__api__encryption__decrypt(
+    NativePortType port_,
+    int cipher,
+    JSAny ciphertext,
+    JSAny aad,
+  ) => wasmModule.wire__crate__api__encryption__decrypt(
+    port_,
+    cipher,
+    ciphertext,
+    aad,
+  );
+
+  void wire__crate__api__encryption__encrypt(
+    NativePortType port_,
+    int cipher,
+    JSAny plaintext,
+    JSAny aad,
+  ) => wasmModule.wire__crate__api__encryption__encrypt(
+    port_,
+    cipher,
+    plaintext,
+    aad,
+  );
+
+  void wire__crate__api__encryption__encryption_algorithm_id(
+    NativePortType port_,
+    int cipher,
+  ) => wasmModule.wire__crate__api__encryption__encryption_algorithm_id(
+    port_,
+    cipher,
+  );
+
+  void wire__crate__api__encryption__generate_aes256_gcm_key(
+    NativePortType port_,
+  ) => wasmModule.wire__crate__api__encryption__generate_aes256_gcm_key(port_);
+
+  void wire__crate__api__encryption__aes_gcm__generate_aes_key(
+    NativePortType port_,
+  ) =>
+      wasmModule.wire__crate__api__encryption__aes_gcm__generate_aes_key(port_);
+
+  void wire__crate__api__encryption__generate_chacha20_poly1305_key(
+    NativePortType port_,
+  ) => wasmModule.wire__crate__api__encryption__generate_chacha20_poly1305_key(
+    port_,
+  );
+
+  void wire__crate__api__encryption__chacha20__generate_chacha_key(
+    NativePortType port_,
+  ) => wasmModule.wire__crate__api__encryption__chacha20__generate_chacha_key(
+    port_,
+  );
+
+  void wire__crate__api__hashing__hasher_algorithm_id(
+    NativePortType port_,
+    int handle,
+  ) => wasmModule.wire__crate__api__hashing__hasher_algorithm_id(port_, handle);
+
+  void wire__crate__api__hashing__hasher_finalize(
+    NativePortType port_,
+    int handle,
+  ) => wasmModule.wire__crate__api__hashing__hasher_finalize(port_, handle);
+
+  void wire__crate__api__hashing__hasher_reset(
+    NativePortType port_,
+    int handle,
+  ) => wasmModule.wire__crate__api__hashing__hasher_reset(port_, handle);
+
+  void wire__crate__api__hashing__hasher_update(
+    NativePortType port_,
+    int handle,
+    JSAny data,
+  ) => wasmModule.wire__crate__api__hashing__hasher_update(port_, handle, data);
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+  wire__crate__api__kdf__hkdf__hkdf_derive(
+    JSAny ikm,
+    JSAny? salt,
+    JSAny info,
+    JSAny output_len,
+  ) => wasmModule.wire__crate__api__kdf__hkdf__hkdf_derive(
+    ikm,
+    salt,
+    info,
+    output_len,
+  );
+
+  void wire__crate__api__kdf__hkdf__hkdf_expand(
+    NativePortType port_,
+    JSAny prk,
+    JSAny info,
+    JSAny output_len,
+  ) => wasmModule.wire__crate__api__kdf__hkdf__hkdf_expand(
+    port_,
+    prk,
+    info,
+    output_len,
+  );
+
+  JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+  wire__crate__api__kdf__hkdf__hkdf_extract(JSAny ikm, JSAny? salt) =>
+      wasmModule.wire__crate__api__kdf__hkdf__hkdf_extract(ikm, salt);
+
+  void wire__crate__api__hashing__sha3_hash(NativePortType port_, JSAny data) =>
+      wasmModule.wire__crate__api__hashing__sha3_hash(port_, data);
+
+  void wire__crate__api__compression__should_skip_compression(
+    NativePortType port_,
+    String file_path,
+  ) => wasmModule.wire__crate__api__compression__should_skip_compression(
+    port_,
+    file_path,
+  );
+
+  void wire__crate__api__streaming__stream_compress_encrypt_file(
+    NativePortType port_,
+    int cipher,
+    JSAny compression,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  ) => wasmModule.wire__crate__api__streaming__stream_compress_encrypt_file(
+    port_,
+    cipher,
+    compression,
+    input_path,
+    output_path,
+    progress_sink,
+  );
+
+  void wire__crate__api__streaming__stream_decrypt_decompress_file(
+    NativePortType port_,
+    int cipher,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  ) => wasmModule.wire__crate__api__streaming__stream_decrypt_decompress_file(
+    port_,
+    cipher,
+    input_path,
+    output_path,
+    progress_sink,
+  );
+
+  void wire__crate__api__streaming__stream_decrypt_file(
+    NativePortType port_,
+    int cipher,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  ) => wasmModule.wire__crate__api__streaming__stream_decrypt_file(
+    port_,
+    cipher,
+    input_path,
+    output_path,
+    progress_sink,
+  );
+
+  void wire__crate__api__streaming__stream_encrypt_file(
+    NativePortType port_,
+    int cipher,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  ) => wasmModule.wire__crate__api__streaming__stream_encrypt_file(
+    port_,
+    cipher,
+    input_path,
+    output_path,
+    progress_sink,
+  );
+
+  void wire__crate__api__streaming__stream_hash_file(
+    NativePortType port_,
+    int hasher,
+    String file_path,
+    String progress_sink,
+  ) => wasmModule.wire__crate__api__streaming__stream_hash_file(
+    port_,
+    hasher,
+    file_path,
+    progress_sink,
+  );
+
+  void wire__crate__api__evfs__vault_capacity(
+    NativePortType port_,
+    int handle,
+  ) => wasmModule.wire__crate__api__evfs__vault_capacity(port_, handle);
+
+  void wire__crate__api__evfs__vault_close(NativePortType port_, int handle) =>
+      wasmModule.wire__crate__api__evfs__vault_close(port_, handle);
+
+  void wire__crate__api__evfs__vault_create(
+    NativePortType port_,
+    String path,
+    JSAny key,
+    String algorithm,
+    JSAny capacity_bytes,
+  ) => wasmModule.wire__crate__api__evfs__vault_create(
+    port_,
+    path,
+    key,
+    algorithm,
+    capacity_bytes,
+  );
+
+  void wire__crate__api__evfs__vault_defragment(
+    NativePortType port_,
+    int handle,
+  ) => wasmModule.wire__crate__api__evfs__vault_defragment(port_, handle);
+
+  void wire__crate__api__evfs__vault_delete(
+    NativePortType port_,
+    int handle,
+    String name,
+  ) => wasmModule.wire__crate__api__evfs__vault_delete(port_, handle, name);
+
+  void wire__crate__api__evfs__vault_health(NativePortType port_, int handle) =>
+      wasmModule.wire__crate__api__evfs__vault_health(port_, handle);
+
+  void wire__crate__api__evfs__vault_list(NativePortType port_, int handle) =>
+      wasmModule.wire__crate__api__evfs__vault_list(port_, handle);
+
+  void wire__crate__api__evfs__vault_open(
+    NativePortType port_,
+    String path,
+    JSAny key,
+  ) => wasmModule.wire__crate__api__evfs__vault_open(port_, path, key);
+
+  void wire__crate__api__evfs__vault_read(
+    NativePortType port_,
+    int handle,
+    String name,
+  ) => wasmModule.wire__crate__api__evfs__vault_read(port_, handle, name);
+
+  void wire__crate__api__evfs__vault_read_stream(
+    NativePortType port_,
+    int handle,
+    String name,
+    bool verify_checksum,
+    String sink,
+    String on_progress,
+  ) => wasmModule.wire__crate__api__evfs__vault_read_stream(
+    port_,
+    handle,
+    name,
+    verify_checksum,
+    sink,
+    on_progress,
+  );
+
+  void wire__crate__api__evfs__vault_resize(
+    NativePortType port_,
+    int handle,
+    JSAny new_capacity,
+  ) => wasmModule.wire__crate__api__evfs__vault_resize(
+    port_,
+    handle,
+    new_capacity,
+  );
+
+  void wire__crate__api__evfs__vault_write(
+    NativePortType port_,
+    int handle,
+    String name,
+    JSAny data,
+    JSAny? compression,
+  ) => wasmModule.wire__crate__api__evfs__vault_write(
+    port_,
+    handle,
+    name,
+    data,
+    compression,
+  );
+
+  void wire__crate__api__evfs__vault_write_file(
+    NativePortType port_,
+    int handle,
+    String name,
+    String file_path,
+    String on_progress,
+  ) => wasmModule.wire__crate__api__evfs__vault_write_file(
+    port_,
+    handle,
+    name,
+    file_path,
+    on_progress,
+  );
+
   void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     int ptr,
@@ -583,6 +1258,281 @@ external RustLibWasmModule get wasmModule;
 @JS()
 @anonymous
 extension type RustLibWasmModule._(JSObject _) implements JSObject {
+  external void wire__crate__api__evfs__types__VaultHandle_health(
+    NativePortType port_,
+    int that,
+  );
+
+  external void wire__crate__api__hashing__argon2__argon2id_hash(
+    NativePortType port_,
+    String password,
+    int preset,
+  );
+
+  external void wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+    NativePortType port_,
+    String password,
+    String salt,
+    int preset,
+  );
+
+  external void wire__crate__api__hashing__argon2__argon2id_verify(
+    NativePortType port_,
+    String phc_hash,
+    String password,
+  );
+
+  external void wire__crate__api__hashing__blake3_hash(
+    NativePortType port_,
+    JSAny data,
+  );
+
+  external void wire__crate__api__compression__compress(
+    NativePortType port_,
+    JSAny data,
+    JSAny config,
+  );
+
+  external void wire__crate__api__compression__compression_algorithm_from_u8(
+    NativePortType port_,
+    int byte,
+  );
+
+  external void wire__crate__api__compression__compression_algorithm_to_u8(
+    NativePortType port_,
+    int that,
+  );
+
+  external void wire__crate__api__encryption__create_aes256_gcm(
+    NativePortType port_,
+    JSAny key,
+  );
+
+  external void wire__crate__api__hashing__create_blake3(NativePortType port_);
+
+  external void wire__crate__api__encryption__create_chacha20_poly1305(
+    NativePortType port_,
+    JSAny key,
+  );
+
+  external void wire__crate__api__encryption__create_noop_encryption(
+    NativePortType port_,
+  );
+
+  external void wire__crate__api__hashing__create_sha3(NativePortType port_);
+
+  external void wire__crate__api__compression__decompress(
+    NativePortType port_,
+    JSAny data,
+    int algorithm,
+  );
+
+  external void wire__crate__api__encryption__decrypt(
+    NativePortType port_,
+    int cipher,
+    JSAny ciphertext,
+    JSAny aad,
+  );
+
+  external void wire__crate__api__encryption__encrypt(
+    NativePortType port_,
+    int cipher,
+    JSAny plaintext,
+    JSAny aad,
+  );
+
+  external void wire__crate__api__encryption__encryption_algorithm_id(
+    NativePortType port_,
+    int cipher,
+  );
+
+  external void wire__crate__api__encryption__generate_aes256_gcm_key(
+    NativePortType port_,
+  );
+
+  external void wire__crate__api__encryption__aes_gcm__generate_aes_key(
+    NativePortType port_,
+  );
+
+  external void wire__crate__api__encryption__generate_chacha20_poly1305_key(
+    NativePortType port_,
+  );
+
+  external void wire__crate__api__encryption__chacha20__generate_chacha_key(
+    NativePortType port_,
+  );
+
+  external void wire__crate__api__hashing__hasher_algorithm_id(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__hashing__hasher_finalize(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__hashing__hasher_reset(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__hashing__hasher_update(
+    NativePortType port_,
+    int handle,
+    JSAny data,
+  );
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+  wire__crate__api__kdf__hkdf__hkdf_derive(
+    JSAny ikm,
+    JSAny? salt,
+    JSAny info,
+    JSAny output_len,
+  );
+
+  external void wire__crate__api__kdf__hkdf__hkdf_expand(
+    NativePortType port_,
+    JSAny prk,
+    JSAny info,
+    JSAny output_len,
+  );
+
+  external JSAny? /* flutter_rust_bridge::for_generated::WireSyncRust2DartDco */
+  wire__crate__api__kdf__hkdf__hkdf_extract(JSAny ikm, JSAny? salt);
+
+  external void wire__crate__api__hashing__sha3_hash(
+    NativePortType port_,
+    JSAny data,
+  );
+
+  external void wire__crate__api__compression__should_skip_compression(
+    NativePortType port_,
+    String file_path,
+  );
+
+  external void wire__crate__api__streaming__stream_compress_encrypt_file(
+    NativePortType port_,
+    int cipher,
+    JSAny compression,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  );
+
+  external void wire__crate__api__streaming__stream_decrypt_decompress_file(
+    NativePortType port_,
+    int cipher,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  );
+
+  external void wire__crate__api__streaming__stream_decrypt_file(
+    NativePortType port_,
+    int cipher,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  );
+
+  external void wire__crate__api__streaming__stream_encrypt_file(
+    NativePortType port_,
+    int cipher,
+    String input_path,
+    String output_path,
+    String progress_sink,
+  );
+
+  external void wire__crate__api__streaming__stream_hash_file(
+    NativePortType port_,
+    int hasher,
+    String file_path,
+    String progress_sink,
+  );
+
+  external void wire__crate__api__evfs__vault_capacity(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__evfs__vault_close(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__evfs__vault_create(
+    NativePortType port_,
+    String path,
+    JSAny key,
+    String algorithm,
+    JSAny capacity_bytes,
+  );
+
+  external void wire__crate__api__evfs__vault_defragment(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__evfs__vault_delete(
+    NativePortType port_,
+    int handle,
+    String name,
+  );
+
+  external void wire__crate__api__evfs__vault_health(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__evfs__vault_list(
+    NativePortType port_,
+    int handle,
+  );
+
+  external void wire__crate__api__evfs__vault_open(
+    NativePortType port_,
+    String path,
+    JSAny key,
+  );
+
+  external void wire__crate__api__evfs__vault_read(
+    NativePortType port_,
+    int handle,
+    String name,
+  );
+
+  external void wire__crate__api__evfs__vault_read_stream(
+    NativePortType port_,
+    int handle,
+    String name,
+    bool verify_checksum,
+    String sink,
+    String on_progress,
+  );
+
+  external void wire__crate__api__evfs__vault_resize(
+    NativePortType port_,
+    int handle,
+    JSAny new_capacity,
+  );
+
+  external void wire__crate__api__evfs__vault_write(
+    NativePortType port_,
+    int handle,
+    String name,
+    JSAny data,
+    JSAny? compression,
+  );
+
+  external void wire__crate__api__evfs__vault_write_file(
+    NativePortType port_,
+    int handle,
+    String name,
+    String file_path,
+    String on_progress,
+  );
+
   external void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     int ptr,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dev_dependencies:
   freezed: ^3.2.5
   build_runner: ^2.11.1
   test: ^1.29.0
+  ffigen: ^20.1.1
 
 flutter:
   plugin:

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -743,7 +743,9 @@ dependencies = [
  "fs4",
  "hex",
  "hkdf",
+ "libc",
  "log",
+ "memmap2",
  "rand",
  "sha2",
  "sha3",
@@ -769,6 +771,15 @@ name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,6 +55,10 @@ testing = [] # exposes noop cipher — never enable in production builds
 
 [profile.release]
 panic = "abort"
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+opt-level = 3
 
 [dev-dependencies]
 hex = "0.4"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -44,6 +44,10 @@ crc32fast = "1.4"
 # Advisory file locking
 fs4 = "0.12"
 
+# Memory-mapped I/O for zero-copy vault reads
+memmap2 = "0.9"
+libc = "0.2"
+
 # Compression
 zstd = { version = "0.13", optional = true }
 brotli = { version = "7.0", optional = true }

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,0 +1,18 @@
+fn main() {
+    println!("cargo:rerun-if-changed=ffi-exports.map");
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR must be set");
+
+    // ELF targets (Android, Linux): use a version script to restrict the
+    // cdylib's dynamic symbol table to FRB FFI symbols only.
+    // This hides #[no_mangle] symbols leaked by dependencies (e.g. blake3).
+    // NOTE: macOS ld is not supported — rustc generates its own -exported_symbols_list
+    // for cdylib targets, and additional flags can only add to it, not restrict it.
+    // macOS .dylib is dev-only; production .so builds are covered.
+    if matches!(target_os.as_str(), "android" | "linux") {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,--version-script={manifest_dir}/ffi-exports.map");
+    }
+}

--- a/rust/ffi-exports.map
+++ b/rust/ffi-exports.map
@@ -1,0 +1,11 @@
+/* Linker version script — only export FRB FFI symbols from the cdylib.
+   Everything else (including #[no_mangle] symbols from deps) becomes local. */
+{
+    global:
+        frb_*;
+        frbgen_m_security_*;
+        free_zero_copy_buffer_*;
+        store_dart_post_cobject;
+    local:
+        *;
+};

--- a/rust/src/api/evfs/helpers.rs
+++ b/rust/src/api/evfs/helpers.rs
@@ -97,10 +97,14 @@ pub(crate) fn capacity_from_file_size(
 
 /// Decrypt all chunks of a streaming segment, calling `on_chunk(plaintext, chunk_index)`
 /// for each decrypted chunk. Returns the BLAKE3 checksum of the full decrypted data.
+///
+/// When `mmap` is `Some`, chunks are read via zero-copy slices into the mapped
+/// file. Falls back to heap-allocated `read_exact` when mmap is unavailable.
 #[allow(clippy::too_many_arguments)]
 #[cfg(feature = "compression")]
 pub(crate) fn decrypt_streaming_chunks(
     file: &mut File,
+    mmap: Option<&super::types::VaultMmap>,
     cipher_key: &[u8],
     nonce_key: &[u8],
     algorithm: Algorithm,
@@ -112,6 +116,7 @@ pub(crate) fn decrypt_streaming_chunks(
     mut on_chunk: impl FnMut(Vec<u8>, u32) -> Result<(), CryptoError>,
 ) -> Result<[u8; 32], CryptoError> {
     let data_region = format::data_region_offset(index_pad_size);
+    let enc_chunk_size = crate::core::streaming::ENCRYPTED_CHUNK_SIZE;
     let mut hasher = blake3::Hasher::new();
     let mut decompressor = if compression != CompressionAlgorithm::None {
         Some(crate::core::compression::streaming::new_decompressor(
@@ -124,16 +129,26 @@ pub(crate) fn decrypt_streaming_chunks(
 
     for i in 0..chunk_count {
         let chunk_offset = (i as u64)
-            .checked_mul(crate::core::streaming::ENCRYPTED_CHUNK_SIZE as u64)
+            .checked_mul(enc_chunk_size as u64)
             .and_then(|co| data_region.checked_add(seg_offset)?.checked_add(co))
             .ok_or_else(|| CryptoError::InvalidParameter("chunk offset overflow".into()))?;
-        file.seek(SeekFrom::Start(chunk_offset))?;
 
-        let mut encrypted = vec![0u8; crate::core::streaming::ENCRYPTED_CHUNK_SIZE];
-        file.read_exact(&mut encrypted)?;
+        // Zero-copy path: slice directly into mmap; fallback: heap read
+        let heap_buf;
+        let encrypted_ref: &[u8] = if let Some(m) = mmap {
+            m.slice(chunk_offset, enc_chunk_size as u64)?
+        } else {
+            file.seek(SeekFrom::Start(chunk_offset))?;
+            heap_buf = {
+                let mut buf = vec![0u8; enc_chunk_size];
+                file.read_exact(&mut buf)?;
+                buf
+            };
+            &heap_buf
+        };
 
         let expected_nonce = segment::derive_chunk_nonce(nonce_key, i as u64, generation)?;
-        let (stored_nonce, _) = encrypted.split_at(crate::core::streaming::NONCE_SIZE);
+        let (stored_nonce, _) = encrypted_ref.split_at(crate::core::streaming::NONCE_SIZE);
         if stored_nonce.ct_ne(&expected_nonce).into() {
             return Err(CryptoError::AuthenticationFailed);
         }
@@ -148,7 +163,7 @@ pub(crate) fn decrypt_streaming_chunks(
 
         let decrypted = segment::aead_decrypt_with_stored_nonce(
             cipher_key,
-            &encrypted,
+            encrypted_ref,
             &aad,
             algorithm,
         )?;

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -82,8 +82,8 @@ pub fn vault_create(
         keys,
         index,
         index_pad_size,
-        file,
         mmap,
+        file,
         wal,
         lock,
     })
@@ -237,8 +237,8 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         keys,
         index,
         index_pad_size,
-        file,
         mmap,
+        file,
         wal,
         lock,
     })

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -7,6 +7,7 @@ pub mod types;
 
 use helpers::*;
 pub use types::*;
+use types::VaultMmap;
 
 use crate::api::compression::{CompressionAlgorithm, CompressionConfig};
 use crate::core::error::CryptoError;
@@ -74,6 +75,7 @@ pub fn vault_create(
     let mut wal = WriteAheadLog::open(&path)?;
     wal.checkpoint()?;
 
+    let mmap = VaultMmap::new(&file).ok();
     Ok(VaultHandle {
         path,
         algorithm: algo,
@@ -81,6 +83,7 @@ pub fn vault_create(
         index,
         index_pad_size,
         file,
+        mmap,
         wal,
         lock,
     })
@@ -227,6 +230,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         file.sync_all()?;
     }
 
+    let mmap = VaultMmap::new(&file).ok();
     Ok(VaultHandle {
         path,
         algorithm,
@@ -234,6 +238,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         index,
         index_pad_size,
         file,
+        mmap,
         wal,
         lock,
     })
@@ -323,8 +328,9 @@ pub fn vault_write(
         handle.index_pad_size,
     )?;
 
-    // 9. WAL commit
+    // 9. WAL commit + refresh mmap (file contents changed)
     handle.wal.commit()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -350,6 +356,7 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
         let mut full_plaintext = Vec::new();
         let checksum = decrypt_streaming_chunks(
             &mut handle.file,
+            handle.mmap.as_ref(),
             handle.keys.cipher_key.as_bytes(),
             handle.keys.nonce_key.as_bytes(),
             handle.algorithm,
@@ -373,19 +380,8 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
         return Ok(full_plaintext);
     }
 
-    // Existing monolithic read logic (used when chunk_count == 0)
-    let read_len = usize::try_from(seg_size).map_err(|_| {
-        CryptoError::VaultCorrupted(format!(
-            "segment size {seg_size} exceeds platform address space"
-        ))
-    })?;
-    handle.file.seek(SeekFrom::Start(
-        format::data_region_offset(handle.index_pad_size) + seg_offset,
-    ))?;
-    let mut encrypted = vec![0u8; read_len];
-    handle.file.read_exact(&mut encrypted)?;
-
-    // Decrypt-then-decompress
+    // Monolithic read (chunk_count == 0): prefer mmap zero-copy, fall back to heap
+    let abs_offset = format::data_region_offset(handle.index_pad_size) + seg_offset;
     let params = SegmentCryptoParams {
         cipher_key: handle.keys.cipher_key.as_bytes(),
         nonce_key: handle.keys.nonce_key.as_bytes(),
@@ -393,7 +389,22 @@ pub fn vault_read(handle: &mut VaultHandle, name: String) -> Result<Vec<u8>, Cry
         segment_index: 0,
         generation: seg_gen,
     };
-    let plaintext = segment::decrypt_segment(&params, &encrypted, seg_compression)?;
+
+    let plaintext = if let Some(ref mmap) = handle.mmap {
+        let encrypted = mmap.slice(abs_offset, seg_size)?;
+        segment::decrypt_segment(&params, encrypted, seg_compression)?
+    } else {
+        // Fallback: heap-allocated read_exact (32-bit or mmap-failed)
+        let read_len = usize::try_from(seg_size).map_err(|_| {
+            CryptoError::VaultCorrupted(format!(
+                "segment size {seg_size} exceeds platform address space"
+            ))
+        })?;
+        handle.file.seek(SeekFrom::Start(abs_offset))?;
+        let mut buf = vec![0u8; read_len];
+        handle.file.read_exact(&mut buf)?;
+        segment::decrypt_segment(&params, &buf, seg_compression)?
+    };
 
     // Verify checksum on decompressed plaintext
     if !segment::verify_checksum(&plaintext, &seg_checksum) {
@@ -435,6 +446,7 @@ pub fn vault_read_stream(
 
     let checksum = decrypt_streaming_chunks(
         &mut handle.file,
+        handle.mmap.as_ref(),
         handle.keys.cipher_key.as_bytes(),
         handle.keys.nonce_key.as_bytes(),
         handle.algorithm,
@@ -605,6 +617,7 @@ pub fn vault_write_stream(
 
     handle.wal.commit()?;
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -754,8 +767,9 @@ pub fn vault_delete(handle: &mut VaultHandle, name: String) -> Result<(), Crypto
         handle.index_pad_size,
     )?;
 
-    // WAL commit
+    // WAL commit + refresh mmap (file contents changed)
     handle.wal.commit()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -810,6 +824,7 @@ fn vault_resize_grow_impl(
 
     handle.wal.commit()?;
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -878,6 +893,7 @@ fn vault_resize_shrink_impl(
 
     handle.wal.commit()?;
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(())
 }
@@ -1042,8 +1058,9 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         )?;
     }
 
-    // Checkpoint WAL (clear history)
+    // Checkpoint WAL (clear history) + refresh mmap (data moved)
     handle.wal.checkpoint()?;
+    handle.refresh_mmap();
 
     Ok(DefragResult {
         segments_moved,

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -2141,6 +2141,7 @@ fn stream_read_chunks(
 
     let checksum = decrypt_streaming_chunks(
         &mut handle.file,
+        handle.mmap.as_ref(),
         handle.keys.cipher_key.as_bytes(),
         handle.keys.nonce_key.as_bytes(),
         handle.algorithm,

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -1,9 +1,80 @@
+use crate::core::error::CryptoError;
 use crate::core::evfs::format::SegmentIndex;
 use crate::core::evfs::segment::VaultKeys;
 use crate::core::evfs::wal::{VaultLock, WriteAheadLog};
 use crate::core::format::Algorithm;
 use flutter_rust_bridge::frb;
+use memmap2::Mmap;
 use std::fs::File;
+
+// ---------------------------------------------------------------------------
+// VaultMmap — read-only memory-mapped view of the vault file
+// ---------------------------------------------------------------------------
+
+/// Read-only memory-mapped view of the vault file for zero-copy segment reads.
+///
+/// Created on vault open and recreated after any mutation (write, delete,
+/// defrag, resize) that changes the file contents.
+pub(crate) struct VaultMmap {
+    mmap: Mmap,
+}
+
+impl VaultMmap {
+    /// Create a new read-only mapping of the vault file.
+    ///
+    /// # Safety contract
+    /// The caller must hold an exclusive flock on the file (VaultLock) so no
+    /// concurrent writer can modify the file while the mapping is live.
+    pub(crate) fn new(file: &File) -> Result<Self, CryptoError> {
+        // SAFETY: file is flock-locked — no concurrent writers
+        let mmap = unsafe { Mmap::map(file) }
+            .map_err(|e| CryptoError::IoError(format!("mmap failed: {e}")))?;
+
+        // Lock pages to prevent kernel from swapping ciphertext to disk.
+        // Failure is non-fatal (mlock limits may be low on some systems).
+        #[cfg(unix)]
+        {
+            unsafe {
+                libc::mlock(mmap.as_ptr().cast::<libc::c_void>(), mmap.len());
+            }
+        }
+
+        Ok(Self { mmap })
+    }
+
+    /// Return a byte slice into the mapped region at `[offset..offset+len]`.
+    ///
+    /// Returns `Err` if the range is out of bounds (e.g. 32-bit overflow or
+    /// the file was truncated between mapping and read).
+    pub(crate) fn slice(&self, offset: u64, len: u64) -> Result<&[u8], CryptoError> {
+        let start = usize::try_from(offset).map_err(|_| {
+            CryptoError::VaultCorrupted(format!("mmap offset {offset} exceeds address space"))
+        })?;
+        let size = usize::try_from(len).map_err(|_| {
+            CryptoError::VaultCorrupted(format!("mmap length {len} exceeds address space"))
+        })?;
+        let end = start.checked_add(size).ok_or_else(|| {
+            CryptoError::VaultCorrupted("mmap range overflow".into())
+        })?;
+        if end > self.mmap.len() {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "mmap read {start}..{end} exceeds file size {}",
+                self.mmap.len()
+            )));
+        }
+        Ok(&self.mmap[start..end])
+    }
+}
+
+#[cfg(unix)]
+impl Drop for VaultMmap {
+    fn drop(&mut self) {
+        // Unlock pages before the mmap is unmapped
+        unsafe {
+            libc::munlock(self.mmap.as_ptr().cast::<libc::c_void>(), self.mmap.len());
+        }
+    }
+}
 
 // ---------------------------------------------------------------------------
 // VaultHandle
@@ -23,8 +94,17 @@ pub struct VaultHandle {
     /// Padded plaintext index size, set at creation and read from header on open.
     pub(crate) index_pad_size: usize,
     pub(crate) file: File,
+    /// Read-only mmap for zero-copy reads. None if mmap failed (32-bit fallback).
+    pub(crate) mmap: Option<VaultMmap>,
     pub(crate) wal: WriteAheadLog,
     pub(crate) lock: VaultLock,
+}
+
+impl VaultHandle {
+    /// (Re)create the mmap after a mutation. Silently falls back to None on failure.
+    pub(crate) fn refresh_mmap(&mut self) {
+        self.mmap = VaultMmap::new(&self.file).ok();
+    }
 }
 
 /// Capacity info returned to callers.

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -26,7 +26,9 @@ impl VaultMmap {
     /// The caller must hold an exclusive flock on the file (VaultLock) so no
     /// concurrent writer can modify the file while the mapping is live.
     pub(crate) fn new(file: &File) -> Result<Self, CryptoError> {
-        // SAFETY: file is flock-locked — no concurrent writers
+        // SAFETY: the caller holds an exclusive advisory flock via VaultLock,
+        // ensuring no cooperating process modifies the file while mapped.
+        // Non-cooperating processes are outside this library's threat model.
         let mmap = unsafe { Mmap::map(file) }
             .map_err(|e| CryptoError::IoError(format!("mmap failed: {e}")))?;
 
@@ -93,9 +95,10 @@ pub struct VaultHandle {
     pub(crate) index: SegmentIndex,
     /// Padded plaintext index size, set at creation and read from header on open.
     pub(crate) index_pad_size: usize,
-    pub(crate) file: File,
     /// Read-only mmap for zero-copy reads. None if mmap failed (32-bit fallback).
+    /// Dropped before `file` so munlock/munmap runs while the fd is still open.
     pub(crate) mmap: Option<VaultMmap>,
+    pub(crate) file: File,
     pub(crate) wal: WriteAheadLog,
     pub(crate) lock: VaultLock,
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -35,9 +35,9 @@ use flutter_rust_bridge::{Handler, IntoIntoDart};
 // Section: boilerplate
 
 flutter_rust_bridge::frb_generated_boilerplate!(
-    default_stream_sink_codec = SseCodec,
-    default_rust_opaque = RustOpaqueMoi,
-    default_rust_auto_opaque = RustAutoOpaqueMoi,
+    default_stream_sink_codec = DcoCodec,
+    default_rust_opaque = RustOpaqueNom,
+    default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2084471439;
@@ -50,32 +50,20 @@ flutter_rust_bridge::frb_generated_default_handler!();
 
 fn wire__crate__api__evfs__types__VaultHandle_health_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    that: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "VaultHandle_health",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_that = that.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let mut api_that_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -101,32 +89,20 @@ fn wire__crate__api__evfs__types__VaultHandle_health_impl(
 }
 fn wire__crate__api__hashing__argon2__argon2id_hash_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    password: impl CstDecode<String>,
+    preset: impl CstDecode<crate::api::hashing::argon2::Argon2Preset>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "argon2id_hash",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_password = <String>::sse_decode(&mut deserializer);
-            let api_preset =
-                <crate::api::hashing::argon2::Argon2Preset>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_password = password.cst_decode();
+            let api_preset = preset.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok =
                         crate::api::hashing::argon2::argon2id_hash(api_password, api_preset)?;
                     Ok(output_ok)
@@ -137,33 +113,22 @@ fn wire__crate__api__hashing__argon2__argon2id_hash_impl(
 }
 fn wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    password: impl CstDecode<String>,
+    salt: impl CstDecode<String>,
+    preset: impl CstDecode<crate::api::hashing::argon2::Argon2Preset>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "argon2id_hash_with_salt",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_password = <String>::sse_decode(&mut deserializer);
-            let api_salt = <String>::sse_decode(&mut deserializer);
-            let api_preset =
-                <crate::api::hashing::argon2::Argon2Preset>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_password = password.cst_decode();
+            let api_salt = salt.cst_decode();
+            let api_preset = preset.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::hashing::argon2::argon2id_hash_with_salt(
                         api_password,
                         api_salt,
@@ -177,31 +142,20 @@ fn wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
 }
 fn wire__crate__api__hashing__argon2__argon2id_verify_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    phc_hash: impl CstDecode<String>,
+    password: impl CstDecode<String>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "argon2id_verify",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_phc_hash = <String>::sse_decode(&mut deserializer);
-            let api_password = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_phc_hash = phc_hash.cst_decode();
+            let api_password = password.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok =
                         crate::api::hashing::argon2::argon2id_verify(api_phc_hash, api_password)?;
                     Ok(output_ok)
@@ -212,30 +166,18 @@ fn wire__crate__api__hashing__argon2__argon2id_verify_impl(
 }
 fn wire__crate__api__hashing__blake3_hash_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    data: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "blake3_hash",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_data = data.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok =
                         Result::<_, ()>::Ok(crate::api::hashing::blake3_hash(api_data))?;
                     Ok(output_ok)
@@ -246,32 +188,20 @@ fn wire__crate__api__hashing__blake3_hash_impl(
 }
 fn wire__crate__api__compression__compress_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    data: impl CstDecode<Vec<u8>>,
+    config: impl CstDecode<crate::api::compression::CompressionConfig>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "compress",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_config =
-                <crate::api::compression::CompressionConfig>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_data = data.cst_decode();
+            let api_config = config.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::compression::compress(&api_data, &api_config)?;
                     Ok(output_ok)
                 })())
@@ -281,30 +211,18 @@ fn wire__crate__api__compression__compress_impl(
 }
 fn wire__crate__api__compression__compression_algorithm_from_u8_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    byte: impl CstDecode<u8>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "compression_algorithm_from_u8",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_byte = <u8>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_byte = byte.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok =
                         crate::api::compression::CompressionAlgorithm::from_u8(api_byte)?;
                     Ok(output_ok)
@@ -315,31 +233,18 @@ fn wire__crate__api__compression__compression_algorithm_from_u8_impl(
 }
 fn wire__crate__api__compression__compression_algorithm_to_u8_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    that: impl CstDecode<crate::api::compression::CompressionAlgorithm>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "compression_algorithm_to_u8",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_that =
-                <crate::api::compression::CompressionAlgorithm>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_that = that.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok(
                         crate::api::compression::CompressionAlgorithm::to_u8(api_that),
                     )?;
@@ -351,30 +256,18 @@ fn wire__crate__api__compression__compression_algorithm_to_u8_impl(
 }
 fn wire__crate__api__encryption__create_aes256_gcm_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    key: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "create_aes256_gcm",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_key = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_key = key.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::create_aes256_gcm(api_key)?;
                     Ok(output_ok)
                 })())
@@ -384,29 +277,16 @@ fn wire__crate__api__encryption__create_aes256_gcm_impl(
 }
 fn wire__crate__api__hashing__create_blake3_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "create_blake3",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok(crate::api::hashing::create_blake3())?;
                     Ok(output_ok)
                 })())
@@ -416,30 +296,18 @@ fn wire__crate__api__hashing__create_blake3_impl(
 }
 fn wire__crate__api__encryption__create_chacha20_poly1305_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    key: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "create_chacha20_poly1305",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_key = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_key = key.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::create_chacha20_poly1305(api_key)?;
                     Ok(output_ok)
                 })())
@@ -449,29 +317,16 @@ fn wire__crate__api__encryption__create_chacha20_poly1305_impl(
 }
 fn wire__crate__api__encryption__create_noop_encryption_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "create_noop_encryption",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok =
                         Result::<_, ()>::Ok(crate::api::encryption::create_noop_encryption())?;
                     Ok(output_ok)
@@ -482,29 +337,16 @@ fn wire__crate__api__encryption__create_noop_encryption_impl(
 }
 fn wire__crate__api__hashing__create_sha3_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "create_sha3",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok(crate::api::hashing::create_sha3())?;
                     Ok(output_ok)
                 })())
@@ -514,32 +356,20 @@ fn wire__crate__api__hashing__create_sha3_impl(
 }
 fn wire__crate__api__compression__decompress_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    data: impl CstDecode<Vec<u8>>,
+    algorithm: impl CstDecode<crate::api::compression::CompressionAlgorithm>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "decompress",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_algorithm =
-                <crate::api::compression::CompressionAlgorithm>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_data = data.cst_decode();
+            let api_algorithm = algorithm.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::compression::decompress(&api_data, api_algorithm)?;
                     Ok(output_ok)
                 })())
@@ -549,34 +379,24 @@ fn wire__crate__api__compression__decompress_impl(
 }
 fn wire__crate__api__encryption__decrypt_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
+    ciphertext: impl CstDecode<Vec<u8>>,
+    aad: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "decrypt",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_ciphertext = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_aad = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
+            let api_ciphertext = ciphertext.cst_decode();
+            let api_aad = aad.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -606,34 +426,24 @@ fn wire__crate__api__encryption__decrypt_impl(
 }
 fn wire__crate__api__encryption__encrypt_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
+    plaintext: impl CstDecode<Vec<u8>>,
+    aad: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "encrypt",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_plaintext = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_aad = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
+            let api_plaintext = plaintext.cst_decode();
+            let api_aad = aad.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -663,32 +473,20 @@ fn wire__crate__api__encryption__encrypt_impl(
 }
 fn wire__crate__api__encryption__encryption_algorithm_id_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "encryption_algorithm_id",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -716,29 +514,16 @@ fn wire__crate__api__encryption__encryption_algorithm_id_impl(
 }
 fn wire__crate__api__encryption__generate_aes256_gcm_key_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "generate_aes256_gcm_key",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::generate_aes256_gcm_key()?;
                     Ok(output_ok)
                 })())
@@ -748,29 +533,16 @@ fn wire__crate__api__encryption__generate_aes256_gcm_key_impl(
 }
 fn wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "generate_aes_key",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::aes_gcm::generate_aes_key()?;
                     Ok(output_ok)
                 })())
@@ -780,29 +552,16 @@ fn wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(
 }
 fn wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "generate_chacha20_poly1305_key",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::generate_chacha20_poly1305_key()?;
                     Ok(output_ok)
                 })())
@@ -812,29 +571,16 @@ fn wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(
 }
 fn wire__crate__api__encryption__chacha20__generate_chacha_key_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "generate_chacha_key",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            deserializer.end();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::encryption::chacha20::generate_chacha_key()?;
                     Ok(output_ok)
                 })())
@@ -844,32 +590,20 @@ fn wire__crate__api__encryption__chacha20__generate_chacha_key_impl(
 }
 fn wire__crate__api__hashing__hasher_algorithm_id_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hasher_algorithm_id",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -895,32 +629,20 @@ fn wire__crate__api__hashing__hasher_algorithm_id_impl(
 }
 fn wire__crate__api__hashing__hasher_finalize_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hasher_finalize",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -946,32 +668,20 @@ fn wire__crate__api__hashing__hasher_finalize_impl(
 }
 fn wire__crate__api__hashing__hasher_reset_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hasher_reset",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -997,33 +707,22 @@ fn wire__crate__api__hashing__hasher_reset_impl(
 }
 fn wire__crate__api__hashing__hasher_update_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+    >,
+    data: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hasher_update",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_data = data.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1049,32 +748,23 @@ fn wire__crate__api__hashing__hasher_update_impl(
     )
 }
 fn wire__crate__api__kdf__hkdf__hkdf_derive_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+    ikm: impl CstDecode<Vec<u8>>,
+    salt: impl CstDecode<Option<Vec<u8>>>,
+    info: impl CstDecode<Vec<u8>>,
+    output_len: impl CstDecode<usize>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hkdf_derive",
             port: None,
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_ikm = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_salt = <Option<Vec<u8>>>::sse_decode(&mut deserializer);
-            let api_info = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_output_len = <usize>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+            let api_ikm = ikm.cst_decode();
+            let api_salt = salt.cst_decode();
+            let api_info = info.cst_decode();
+            let api_output_len = output_len.cst_decode();
+            transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                 let output_ok = crate::api::kdf::hkdf::hkdf_derive(
                     api_ikm,
                     api_salt,
@@ -1088,32 +778,22 @@ fn wire__crate__api__kdf__hkdf__hkdf_derive_impl(
 }
 fn wire__crate__api__kdf__hkdf__hkdf_expand_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    prk: impl CstDecode<Vec<u8>>,
+    info: impl CstDecode<Vec<u8>>,
+    output_len: impl CstDecode<usize>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hkdf_expand",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_prk = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_info = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_output_len = <usize>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_prk = prk.cst_decode();
+            let api_info = info.cst_decode();
+            let api_output_len = output_len.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok =
                         crate::api::kdf::hkdf::hkdf_expand(api_prk, api_info, api_output_len)?;
                     Ok(output_ok)
@@ -1123,30 +803,19 @@ fn wire__crate__api__kdf__hkdf__hkdf_expand_impl(
     )
 }
 fn wire__crate__api__kdf__hkdf__hkdf_extract_impl(
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
-) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::SseCodec, _>(
+    ikm: impl CstDecode<Vec<u8>>,
+    salt: impl CstDecode<Option<Vec<u8>>>,
+) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_sync::<flutter_rust_bridge::for_generated::DcoCodec, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "hkdf_extract",
             port: None,
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Sync,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_ikm = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_salt = <Option<Vec<u8>>>::sse_decode(&mut deserializer);
-            deserializer.end();
-            transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+            let api_ikm = ikm.cst_decode();
+            let api_salt = salt.cst_decode();
+            transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                 let output_ok = crate::api::kdf::hkdf::hkdf_extract(api_ikm, api_salt)?;
                 Ok(output_ok)
             })())
@@ -1155,30 +824,18 @@ fn wire__crate__api__kdf__hkdf__hkdf_extract_impl(
 }
 fn wire__crate__api__hashing__sha3_hash_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    data: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "sha3_hash",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_data = data.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok(crate::api::hashing::sha3_hash(api_data))?;
                     Ok(output_ok)
                 })())
@@ -1188,30 +845,18 @@ fn wire__crate__api__hashing__sha3_hash_impl(
 }
 fn wire__crate__api__compression__should_skip_compression_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    file_path: impl CstDecode<String>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "should_skip_compression",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_file_path = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_file_path = file_path.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let output_ok = Result::<_, ()>::Ok(
                         crate::api::compression::should_skip_compression(&api_file_path),
                     )?;
@@ -1223,40 +868,28 @@ fn wire__crate__api__compression__should_skip_compression_impl(
 }
 fn wire__crate__api__streaming__stream_compress_encrypt_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
+    compression: impl CstDecode<crate::api::compression::CompressionConfig>,
+    input_path: impl CstDecode<String>,
+    output_path: impl CstDecode<String>,
+    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "stream_compress_encrypt_file",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_compression =
-                <crate::api::compression::CompressionConfig>::sse_decode(&mut deserializer);
-            let api_input_path = <String>::sse_decode(&mut deserializer);
-            let api_output_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_sink =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
+            let api_compression = compression.cst_decode();
+            let api_input_path = input_path.cst_decode();
+            let api_output_path = output_path.cst_decode();
+            let api_progress_sink = progress_sink.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1288,38 +921,26 @@ fn wire__crate__api__streaming__stream_compress_encrypt_file_impl(
 }
 fn wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
+    input_path: impl CstDecode<String>,
+    output_path: impl CstDecode<String>,
+    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "stream_decrypt_decompress_file",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_input_path = <String>::sse_decode(&mut deserializer);
-            let api_output_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_sink =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
+            let api_input_path = input_path.cst_decode();
+            let api_output_path = output_path.cst_decode();
+            let api_progress_sink = progress_sink.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1350,38 +971,26 @@ fn wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
 }
 fn wire__crate__api__streaming__stream_decrypt_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
+    input_path: impl CstDecode<String>,
+    output_path: impl CstDecode<String>,
+    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "stream_decrypt_file",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_input_path = <String>::sse_decode(&mut deserializer);
-            let api_output_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_sink =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
+            let api_input_path = input_path.cst_decode();
+            let api_output_path = output_path.cst_decode();
+            let api_progress_sink = progress_sink.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1412,38 +1021,26 @@ fn wire__crate__api__streaming__stream_decrypt_file_impl(
 }
 fn wire__crate__api__streaming__stream_encrypt_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    cipher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+    >,
+    input_path: impl CstDecode<String>,
+    output_path: impl CstDecode<String>,
+    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "stream_encrypt_file",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_cipher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_input_path = <String>::sse_decode(&mut deserializer);
-            let api_output_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_sink =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_cipher = cipher.cst_decode();
+            let api_input_path = input_path.cst_decode();
+            let api_output_path = output_path.cst_decode();
+            let api_progress_sink = progress_sink.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_cipher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1474,37 +1071,24 @@ fn wire__crate__api__streaming__stream_encrypt_file_impl(
 }
 fn wire__crate__api__streaming__stream_hash_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    hasher: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+    >,
+    file_path: impl CstDecode<String>,
+    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "stream_hash_file",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_hasher = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_file_path = <String>::sse_decode(&mut deserializer);
-            let api_progress_sink =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_hasher = hasher.cst_decode();
+            let api_file_path = file_path.cst_decode();
+            let api_progress_sink = progress_sink.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_hasher_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1534,32 +1118,20 @@ fn wire__crate__api__streaming__stream_hash_file_impl(
 }
 fn wire__crate__api__evfs__vault_capacity_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_capacity",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1586,30 +1158,18 @@ fn wire__crate__api__evfs__vault_capacity_impl(
 }
 fn wire__crate__api__evfs__vault_close_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<VaultHandle>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_close",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <VaultHandle>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::evfs::vault_close(api_handle)?;
                     Ok(output_ok)
                 })())
@@ -1619,33 +1179,24 @@ fn wire__crate__api__evfs__vault_close_impl(
 }
 fn wire__crate__api__evfs__vault_create_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    path: impl CstDecode<String>,
+    key: impl CstDecode<Vec<u8>>,
+    algorithm: impl CstDecode<String>,
+    capacity_bytes: impl CstDecode<u64>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_create",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_path = <String>::sse_decode(&mut deserializer);
-            let api_key = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_algorithm = <String>::sse_decode(&mut deserializer);
-            let api_capacity_bytes = <u64>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_path = path.cst_decode();
+            let api_key = key.cst_decode();
+            let api_algorithm = algorithm.cst_decode();
+            let api_capacity_bytes = capacity_bytes.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::evfs::vault_create(
                         api_path,
                         api_key,
@@ -1660,32 +1211,20 @@ fn wire__crate__api__evfs__vault_create_impl(
 }
 fn wire__crate__api__evfs__vault_defragment_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_defragment",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1711,33 +1250,22 @@ fn wire__crate__api__evfs__vault_defragment_impl(
 }
 fn wire__crate__api__evfs__vault_delete_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    name: impl CstDecode<String>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_delete",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_name = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_name = name.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1764,32 +1292,20 @@ fn wire__crate__api__evfs__vault_delete_impl(
 }
 fn wire__crate__api__evfs__vault_health_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_health",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1816,32 +1332,20 @@ fn wire__crate__api__evfs__vault_health_impl(
 }
 fn wire__crate__api__evfs__vault_list_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_list",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
             move |context| {
-                transform_result_sse::<_, ()>((move || {
+                transform_result_dco::<_, _, ()>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1868,31 +1372,20 @@ fn wire__crate__api__evfs__vault_list_impl(
 }
 fn wire__crate__api__evfs__vault_open_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    path: impl CstDecode<String>,
+    key: impl CstDecode<Vec<u8>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_open",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_path = <String>::sse_decode(&mut deserializer);
-            let api_key = <Vec<u8>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_path = path.cst_decode();
+            let api_key = key.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::evfs::vault_open(api_path, api_key)?;
                     Ok(output_ok)
                 })())
@@ -1902,33 +1395,22 @@ fn wire__crate__api__evfs__vault_open_impl(
 }
 fn wire__crate__api__evfs__vault_read_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    name: impl CstDecode<String>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_read",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_name = <String>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_name = name.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -1954,42 +1436,28 @@ fn wire__crate__api__evfs__vault_read_impl(
 }
 fn wire__crate__api__evfs__vault_read_stream_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    name: impl CstDecode<String>,
+    verify_checksum: impl CstDecode<bool>,
+    sink: impl CstDecode<StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec>>,
+    on_progress: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_read_stream",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_name = <String>::sse_decode(&mut deserializer);
-            let api_verify_checksum = <bool>::sse_decode(&mut deserializer);
-            let api_sink =
-                <StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            let api_on_progress =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_name = name.cst_decode();
+            let api_verify_checksum = verify_checksum.cst_decode();
+            let api_sink = sink.cst_decode();
+            let api_on_progress = on_progress.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -2021,33 +1489,22 @@ fn wire__crate__api__evfs__vault_read_stream_impl(
 }
 fn wire__crate__api__evfs__vault_resize_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    new_capacity: impl CstDecode<u64>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_resize",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_new_capacity = <u64>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_new_capacity = new_capacity.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -2074,36 +1531,26 @@ fn wire__crate__api__evfs__vault_resize_impl(
 }
 fn wire__crate__api__evfs__vault_write_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    name: impl CstDecode<String>,
+    data: impl CstDecode<Vec<u8>>,
+    compression: impl CstDecode<Option<crate::api::compression::CompressionConfig>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_write",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_name = <String>::sse_decode(&mut deserializer);
-            let api_data = <Vec<u8>>::sse_decode(&mut deserializer);
-            let api_compression =
-                <Option<crate::api::compression::CompressionConfig>>::sse_decode(&mut deserializer);
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_name = name.cst_decode();
+            let api_data = data.cst_decode();
+            let api_compression = compression.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -2134,38 +1581,26 @@ fn wire__crate__api__evfs__vault_write_impl(
 }
 fn wire__crate__api__evfs__vault_write_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
-    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
-    rust_vec_len_: i32,
-    data_len_: i32,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    name: impl CstDecode<String>,
+    file_path: impl CstDecode<String>,
+    on_progress: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
 ) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::SseCodec, _, _>(
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
             debug_name: "vault_write_file",
             port: Some(port_),
             mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
         },
         move || {
-            let message = unsafe {
-                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
-                    ptr_,
-                    rust_vec_len_,
-                    data_len_,
-                )
-            };
-            let mut deserializer =
-                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
-            let api_handle = <RustOpaqueMoi<
-                flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
-            >>::sse_decode(&mut deserializer);
-            let api_name = <String>::sse_decode(&mut deserializer);
-            let api_file_path = <String>::sse_decode(&mut deserializer);
-            let api_on_progress =
-                <StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>>::sse_decode(
-                    &mut deserializer,
-                );
-            deserializer.end();
+            let api_handle = handle.cst_decode();
+            let api_name = name.cst_decode();
+            let api_file_path = file_path.cst_decode();
+            let api_on_progress = on_progress.cst_decode();
             move |context| {
-                transform_result_sse::<_, crate::core::error::CryptoError>((move || {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
                     let decode_indices_ =
                         flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
@@ -2195,20 +1630,71 @@ fn wire__crate__api__evfs__vault_write_file_impl(
     )
 }
 
-// Section: related_funcs
-
-flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
-    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>
-);
-flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
-    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>
-);
-flutter_rust_bridge::frb_generated_moi_arc_impl_value!(
-    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>
-);
-
 // Section: dart2rust
 
+impl CstDecode<crate::api::hashing::argon2::Argon2Preset> for i32 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::hashing::argon2::Argon2Preset {
+        match self {
+            0 => crate::api::hashing::argon2::Argon2Preset::Mobile,
+            1 => crate::api::hashing::argon2::Argon2Preset::Desktop,
+            _ => unreachable!("Invalid variant for Argon2Preset: {}", self),
+        }
+    }
+}
+impl CstDecode<bool> for bool {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> bool {
+        self
+    }
+}
+impl CstDecode<crate::api::compression::CompressionAlgorithm> for i32 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::compression::CompressionAlgorithm {
+        match self {
+            0 => crate::api::compression::CompressionAlgorithm::Zstd,
+            1 => crate::api::compression::CompressionAlgorithm::Brotli,
+            2 => crate::api::compression::CompressionAlgorithm::None,
+            _ => unreachable!("Invalid variant for CompressionAlgorithm: {}", self),
+        }
+    }
+}
+impl CstDecode<f64> for f64 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> f64 {
+        self
+    }
+}
+impl CstDecode<i32> for i32 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> i32 {
+        self
+    }
+}
+impl CstDecode<u32> for u32 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> u32 {
+        self
+    }
+}
+impl CstDecode<u64> for u64 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> u64 {
+        self
+    }
+}
+impl CstDecode<u8> for u8 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> u8 {
+        self
+    }
+}
+impl CstDecode<usize> for usize {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> usize {
+        self
+    }
+}
 impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2220,7 +1706,7 @@ impl SseDecode for flutter_rust_bridge::for_generated::anyhow::Error {
 impl SseDecode for CipherHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <RustOpaqueMoi<
+        let mut inner = <RustOpaqueNom<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
@@ -2230,7 +1716,7 @@ impl SseDecode for CipherHandle {
 impl SseDecode for HasherHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <RustOpaqueMoi<
+        let mut inner = <RustOpaqueNom<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
@@ -2240,7 +1726,7 @@ impl SseDecode for HasherHandle {
 impl SseDecode for VaultHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
-        let mut inner = <RustOpaqueMoi<
+        let mut inner = <RustOpaqueNom<
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
@@ -2248,36 +1734,36 @@ impl SseDecode for VaultHandle {
 }
 
 impl SseDecode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
+    for RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <usize>::sse_decode(deserializer);
-        return decode_rust_opaque_moi(inner);
+        return unsafe { decode_rust_opaque_nom(inner) };
     }
 }
 
 impl SseDecode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
+    for RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <usize>::sse_decode(deserializer);
-        return decode_rust_opaque_moi(inner);
+        return unsafe { decode_rust_opaque_nom(inner) };
     }
 }
 
 impl SseDecode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
+    for RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <usize>::sse_decode(deserializer);
-        return decode_rust_opaque_moi(inner);
+        return unsafe { decode_rust_opaque_nom(inner) };
     }
 }
 
-impl SseDecode for StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec> {
+impl SseDecode for StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <String>::sse_decode(deserializer);
@@ -2285,7 +1771,7 @@ impl SseDecode for StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec>
     }
 }
 
-impl SseDecode for StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::SseCodec> {
+impl SseDecode for StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut inner = <String>::sse_decode(deserializer);
@@ -2591,137 +2077,6 @@ fn pde_ffi_dispatcher_primary_impl(
 ) {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        1 => wire__crate__api__evfs__types__VaultHandle_health_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        2 => {
-            wire__crate__api__hashing__argon2__argon2id_hash_impl(port, ptr, rust_vec_len, data_len)
-        }
-        3 => wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        4 => wire__crate__api__hashing__argon2__argon2id_verify_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        5 => wire__crate__api__hashing__blake3_hash_impl(port, ptr, rust_vec_len, data_len),
-        6 => wire__crate__api__compression__compress_impl(port, ptr, rust_vec_len, data_len),
-        7 => wire__crate__api__compression__compression_algorithm_from_u8_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        8 => wire__crate__api__compression__compression_algorithm_to_u8_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        9 => {
-            wire__crate__api__encryption__create_aes256_gcm_impl(port, ptr, rust_vec_len, data_len)
-        }
-        10 => wire__crate__api__hashing__create_blake3_impl(port, ptr, rust_vec_len, data_len),
-        11 => wire__crate__api__encryption__create_chacha20_poly1305_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        12 => wire__crate__api__encryption__create_noop_encryption_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        13 => wire__crate__api__hashing__create_sha3_impl(port, ptr, rust_vec_len, data_len),
-        14 => wire__crate__api__compression__decompress_impl(port, ptr, rust_vec_len, data_len),
-        15 => wire__crate__api__encryption__decrypt_impl(port, ptr, rust_vec_len, data_len),
-        16 => wire__crate__api__encryption__encrypt_impl(port, ptr, rust_vec_len, data_len),
-        17 => wire__crate__api__encryption__encryption_algorithm_id_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        18 => wire__crate__api__encryption__generate_aes256_gcm_key_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        19 => wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        20 => wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        21 => wire__crate__api__encryption__chacha20__generate_chacha_key_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        22 => {
-            wire__crate__api__hashing__hasher_algorithm_id_impl(port, ptr, rust_vec_len, data_len)
-        }
-        23 => wire__crate__api__hashing__hasher_finalize_impl(port, ptr, rust_vec_len, data_len),
-        24 => wire__crate__api__hashing__hasher_reset_impl(port, ptr, rust_vec_len, data_len),
-        25 => wire__crate__api__hashing__hasher_update_impl(port, ptr, rust_vec_len, data_len),
-        27 => wire__crate__api__kdf__hkdf__hkdf_expand_impl(port, ptr, rust_vec_len, data_len),
-        29 => wire__crate__api__hashing__sha3_hash_impl(port, ptr, rust_vec_len, data_len),
-        30 => wire__crate__api__compression__should_skip_compression_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        31 => wire__crate__api__streaming__stream_compress_encrypt_file_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        32 => wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
-            port,
-            ptr,
-            rust_vec_len,
-            data_len,
-        ),
-        33 => {
-            wire__crate__api__streaming__stream_decrypt_file_impl(port, ptr, rust_vec_len, data_len)
-        }
-        34 => {
-            wire__crate__api__streaming__stream_encrypt_file_impl(port, ptr, rust_vec_len, data_len)
-        }
-        35 => wire__crate__api__streaming__stream_hash_file_impl(port, ptr, rust_vec_len, data_len),
-        36 => wire__crate__api__evfs__vault_capacity_impl(port, ptr, rust_vec_len, data_len),
-        37 => wire__crate__api__evfs__vault_close_impl(port, ptr, rust_vec_len, data_len),
-        38 => wire__crate__api__evfs__vault_create_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__evfs__vault_defragment_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__evfs__vault_delete_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__evfs__vault_health_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__evfs__vault_list_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__evfs__vault_open_impl(port, ptr, rust_vec_len, data_len),
-        44 => wire__crate__api__evfs__vault_read_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__evfs__vault_read_stream_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__evfs__vault_resize_impl(port, ptr, rust_vec_len, data_len),
-        47 => wire__crate__api__evfs__vault_write_impl(port, ptr, rust_vec_len, data_len),
-        48 => wire__crate__api__evfs__vault_write_file_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2734,8 +2089,6 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        26 => wire__crate__api__kdf__hkdf__hkdf_derive_impl(ptr, rust_vec_len, data_len),
-        28 => wire__crate__api__kdf__hkdf__hkdf_extract_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -2745,7 +2098,7 @@ fn pde_ffi_dispatcher_sync_impl(
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<CipherHandle> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self.0)
             .into_dart()
     }
 }
@@ -2760,7 +2113,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<CipherHandle>> for CipherHandl
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<HasherHandle> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self.0)
             .into_dart()
     }
 }
@@ -2775,7 +2128,7 @@ impl flutter_rust_bridge::IntoIntoDart<FrbWrapper<HasherHandle>> for HasherHandl
 // Codec=Dco (DartCObject based), see doc to use other codecs
 impl flutter_rust_bridge::IntoDart for FrbWrapper<VaultHandle> {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
-        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self.0)
+        flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self.0)
             .into_dart()
     }
 }
@@ -2997,26 +2350,26 @@ impl SseEncode for flutter_rust_bridge::for_generated::anyhow::Error {
 impl SseEncode for CipherHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+        <RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self), serializer);
     }
 }
 
 impl SseEncode for HasherHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+        <RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self), serializer);
     }
 }
 
 impl SseEncode for VaultHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
-        <RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, MoiArc<_>>(self), serializer);
+        <RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self), serializer);
     }
 }
 
 impl SseEncode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
+    for RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3027,7 +2380,7 @@ impl SseEncode
 }
 
 impl SseEncode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
+    for RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3038,7 +2391,7 @@ impl SseEncode
 }
 
 impl SseEncode
-    for RustOpaqueMoi<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
+    for RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
 {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -3048,14 +2401,14 @@ impl SseEncode
     }
 }
 
-impl SseEncode for StreamSink<f64, flutter_rust_bridge::for_generated::SseCodec> {
+impl SseEncode for StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         unimplemented!("")
     }
 }
 
-impl SseEncode for StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::SseCodec> {
+impl SseEncode for StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         unimplemented!("")
@@ -3338,46 +2691,1017 @@ mod io {
 
     flutter_rust_bridge::frb_generated_boilerplate_io!();
 
+    // Section: dart2rust
+
+    impl CstDecode<flutter_rust_bridge::for_generated::anyhow::Error>
+        for *mut wire_cst_list_prim_u_8_strict
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> flutter_rust_bridge::for_generated::anyhow::Error {
+            unimplemented!()
+        }
+    }
+    impl CstDecode<CipherHandle> for usize {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> CipherHandle {
+            flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(CstDecode::<
+                RustOpaqueNom<
+                    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
+                >,
+            >::cst_decode(
+                self
+            ))
+        }
+    }
+    impl CstDecode<HasherHandle> for usize {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> HasherHandle {
+            flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(CstDecode::<
+                RustOpaqueNom<
+                    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
+                >,
+            >::cst_decode(
+                self
+            ))
+        }
+    }
+    impl CstDecode<VaultHandle> for usize {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> VaultHandle {
+            flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(CstDecode::<
+                RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+            >::cst_decode(
+                self
+            ))
+        }
+    }
+    impl
+        CstDecode<
+            RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+        > for usize
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(
+            self,
+        ) -> RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
+        {
+            unsafe { decode_rust_opaque_nom(self as _) }
+        }
+    }
+    impl
+        CstDecode<
+            RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+        > for usize
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(
+            self,
+        ) -> RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
+        {
+            unsafe { decode_rust_opaque_nom(self as _) }
+        }
+    }
+    impl
+        CstDecode<
+            RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+        > for usize
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(
+            self,
+        ) -> RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
+        {
+            unsafe { decode_rust_opaque_nom(self as _) }
+        }
+    }
+    impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>
+        for *mut wire_cst_list_prim_u_8_strict
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec> {
+            let raw: String = self.cst_decode();
+            StreamSink::deserialize(raw)
+        }
+    }
+    impl CstDecode<StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec>>
+        for *mut wire_cst_list_prim_u_8_strict
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec> {
+            let raw: String = self.cst_decode();
+            StreamSink::deserialize(raw)
+        }
+    }
+    impl CstDecode<String> for *mut wire_cst_list_prim_u_8_strict {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> String {
+            let vec: Vec<u8> = self.cst_decode();
+            String::from_utf8(vec).unwrap()
+        }
+    }
+    impl CstDecode<crate::api::compression::CompressionConfig> for *mut wire_cst_compression_config {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::compression::CompressionConfig {
+            let wrap = unsafe { flutter_rust_bridge::for_generated::box_from_leak_ptr(self) };
+            CstDecode::<crate::api::compression::CompressionConfig>::cst_decode(*wrap).into()
+        }
+    }
+    impl CstDecode<i32> for *mut i32 {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> i32 {
+            unsafe { *flutter_rust_bridge::for_generated::box_from_leak_ptr(self) }
+        }
+    }
+    impl CstDecode<crate::api::compression::CompressionConfig> for wire_cst_compression_config {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::compression::CompressionConfig {
+            crate::api::compression::CompressionConfig {
+                algorithm: self.algorithm.cst_decode(),
+                level: self.level.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::core::error::CryptoError> for wire_cst_crypto_error {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::core::error::CryptoError {
+            match self.tag {
+                0 => {
+                    let ans = unsafe { self.kind.InvalidKeyLength };
+                    crate::core::error::CryptoError::InvalidKeyLength {
+                        expected: ans.expected.cst_decode(),
+                        actual: ans.actual.cst_decode(),
+                    }
+                }
+                1 => crate::core::error::CryptoError::InvalidNonce,
+                2 => {
+                    let ans = unsafe { self.kind.EncryptionFailed };
+                    crate::core::error::CryptoError::EncryptionFailed(ans.field0.cst_decode())
+                }
+                3 => crate::core::error::CryptoError::DecryptionFailed,
+                4 => {
+                    let ans = unsafe { self.kind.HashingFailed };
+                    crate::core::error::CryptoError::HashingFailed(ans.field0.cst_decode())
+                }
+                5 => {
+                    let ans = unsafe { self.kind.KdfFailed };
+                    crate::core::error::CryptoError::KdfFailed(ans.field0.cst_decode())
+                }
+                6 => {
+                    let ans = unsafe { self.kind.IoError };
+                    crate::core::error::CryptoError::IoError(ans.field0.cst_decode())
+                }
+                7 => {
+                    let ans = unsafe { self.kind.InvalidParameter };
+                    crate::core::error::CryptoError::InvalidParameter(ans.field0.cst_decode())
+                }
+                8 => {
+                    let ans = unsafe { self.kind.CompressionFailed };
+                    crate::core::error::CryptoError::CompressionFailed(ans.field0.cst_decode())
+                }
+                9 => crate::core::error::CryptoError::AuthenticationFailed,
+                10 => {
+                    let ans = unsafe { self.kind.VaultFull };
+                    crate::core::error::CryptoError::VaultFull {
+                        needed: ans.needed.cst_decode(),
+                        available: ans.available.cst_decode(),
+                    }
+                }
+                11 => crate::core::error::CryptoError::VaultLocked,
+                12 => {
+                    let ans = unsafe { self.kind.SegmentNotFound };
+                    crate::core::error::CryptoError::SegmentNotFound(ans.field0.cst_decode())
+                }
+                13 => {
+                    let ans = unsafe { self.kind.VaultCorrupted };
+                    crate::core::error::CryptoError::VaultCorrupted(ans.field0.cst_decode())
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::DefragResult> for wire_cst_defrag_result {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::DefragResult {
+            crate::api::evfs::types::DefragResult {
+                segments_moved: self.segments_moved.cst_decode(),
+                bytes_reclaimed: self.bytes_reclaimed.cst_decode(),
+                free_regions_before: self.free_regions_before.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<Vec<String>> for *mut wire_cst_list_String {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<String> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
+    impl CstDecode<Vec<u8>> for *mut wire_cst_list_prim_u_8_loose {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<u8> {
+            unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            }
+        }
+    }
+    impl CstDecode<Vec<u8>> for *mut wire_cst_list_prim_u_8_strict {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<u8> {
+            unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::VaultCapacityInfo> for wire_cst_vault_capacity_info {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::VaultCapacityInfo {
+            crate::api::evfs::types::VaultCapacityInfo {
+                total_bytes: self.total_bytes.cst_decode(),
+                used_bytes: self.used_bytes.cst_decode(),
+                free_list_bytes: self.free_list_bytes.cst_decode(),
+                unallocated_bytes: self.unallocated_bytes.cst_decode(),
+                segment_count: self.segment_count.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::VaultHealthInfo> for wire_cst_vault_health_info {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::VaultHealthInfo {
+            crate::api::evfs::types::VaultHealthInfo {
+                total_bytes: self.total_bytes.cst_decode(),
+                used_bytes: self.used_bytes.cst_decode(),
+                free_list_bytes: self.free_list_bytes.cst_decode(),
+                unallocated_bytes: self.unallocated_bytes.cst_decode(),
+                segment_count: self.segment_count.cst_decode(),
+                free_region_count: self.free_region_count.cst_decode(),
+                largest_free_block: self.largest_free_block.cst_decode(),
+                fragmentation_ratio: self.fragmentation_ratio.cst_decode(),
+                is_consistent: self.is_consistent.cst_decode(),
+            }
+        }
+    }
+    impl NewWithNullPtr for wire_cst_compression_config {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                algorithm: Default::default(),
+                level: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_compression_config {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_crypto_error {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                tag: -1,
+                kind: CryptoErrorKind { nil__: () },
+            }
+        }
+    }
+    impl Default for wire_cst_crypto_error {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_defrag_result {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                segments_moved: Default::default(),
+                bytes_reclaimed: Default::default(),
+                free_regions_before: Default::default(),
+            }
+        }
+    }
+    impl Default for wire_cst_defrag_result {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_vault_capacity_info {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                total_bytes: Default::default(),
+                used_bytes: Default::default(),
+                free_list_bytes: Default::default(),
+                unallocated_bytes: Default::default(),
+                segment_count: Default::default(),
+            }
+        }
+    }
+    impl Default for wire_cst_vault_capacity_info {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_vault_health_info {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                total_bytes: Default::default(),
+                used_bytes: Default::default(),
+                free_list_bytes: Default::default(),
+                unallocated_bytes: Default::default(),
+                segment_count: Default::default(),
+                free_region_count: Default::default(),
+                largest_free_block: Default::default(),
+                fragmentation_ratio: Default::default(),
+                is_consistent: Default::default(),
+            }
+        }
+    }
+    impl Default for wire_cst_vault_health_info {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__types__VaultHandle_health(
+        port_: i64,
+        that: usize,
+    ) {
+        wire__crate__api__evfs__types__VaultHandle_health_impl(port_, that)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__argon2__argon2id_hash(
+        port_: i64,
+        password: *mut wire_cst_list_prim_u_8_strict,
+        preset: i32,
+    ) {
+        wire__crate__api__hashing__argon2__argon2id_hash_impl(port_, password, preset)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+        port_: i64,
+        password: *mut wire_cst_list_prim_u_8_strict,
+        salt: *mut wire_cst_list_prim_u_8_strict,
+        preset: i32,
+    ) {
+        wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
+            port_, password, salt, preset,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__argon2__argon2id_verify(
+        port_: i64,
+        phc_hash: *mut wire_cst_list_prim_u_8_strict,
+        password: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__hashing__argon2__argon2id_verify_impl(port_, phc_hash, password)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__blake3_hash(
+        port_: i64,
+        data: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__hashing__blake3_hash_impl(port_, data)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__compression__compress(
+        port_: i64,
+        data: *mut wire_cst_list_prim_u_8_loose,
+        config: *mut wire_cst_compression_config,
+    ) {
+        wire__crate__api__compression__compress_impl(port_, data, config)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__compression__compression_algorithm_from_u8(
+        port_: i64,
+        byte: u8,
+    ) {
+        wire__crate__api__compression__compression_algorithm_from_u8_impl(port_, byte)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__compression__compression_algorithm_to_u8(
+        port_: i64,
+        that: i32,
+    ) {
+        wire__crate__api__compression__compression_algorithm_to_u8_impl(port_, that)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__create_aes256_gcm(
+        port_: i64,
+        key: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__encryption__create_aes256_gcm_impl(port_, key)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__create_blake3(port_: i64) {
+        wire__crate__api__hashing__create_blake3_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__create_chacha20_poly1305(
+        port_: i64,
+        key: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__encryption__create_chacha20_poly1305_impl(port_, key)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__create_noop_encryption(
+        port_: i64,
+    ) {
+        wire__crate__api__encryption__create_noop_encryption_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__create_sha3(port_: i64) {
+        wire__crate__api__hashing__create_sha3_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__compression__decompress(
+        port_: i64,
+        data: *mut wire_cst_list_prim_u_8_loose,
+        algorithm: i32,
+    ) {
+        wire__crate__api__compression__decompress_impl(port_, data, algorithm)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__decrypt(
+        port_: i64,
+        cipher: usize,
+        ciphertext: *mut wire_cst_list_prim_u_8_loose,
+        aad: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__encryption__decrypt_impl(port_, cipher, ciphertext, aad)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__encrypt(
+        port_: i64,
+        cipher: usize,
+        plaintext: *mut wire_cst_list_prim_u_8_loose,
+        aad: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__encryption__encrypt_impl(port_, cipher, plaintext, aad)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__encryption_algorithm_id(
+        port_: i64,
+        cipher: usize,
+    ) {
+        wire__crate__api__encryption__encryption_algorithm_id_impl(port_, cipher)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__generate_aes256_gcm_key(
+        port_: i64,
+    ) {
+        wire__crate__api__encryption__generate_aes256_gcm_key_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__aes_gcm__generate_aes_key(
+        port_: i64,
+    ) {
+        wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__generate_chacha20_poly1305_key(
+        port_: i64,
+    ) {
+        wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__encryption__chacha20__generate_chacha_key(
+        port_: i64,
+    ) {
+        wire__crate__api__encryption__chacha20__generate_chacha_key_impl(port_)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__hasher_algorithm_id(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__hashing__hasher_algorithm_id_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__hasher_finalize(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__hashing__hasher_finalize_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__hasher_reset(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__hashing__hasher_reset_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__hasher_update(
+        port_: i64,
+        handle: usize,
+        data: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__hashing__hasher_update_impl(port_, handle, data)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__kdf__hkdf__hkdf_derive(
+        ikm: *mut wire_cst_list_prim_u_8_loose,
+        salt: *mut wire_cst_list_prim_u_8_strict,
+        info: *mut wire_cst_list_prim_u_8_loose,
+        output_len: usize,
+    ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+        wire__crate__api__kdf__hkdf__hkdf_derive_impl(ikm, salt, info, output_len)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__kdf__hkdf__hkdf_expand(
+        port_: i64,
+        prk: *mut wire_cst_list_prim_u_8_loose,
+        info: *mut wire_cst_list_prim_u_8_loose,
+        output_len: usize,
+    ) {
+        wire__crate__api__kdf__hkdf__hkdf_expand_impl(port_, prk, info, output_len)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__kdf__hkdf__hkdf_extract(
+        ikm: *mut wire_cst_list_prim_u_8_loose,
+        salt: *mut wire_cst_list_prim_u_8_strict,
+    ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+        wire__crate__api__kdf__hkdf__hkdf_extract_impl(ikm, salt)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__hashing__sha3_hash(
+        port_: i64,
+        data: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__hashing__sha3_hash_impl(port_, data)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__compression__should_skip_compression(
+        port_: i64,
+        file_path: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__compression__should_skip_compression_impl(port_, file_path)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_compress_encrypt_file(
+        port_: i64,
+        cipher: usize,
+        compression: *mut wire_cst_compression_config,
+        input_path: *mut wire_cst_list_prim_u_8_strict,
+        output_path: *mut wire_cst_list_prim_u_8_strict,
+        progress_sink: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__streaming__stream_compress_encrypt_file_impl(
+            port_,
+            cipher,
+            compression,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_decrypt_decompress_file(
+        port_: i64,
+        cipher: usize,
+        input_path: *mut wire_cst_list_prim_u_8_strict,
+        output_path: *mut wire_cst_list_prim_u_8_strict,
+        progress_sink: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
+            port_,
+            cipher,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_decrypt_file(
+        port_: i64,
+        cipher: usize,
+        input_path: *mut wire_cst_list_prim_u_8_strict,
+        output_path: *mut wire_cst_list_prim_u_8_strict,
+        progress_sink: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__streaming__stream_decrypt_file_impl(
+            port_,
+            cipher,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_encrypt_file(
+        port_: i64,
+        cipher: usize,
+        input_path: *mut wire_cst_list_prim_u_8_strict,
+        output_path: *mut wire_cst_list_prim_u_8_strict,
+        progress_sink: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__streaming__stream_encrypt_file_impl(
+            port_,
+            cipher,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_hash_file(
+        port_: i64,
+        hasher: usize,
+        file_path: *mut wire_cst_list_prim_u_8_strict,
+        progress_sink: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__streaming__stream_hash_file_impl(port_, hasher, file_path, progress_sink)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_capacity(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__evfs__vault_capacity_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_close(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__evfs__vault_close_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_create(
+        port_: i64,
+        path: *mut wire_cst_list_prim_u_8_strict,
+        key: *mut wire_cst_list_prim_u_8_loose,
+        algorithm: *mut wire_cst_list_prim_u_8_strict,
+        capacity_bytes: u64,
+    ) {
+        wire__crate__api__evfs__vault_create_impl(port_, path, key, algorithm, capacity_bytes)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_defragment(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__evfs__vault_defragment_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_delete(
+        port_: i64,
+        handle: usize,
+        name: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__evfs__vault_delete_impl(port_, handle, name)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_health(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__evfs__vault_health_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_list(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__evfs__vault_list_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_open(
+        port_: i64,
+        path: *mut wire_cst_list_prim_u_8_strict,
+        key: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__evfs__vault_open_impl(port_, path, key)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_read(
+        port_: i64,
+        handle: usize,
+        name: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__evfs__vault_read_impl(port_, handle, name)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_read_stream(
+        port_: i64,
+        handle: usize,
+        name: *mut wire_cst_list_prim_u_8_strict,
+        verify_checksum: bool,
+        sink: *mut wire_cst_list_prim_u_8_strict,
+        on_progress: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__evfs__vault_read_stream_impl(
+            port_,
+            handle,
+            name,
+            verify_checksum,
+            sink,
+            on_progress,
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_resize(
+        port_: i64,
+        handle: usize,
+        new_capacity: u64,
+    ) {
+        wire__crate__api__evfs__vault_resize_impl(port_, handle, new_capacity)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_write(
+        port_: i64,
+        handle: usize,
+        name: *mut wire_cst_list_prim_u_8_strict,
+        data: *mut wire_cst_list_prim_u_8_loose,
+        compression: *mut wire_cst_compression_config,
+    ) {
+        wire__crate__api__evfs__vault_write_impl(port_, handle, name, data, compression)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_write_file(
+        port_: i64,
+        handle: usize,
+        name: *mut wire_cst_list_prim_u_8_strict,
+        file_path: *mut wire_cst_list_prim_u_8_strict,
+        on_progress: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__evfs__vault_write_file_impl(port_, handle, name, file_path, on_progress)
+    }
+
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::increment_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::increment_strong_count(ptr as _);
+        }
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::decrement_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::decrement_strong_count(ptr as _);
+        }
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::increment_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::increment_strong_count(ptr as _);
+        }
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::decrement_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::decrement_strong_count(ptr as _);
+        }
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::increment_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::increment_strong_count(ptr as _);
+        }
     }
 
     #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::decrement_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::decrement_strong_count(ptr as _);
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_box_autoadd_compression_config(
+    ) -> *mut wire_cst_compression_config {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(
+            wire_cst_compression_config::new_with_null_ptr(),
+        )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_box_autoadd_i_32(value: i32) -> *mut i32 {
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(value)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_list_String(len: i32) -> *mut wire_cst_list_String {
+        let wrap = wire_cst_list_String {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <*mut wire_cst_list_prim_u_8_strict>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_list_prim_u_8_loose(
+        len: i32,
+    ) -> *mut wire_cst_list_prim_u_8_loose {
+        let ans = wire_cst_list_prim_u_8_loose {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(Default::default(), len),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_list_prim_u_8_strict(
+        len: i32,
+    ) -> *mut wire_cst_list_prim_u_8_strict {
+        let ans = wire_cst_list_prim_u_8_strict {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(Default::default(), len),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_compression_config {
+        algorithm: i32,
+        level: *mut i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_crypto_error {
+        tag: i32,
+        kind: CryptoErrorKind,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub union CryptoErrorKind {
+        InvalidKeyLength: wire_cst_CryptoError_InvalidKeyLength,
+        EncryptionFailed: wire_cst_CryptoError_EncryptionFailed,
+        HashingFailed: wire_cst_CryptoError_HashingFailed,
+        KdfFailed: wire_cst_CryptoError_KdfFailed,
+        IoError: wire_cst_CryptoError_IoError,
+        InvalidParameter: wire_cst_CryptoError_InvalidParameter,
+        CompressionFailed: wire_cst_CryptoError_CompressionFailed,
+        VaultFull: wire_cst_CryptoError_VaultFull,
+        SegmentNotFound: wire_cst_CryptoError_SegmentNotFound,
+        VaultCorrupted: wire_cst_CryptoError_VaultCorrupted,
+        nil__: (),
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_InvalidKeyLength {
+        expected: usize,
+        actual: usize,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_EncryptionFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_HashingFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_KdfFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_IoError {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_InvalidParameter {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_CompressionFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_VaultFull {
+        needed: u64,
+        available: u64,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_SegmentNotFound {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_VaultCorrupted {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_defrag_result {
+        segments_moved: u32,
+        bytes_reclaimed: u64,
+        free_regions_before: u32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_String {
+        ptr: *mut *mut wire_cst_list_prim_u_8_strict,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_prim_u_8_loose {
+        ptr: *mut u8,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_prim_u_8_strict {
+        ptr: *mut u8,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_vault_capacity_info {
+        total_bytes: u64,
+        used_bytes: u64,
+        free_list_bytes: u64,
+        unallocated_bytes: u64,
+        segment_count: usize,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_vault_health_info {
+        total_bytes: u64,
+        used_bytes: u64,
+        free_list_bytes: u64,
+        unallocated_bytes: u64,
+        segment_count: u32,
+        free_region_count: u32,
+        largest_free_block: u64,
+        fragmentation_ratio: f64,
+        is_consistent: bool,
     }
 }
 #[cfg(not(target_family = "wasm"))]
@@ -3407,46 +3731,868 @@ mod web {
 
     flutter_rust_bridge::frb_generated_boilerplate_web!();
 
+    // Section: dart2rust
+
+    impl CstDecode<flutter_rust_bridge::for_generated::anyhow::Error> for String {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> flutter_rust_bridge::for_generated::anyhow::Error {
+            unimplemented!()
+        }
+    }
+    impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>> for String {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec> {
+            StreamSink::deserialize(self)
+        }
+    }
+    impl CstDecode<StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec>> for String {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec> {
+            StreamSink::deserialize(self)
+        }
+    }
+    impl CstDecode<String> for String {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> String {
+            self
+        }
+    }
+    impl CstDecode<crate::api::compression::CompressionConfig>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::compression::CompressionConfig {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                2,
+                "Expected 2 elements, got {}",
+                self_.length()
+            );
+            crate::api::compression::CompressionConfig {
+                algorithm: self_.get(0).cst_decode(),
+                level: self_.get(1).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::core::error::CryptoError>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::core::error::CryptoError {
+            let self_ = self.unchecked_into::<flutter_rust_bridge::for_generated::js_sys::Array>();
+            match self_.get(0).unchecked_into_f64() as _ {
+                0 => crate::core::error::CryptoError::InvalidKeyLength {
+                    expected: self_.get(1).cst_decode(),
+                    actual: self_.get(2).cst_decode(),
+                },
+                1 => crate::core::error::CryptoError::InvalidNonce,
+                2 => crate::core::error::CryptoError::EncryptionFailed(self_.get(1).cst_decode()),
+                3 => crate::core::error::CryptoError::DecryptionFailed,
+                4 => crate::core::error::CryptoError::HashingFailed(self_.get(1).cst_decode()),
+                5 => crate::core::error::CryptoError::KdfFailed(self_.get(1).cst_decode()),
+                6 => crate::core::error::CryptoError::IoError(self_.get(1).cst_decode()),
+                7 => crate::core::error::CryptoError::InvalidParameter(self_.get(1).cst_decode()),
+                8 => crate::core::error::CryptoError::CompressionFailed(self_.get(1).cst_decode()),
+                9 => crate::core::error::CryptoError::AuthenticationFailed,
+                10 => crate::core::error::CryptoError::VaultFull {
+                    needed: self_.get(1).cst_decode(),
+                    available: self_.get(2).cst_decode(),
+                },
+                11 => crate::core::error::CryptoError::VaultLocked,
+                12 => crate::core::error::CryptoError::SegmentNotFound(self_.get(1).cst_decode()),
+                13 => crate::core::error::CryptoError::VaultCorrupted(self_.get(1).cst_decode()),
+                _ => unreachable!(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::DefragResult>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::DefragResult {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                3,
+                "Expected 3 elements, got {}",
+                self_.length()
+            );
+            crate::api::evfs::types::DefragResult {
+                segments_moved: self_.get(0).cst_decode(),
+                bytes_reclaimed: self_.get(1).cst_decode(),
+                free_regions_before: self_.get(2).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<Vec<String>> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<String> {
+            self.dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap()
+                .iter()
+                .map(CstDecode::cst_decode)
+                .collect()
+        }
+    }
+    impl CstDecode<Vec<u8>> for Box<[u8]> {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<u8> {
+            self.into_vec()
+        }
+    }
+    impl CstDecode<Option<Vec<u8>>> for Option<Box<[u8]>> {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Option<Vec<u8>> {
+            self.map(CstDecode::cst_decode)
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::VaultCapacityInfo>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::VaultCapacityInfo {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                5,
+                "Expected 5 elements, got {}",
+                self_.length()
+            );
+            crate::api::evfs::types::VaultCapacityInfo {
+                total_bytes: self_.get(0).cst_decode(),
+                used_bytes: self_.get(1).cst_decode(),
+                free_list_bytes: self_.get(2).cst_decode(),
+                unallocated_bytes: self_.get(3).cst_decode(),
+                segment_count: self_.get(4).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::VaultHealthInfo>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::VaultHealthInfo {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                9,
+                "Expected 9 elements, got {}",
+                self_.length()
+            );
+            crate::api::evfs::types::VaultHealthInfo {
+                total_bytes: self_.get(0).cst_decode(),
+                used_bytes: self_.get(1).cst_decode(),
+                free_list_bytes: self_.get(2).cst_decode(),
+                unallocated_bytes: self_.get(3).cst_decode(),
+                segment_count: self_.get(4).cst_decode(),
+                free_region_count: self_.get(5).cst_decode(),
+                largest_free_block: self_.get(6).cst_decode(),
+                fragmentation_ratio: self_.get(7).cst_decode(),
+                is_consistent: self_.get(8).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<flutter_rust_bridge::for_generated::anyhow::Error>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> flutter_rust_bridge::for_generated::anyhow::Error {
+            unimplemented!()
+        }
+    }
+    impl CstDecode<CipherHandle> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> CipherHandle {
+            flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(CstDecode::<
+                RustOpaqueNom<
+                    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>,
+                >,
+            >::cst_decode(
+                self
+            ))
+        }
+    }
+    impl CstDecode<HasherHandle> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> HasherHandle {
+            flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(CstDecode::<
+                RustOpaqueNom<
+                    flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>,
+                >,
+            >::cst_decode(
+                self
+            ))
+        }
+    }
+    impl CstDecode<VaultHandle> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> VaultHandle {
+            flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(CstDecode::<
+                RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+            >::cst_decode(
+                self
+            ))
+        }
+    }
+    impl
+        CstDecode<
+            RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
+        > for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(
+            self,
+        ) -> RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>
+        {
+            #[cfg(target_pointer_width = "64")]
+            {
+                compile_error!("64-bit pointers are not supported.");
+            }
+            unsafe { decode_rust_opaque_nom((self.as_f64().unwrap() as usize) as _) }
+        }
+    }
+    impl
+        CstDecode<
+            RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>,
+        > for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(
+            self,
+        ) -> RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>
+        {
+            #[cfg(target_pointer_width = "64")]
+            {
+                compile_error!("64-bit pointers are not supported.");
+            }
+            unsafe { decode_rust_opaque_nom((self.as_f64().unwrap() as usize) as _) }
+        }
+    }
+    impl
+        CstDecode<
+            RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+        > for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(
+            self,
+        ) -> RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
+        {
+            #[cfg(target_pointer_width = "64")]
+            {
+                compile_error!("64-bit pointers are not supported.");
+            }
+            unsafe { decode_rust_opaque_nom((self.as_f64().unwrap() as usize) as _) }
+        }
+    }
+    impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec> {
+            StreamSink::deserialize(self.as_string().expect("should be a string"))
+        }
+    }
+    impl CstDecode<StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> StreamSink<Vec<u8>, flutter_rust_bridge::for_generated::DcoCodec> {
+            StreamSink::deserialize(self.as_string().expect("should be a string"))
+        }
+    }
+    impl CstDecode<String> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> String {
+            self.as_string().expect("non-UTF-8 string, or not a string")
+        }
+    }
+    impl CstDecode<crate::api::hashing::argon2::Argon2Preset>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::hashing::argon2::Argon2Preset {
+            (self.unchecked_into_f64() as i32).cst_decode()
+        }
+    }
+    impl CstDecode<bool> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> bool {
+            self.is_truthy()
+        }
+    }
+    impl CstDecode<crate::api::compression::CompressionAlgorithm>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::compression::CompressionAlgorithm {
+            (self.unchecked_into_f64() as i32).cst_decode()
+        }
+    }
+    impl CstDecode<f64> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> f64 {
+            self.unchecked_into_f64() as _
+        }
+    }
+    impl CstDecode<i32> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> i32 {
+            self.unchecked_into_f64() as _
+        }
+    }
+    impl CstDecode<Vec<u8>> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<u8> {
+            self.unchecked_into::<flutter_rust_bridge::for_generated::js_sys::Uint8Array>()
+                .to_vec()
+                .into()
+        }
+    }
+    impl CstDecode<u32> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> u32 {
+            self.unchecked_into_f64() as _
+        }
+    }
+    impl CstDecode<u64> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> u64 {
+            ::std::convert::TryInto::<u64>::try_into(self).unwrap() as _
+        }
+    }
+    impl CstDecode<u8> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> u8 {
+            self.unchecked_into_f64() as _
+        }
+    }
+    impl CstDecode<usize> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> usize {
+            ::std::convert::TryInto::<u64>::try_into(self).unwrap() as _
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__types__VaultHandle_health(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        that: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__types__VaultHandle_health_impl(port_, that)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__argon2__argon2id_hash(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        password: String,
+        preset: i32,
+    ) {
+        wire__crate__api__hashing__argon2__argon2id_hash_impl(port_, password, preset)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__argon2__argon2id_hash_with_salt(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        password: String,
+        salt: String,
+        preset: i32,
+    ) {
+        wire__crate__api__hashing__argon2__argon2id_hash_with_salt_impl(
+            port_, password, salt, preset,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__argon2__argon2id_verify(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        phc_hash: String,
+        password: String,
+    ) {
+        wire__crate__api__hashing__argon2__argon2id_verify_impl(port_, phc_hash, password)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__blake3_hash(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        data: Box<[u8]>,
+    ) {
+        wire__crate__api__hashing__blake3_hash_impl(port_, data)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__compression__compress(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        data: Box<[u8]>,
+        config: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__compression__compress_impl(port_, data, config)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__compression__compression_algorithm_from_u8(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        byte: u8,
+    ) {
+        wire__crate__api__compression__compression_algorithm_from_u8_impl(port_, byte)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__compression__compression_algorithm_to_u8(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        that: i32,
+    ) {
+        wire__crate__api__compression__compression_algorithm_to_u8_impl(port_, that)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__create_aes256_gcm(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        key: Box<[u8]>,
+    ) {
+        wire__crate__api__encryption__create_aes256_gcm_impl(port_, key)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__create_blake3(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__hashing__create_blake3_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__create_chacha20_poly1305(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        key: Box<[u8]>,
+    ) {
+        wire__crate__api__encryption__create_chacha20_poly1305_impl(port_, key)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__create_noop_encryption(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__encryption__create_noop_encryption_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__create_sha3(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__hashing__create_sha3_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__compression__decompress(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        data: Box<[u8]>,
+        algorithm: i32,
+    ) {
+        wire__crate__api__compression__decompress_impl(port_, data, algorithm)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__decrypt(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        ciphertext: Box<[u8]>,
+        aad: Box<[u8]>,
+    ) {
+        wire__crate__api__encryption__decrypt_impl(port_, cipher, ciphertext, aad)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__encrypt(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        plaintext: Box<[u8]>,
+        aad: Box<[u8]>,
+    ) {
+        wire__crate__api__encryption__encrypt_impl(port_, cipher, plaintext, aad)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__encryption_algorithm_id(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__encryption__encryption_algorithm_id_impl(port_, cipher)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__generate_aes256_gcm_key(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__encryption__generate_aes256_gcm_key_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__aes_gcm__generate_aes_key(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__encryption__aes_gcm__generate_aes_key_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__generate_chacha20_poly1305_key(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__encryption__generate_chacha20_poly1305_key_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__encryption__chacha20__generate_chacha_key(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+    ) {
+        wire__crate__api__encryption__chacha20__generate_chacha_key_impl(port_)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__hasher_algorithm_id(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__hashing__hasher_algorithm_id_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__hasher_finalize(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__hashing__hasher_finalize_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__hasher_reset(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__hashing__hasher_reset_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__hasher_update(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        data: Box<[u8]>,
+    ) {
+        wire__crate__api__hashing__hasher_update_impl(port_, handle, data)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__kdf__hkdf__hkdf_derive(
+        ikm: Box<[u8]>,
+        salt: Option<Box<[u8]>>,
+        info: Box<[u8]>,
+        output_len: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+        wire__crate__api__kdf__hkdf__hkdf_derive_impl(ikm, salt, info, output_len)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__kdf__hkdf__hkdf_expand(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        prk: Box<[u8]>,
+        info: Box<[u8]>,
+        output_len: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__kdf__hkdf__hkdf_expand_impl(port_, prk, info, output_len)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__kdf__hkdf__hkdf_extract(
+        ikm: Box<[u8]>,
+        salt: Option<Box<[u8]>>,
+    ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartDco {
+        wire__crate__api__kdf__hkdf__hkdf_extract_impl(ikm, salt)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__hashing__sha3_hash(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        data: Box<[u8]>,
+    ) {
+        wire__crate__api__hashing__sha3_hash_impl(port_, data)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__compression__should_skip_compression(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        file_path: String,
+    ) {
+        wire__crate__api__compression__should_skip_compression_impl(port_, file_path)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__streaming__stream_compress_encrypt_file(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        compression: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        input_path: String,
+        output_path: String,
+        progress_sink: String,
+    ) {
+        wire__crate__api__streaming__stream_compress_encrypt_file_impl(
+            port_,
+            cipher,
+            compression,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__streaming__stream_decrypt_decompress_file(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        input_path: String,
+        output_path: String,
+        progress_sink: String,
+    ) {
+        wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
+            port_,
+            cipher,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__streaming__stream_decrypt_file(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        input_path: String,
+        output_path: String,
+        progress_sink: String,
+    ) {
+        wire__crate__api__streaming__stream_decrypt_file_impl(
+            port_,
+            cipher,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__streaming__stream_encrypt_file(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        input_path: String,
+        output_path: String,
+        progress_sink: String,
+    ) {
+        wire__crate__api__streaming__stream_encrypt_file_impl(
+            port_,
+            cipher,
+            input_path,
+            output_path,
+            progress_sink,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__streaming__stream_hash_file(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        hasher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        file_path: String,
+        progress_sink: String,
+    ) {
+        wire__crate__api__streaming__stream_hash_file_impl(port_, hasher, file_path, progress_sink)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_capacity(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_capacity_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_close(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_close_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_create(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        path: String,
+        key: Box<[u8]>,
+        algorithm: String,
+        capacity_bytes: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_create_impl(port_, path, key, algorithm, capacity_bytes)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_defragment(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_defragment_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_delete(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        name: String,
+    ) {
+        wire__crate__api__evfs__vault_delete_impl(port_, handle, name)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_health(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_health_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_list(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_list_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_open(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        path: String,
+        key: Box<[u8]>,
+    ) {
+        wire__crate__api__evfs__vault_open_impl(port_, path, key)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_read(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        name: String,
+    ) {
+        wire__crate__api__evfs__vault_read_impl(port_, handle, name)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_read_stream(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        name: String,
+        verify_checksum: bool,
+        sink: String,
+        on_progress: String,
+    ) {
+        wire__crate__api__evfs__vault_read_stream_impl(
+            port_,
+            handle,
+            name,
+            verify_checksum,
+            sink,
+            on_progress,
+        )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_resize(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        new_capacity: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_resize_impl(port_, handle, new_capacity)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_write(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        name: String,
+        data: Box<[u8]>,
+        compression: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_write_impl(port_, handle, name, data, compression)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_write_file(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        name: String,
+        file_path: String,
+        on_progress: String,
+    ) {
+        wire__crate__api__evfs__vault_write_file_impl(port_, handle, name, file_path, on_progress)
+    }
+
     #[wasm_bindgen]
     pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::increment_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::increment_strong_count(ptr as _);
+        }
     }
 
     #[wasm_bindgen]
     pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::decrement_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>::decrement_strong_count(ptr as _);
+        }
     }
 
     #[wasm_bindgen]
     pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::increment_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::increment_strong_count(ptr as _);
+        }
     }
 
     #[wasm_bindgen]
     pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerHasherHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::decrement_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<HasherHandle>>::decrement_strong_count(ptr as _);
+        }
     }
 
     #[wasm_bindgen]
     pub fn rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::increment_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::increment_strong_count(ptr as _);
+        }
     }
 
     #[wasm_bindgen]
     pub fn rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
         ptr: *const std::ffi::c_void,
     ) {
-        MoiArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::decrement_strong_count(ptr as _);
+        unsafe {
+            StdArc::<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>::decrement_strong_count(ptr as _);
+        }
     }
 }
 #[cfg(target_family = "wasm")]


### PR DESCRIPTION
## Summary

Eliminate unnecessary data copies at the Dart-Rust FFI boundary and within the Rust I/O pipeline.

### Release profile hardening (PR #105)
- `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"`, `opt-level = 3`
- ELF linker version script restricting `.so` exports to FRB FFI symbols only
- `build.rs` applies version script on Android/Linux cdylib builds

### mmap zero-copy vault reads (PR #106)
- `vault_read` and `vault_read_stream` slice directly into memory-mapped file pages via `memmap2`
- `mlock()` pins ciphertext pages on unix to prevent swap-to-disk
- Graceful fallback to heap `read_exact` when mmap fails (32-bit, low limits)
- mmap invalidated and recreated after every mutation (write, delete, defrag, resize)
- `VaultHandle` field ordering ensures `munlock` -> `munmap` -> `close(fd)` drop sequence

### DCO codec for zero-copy Rust-to-Dart transfers (PR #107)
- `full_dep: true` switches all 50 FRB functions from SSE to CST+DCO codec
- `Vec<u8>` returns use `allo-isolate` `ExternalTypedData` (pointer transfer, no memcpy)
- Every encrypt, decrypt, hash, and vault_read call benefits

## Test plan

- [x] 331 Rust tests pass
- [x] `cargo clippy --all-features` clean
- [x] `dart analyze lib/` — no issues
- [x] iOS cross-check (`aarch64-apple-ios`, `aarch64-apple-ios-sim`) passes
- [x] macOS cross-check (`x86_64-apple-darwin`, `aarch64-apple-darwin`) passes
- [x] 76/76 Dart integration tests pass on iPhone 17 Pro simulator (iOS 26.2)
- [x] Unsafe audit: mmap safety contract, mlock/munlock, Drop ordering verified sound
- [x] All 6 vault mutation paths verified to call `refresh_mmap()` after commit
- [x] Rust: 0 SSE, 51 DCO confirmed
- [x] Dart: 0 SSE, 50 DCO confirmed
- [x] `free_zero_copy_buffer_*` finalizers exported in `ffi-exports.map`
- [x] ZeroizeOnDrop behavior preserved — no regression