### PR TITLE
feat: EVFS key rotation

### DIFF
--- a/rust/src/api/evfs/helpers.rs
+++ b/rust/src/api/evfs/helpers.rs
@@ -161,12 +161,8 @@ pub(crate) fn decrypt_streaming_chunks(
         }
         .to_bytes();
 
-        let decrypted = segment::aead_decrypt_with_stored_nonce(
-            cipher_key,
-            encrypted_ref,
-            &aad,
-            algorithm,
-        )?;
+        let decrypted =
+            segment::aead_decrypt_with_stored_nonce(cipher_key, encrypted_ref, &aad, algorithm)?;
 
         let plaintext = if is_final {
             crate::core::streaming::strip_last_chunk_padding(&decrypted)?
@@ -191,4 +187,41 @@ pub(crate) fn decrypt_streaming_chunks(
     }
 
     Ok(hasher.finalize().into())
+}
+
+/// Decrypt a raw encrypted monolithic segment blob (`nonce || ciphertext || tag`)
+/// without going through a `VaultHandle` read path.
+///
+/// # Errors
+///
+/// - [`CryptoError::AuthenticationFailed`] — nonce mismatch or AEAD tag failure.
+/// - [`CryptoError::VaultCorrupted`] — BLAKE3 checksum mismatch after decryption.
+/// - Any lower-level [`CryptoError`] propagated from decompression or AEAD.
+#[cfg(feature = "compression")]
+pub(crate) fn decrypt_segment_raw(
+    encrypted: &[u8],
+    cipher_key: &[u8],
+    nonce_key: &[u8],
+    algorithm: Algorithm,
+    generation: u64,
+    compression: CompressionAlgorithm,
+    expected_checksum: &[u8; 32],
+) -> Result<Vec<u8>, CryptoError> {
+    let params = segment::SegmentCryptoParams {
+        cipher_key,
+        nonce_key,
+        algorithm,
+        segment_index: 0, // monolithic segments always use index 0 for nonce derivation
+        generation,
+    };
+
+    let plaintext = segment::decrypt_segment(&params, encrypted, compression)?;
+
+    if !segment::verify_checksum(&plaintext, expected_checksum) {
+        return Err(CryptoError::VaultCorrupted(
+            "decrypt_segment_raw: BLAKE3 integrity check failed".into(),
+        ));
+    }
+
+    Ok(plaintext)
 }

--- a/rust/src/api/evfs/helpers.rs
+++ b/rust/src/api/evfs/helpers.rs
@@ -4,6 +4,7 @@ use crate::core::evfs::segment::{self, VaultKeys};
 use crate::core::format::Algorithm;
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
+use zeroize::Zeroize;
 
 #[cfg(feature = "compression")]
 use crate::api::compression::CompressionAlgorithm;
@@ -215,9 +216,10 @@ pub(crate) fn decrypt_segment_raw(
         generation,
     };
 
-    let plaintext = segment::decrypt_segment(&params, encrypted, compression)?;
+    let mut plaintext = segment::decrypt_segment(&params, encrypted, compression)?;
 
     if !segment::verify_checksum(&plaintext, expected_checksum) {
+        plaintext.zeroize();
         return Err(CryptoError::VaultCorrupted(
             "decrypt_segment_raw: BLAKE3 integrity check failed".into(),
         ));

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -6,8 +6,8 @@ mod tests;
 pub mod types;
 
 use helpers::*;
-pub use types::*;
 use types::VaultMmap;
+pub use types::*;
 
 use crate::api::compression::{CompressionAlgorithm, CompressionConfig};
 use crate::core::error::CryptoError;
@@ -1066,6 +1066,250 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
         segments_moved,
         bytes_reclaimed,
         free_regions_before,
+    })
+}
+
+/// Consumes old handle (keys invalidated after rename). Returns new handle with new keys.
+pub fn vault_rotate_key(
+    mut handle: VaultHandle,
+    mut new_key: Vec<u8>,
+) -> Result<VaultHandle, CryptoError> {
+    // We acquire a lock on both the current vault and the new vault that we do the transition with.
+    let lock = VaultLock::acquire(&handle.path)?;
+    let temp_path = format!("{}.rotating", &handle.path);
+    let temp_lock = VaultLock::acquire(&temp_path)?;
+
+    // Generate the new key
+    let capacity = handle.index.capacity;
+    let new_keys = segment::derive_vault_keys(&new_key)?;
+    new_key.zeroize();
+    // Re-calc the same constants.
+    let index_pad_size = format::compute_index_size(capacity);
+    let total_size = format::total_vault_size(capacity, index_pad_size)?;
+    let data_off = format::data_region_offset(index_pad_size);
+
+    // Create the temporary/rotating vault file, pre-allocate the size, and write the header.
+    // We need the vault to be setup before writing segments.
+    let mut temp_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .map_err(|e| CryptoError::IoError(format!("cannot create vault: {e}")))?;
+    segment::preallocate_vault(&mut temp_file, total_size)?;
+    let header = VaultHeader::new(handle.algorithm.to_byte(), index_pad_size as u32);
+    temp_file.seek(SeekFrom::Start(0))?;
+    temp_file.write_all(&header.to_bytes())?;
+
+    // Get all the segments from the previous vault.
+    let old_file = &mut handle.file;
+    let segment_entries = handle.index.entries.drain(..);
+    let mut new_index = SegmentIndex::new(capacity);
+
+    for old_entry in segment_entries {
+        if old_entry.is_streaming() {
+            // FIXME: @Adel-Ayoub is there a way to decrypt a segment if it isnt in chunked storage.
+            // It would be nice if we could use only decrypt_segment_raw.
+            let mut full_plaintext: Vec<u8> = Vec::new();
+            decrypt_streaming_chunks(
+                old_file,
+                handle.mmap.as_ref(),
+                handle.keys.cipher_key.as_bytes(),
+                handle.keys.nonce_key.as_bytes(),
+                handle.algorithm,
+                index_pad_size,
+                old_entry.offset,
+                old_entry.generation,
+                old_entry.compression,
+                old_entry.chunk_count,
+                |chunk, _| {
+                    full_plaintext.extend_from_slice(&chunk);
+                    Ok(())
+                },
+            )?;
+
+            let total_plaintext_size = full_plaintext.len() as u64;
+            let expected_chunks = format::streaming_chunk_count(total_plaintext_size)?;
+            let total_enc_size = format::streaming_segment_size(total_plaintext_size)?;
+
+            let new_gen = new_index.next_gen();
+            let new_offset = new_index.allocate(total_enc_size)?;
+
+            // Re-encrypt chunk-by-chunk into the rotating vault using the new keys.
+            use crate::core::streaming::{pad_last_chunk, CHUNK_SIZE};
+            let mut chunk_buf = vec![0u8; CHUNK_SIZE];
+            let mut buf_len: usize = 0;
+            let mut chunk_index: u64 = 0;
+            let mut pos: usize = 0;
+
+            while pos < full_plaintext.len() {
+                let take = (CHUNK_SIZE - buf_len).min(full_plaintext.len() - pos);
+                chunk_buf[buf_len..buf_len + take]
+                    .copy_from_slice(&full_plaintext[pos..pos + take]);
+                buf_len += take;
+                pos += take;
+
+                if buf_len == CHUNK_SIZE {
+                    let abs_off = chunk_abs_offset(data_off, new_offset, chunk_index)?;
+                    write_encrypted_chunk(
+                        &mut temp_file,
+                        new_keys.cipher_key.as_bytes(),
+                        new_keys.nonce_key.as_bytes(),
+                        handle.algorithm,
+                        &chunk_buf,
+                        chunk_index,
+                        new_gen,
+                        false,
+                        abs_off,
+                    )?;
+                    chunk_index += 1;
+                    buf_len = 0;
+                }
+            }
+            full_plaintext.zeroize();
+
+            // The final chunk always exists (even for empty segments) and must be padded.
+            let mut padded = pad_last_chunk(&chunk_buf[..buf_len])?;
+            chunk_buf.zeroize();
+            let final_off = chunk_abs_offset(data_off, new_offset, chunk_index)?;
+            let r = write_encrypted_chunk(
+                &mut temp_file,
+                new_keys.cipher_key.as_bytes(),
+                new_keys.nonce_key.as_bytes(),
+                handle.algorithm,
+                &padded,
+                chunk_index,
+                new_gen,
+                true,
+                final_off,
+            );
+            padded.zeroize();
+            r?;
+
+            // Preserve the BLAKE3 checksum — it covers the plaintext, which hasn't changed.
+            // compression is None because decrypt_streaming_chunks already decompressed.
+            let new_entry = SegmentEntry::new(
+                &old_entry.name,
+                new_offset,
+                total_enc_size,
+                new_gen,
+                old_entry.checksum,
+                CompressionAlgorithm::None,
+                expected_chunks,
+            )?;
+            new_index.add(new_entry)?;
+        } else {
+            let abs_offset = data_off + old_entry.offset;
+            let encrypted: Vec<u8> = if let Some(ref mmap) = handle.mmap {
+                mmap.slice(abs_offset, old_entry.size)?.to_vec()
+            } else {
+                old_file.seek(SeekFrom::Start(abs_offset))?;
+                let mut buf = vec![0u8; old_entry.size as usize];
+                old_file.read_exact(&mut buf)?;
+                buf
+            };
+
+            // Decrypt with the old keys (also decompresses and verifies the BLAKE3 checksum).
+            let plaintext = decrypt_segment_raw(
+                &encrypted,
+                handle.keys.cipher_key.as_bytes(),
+                handle.keys.nonce_key.as_bytes(),
+                handle.algorithm,
+                old_entry.generation,
+                old_entry.compression,
+                &old_entry.checksum,
+            )?;
+
+            // Re-encrypt with the new keys. No compression: plaintext is already decompressed.
+            let new_gen = new_index.next_gen();
+            let params = SegmentCryptoParams {
+                cipher_key: new_keys.cipher_key.as_bytes(),
+                nonce_key: new_keys.nonce_key.as_bytes(),
+                algorithm: handle.algorithm,
+                segment_index: 0,
+                generation: new_gen,
+            };
+            let (new_encrypted, _) = segment::encrypt_segment(
+                &params,
+                &plaintext,
+                &old_entry.name,
+                &CompressionConfig {
+                    algorithm: CompressionAlgorithm::None,
+                    level: None,
+                },
+            )?;
+
+            let new_offset = new_index.allocate(new_encrypted.len() as u64)?;
+            temp_file.seek(SeekFrom::Start(data_off + new_offset))?;
+            temp_file.write_all(&new_encrypted)?;
+
+            // Preserve the BLAKE3 checksum — it covers the plaintext, which hasn't changed.
+            let new_entry = SegmentEntry::new(
+                &old_entry.name,
+                new_offset,
+                new_encrypted.len() as u64,
+                new_gen,
+                old_entry.checksum,
+                CompressionAlgorithm::None,
+                0,
+            )?;
+            new_index.add(new_entry)?;
+        }
+    }
+
+    // After writing all segments, sync the file and do maintenance stuff.
+    flush_index(
+        &mut temp_file,
+        &new_index,
+        &new_keys,
+        handle.algorithm,
+        capacity,
+        index_pad_size,
+    )?;
+    temp_file.sync_all()?;
+
+    // Open the WAL for the rotating file to ensure everything is file.
+    let mut rotating_wal = WriteAheadLog::open(&temp_path)?;
+    rotating_wal.checkpoint()?;
+    drop(rotating_wal);
+    let _ = std::fs::remove_file(format!("{temp_path}.wal"));
+    drop(temp_file); // close the rotating vault fd before rename
+    temp_lock.release()?;
+
+    // Close the previous vault.
+    handle.wal.checkpoint()?;
+    let algorithm = handle.algorithm;
+    let original_path = handle.path.clone();
+    // SAFETY: Dropping [`VaultHandle`] zeroizes everything, ensuring no ciphertext/keys are
+    // leaked into memory.
+    drop(handle);
+    lock.release()?;
+
+    // And move our vault into the new path
+    std::fs::rename(&temp_path, &original_path)
+        .map_err(|e| CryptoError::KeyRotationFailed(format!("rename failed: {e}")))?;
+    let new_lock = VaultLock::acquire(&original_path)?;
+    let new_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&original_path)
+        .map_err(|e| CryptoError::IoError(format!("cannot reopen vault after rotation: {e}")))?;
+    // The WAL at {original_path}.wal was already checkpointed above; open and
+    // checkpoint once more to guard against any edge-case leftover entries.
+    let mut new_wal = WriteAheadLog::open(&original_path)?;
+    new_wal.checkpoint()?;
+    let new_mmap = VaultMmap::new(&new_file).ok();
+
+    Ok(VaultHandle {
+        path: original_path,
+        algorithm,
+        keys: new_keys,
+        index: new_index,
+        index_pad_size,
+        mmap: new_mmap,
+        file: new_file,
+        wal: new_wal,
+        lock: new_lock,
     })
 }
 

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -94,6 +94,16 @@ pub fn vault_create(
 pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoError> {
     let lock = VaultLock::acquire(&path)?;
 
+    // If a previous key rotation was interrupted after pre-allocation but before
+    // the atomic rename completed, a stale .rotating vault will be sitting next
+    // to the original. The original is intact — just remove the orphan so it
+    // does not interfere with a future rotation attempt.
+    let rotating_path = format!("{path}.rotating");
+    if std::path::Path::new(&rotating_path).exists() {
+        let _ = std::fs::remove_file(&rotating_path);
+        let _ = std::fs::remove_file(format!("{rotating_path}.wal"));
+    }
+
     let mut file = OpenOptions::new()
         .read(true)
         .write(true)

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -1075,7 +1075,6 @@ pub fn vault_rotate_key(
     mut new_key: Vec<u8>,
 ) -> Result<VaultHandle, CryptoError> {
     // We acquire a lock on both the current vault and the new vault that we do the transition with.
-    let lock = VaultLock::acquire(&handle.path)?;
     let temp_path = format!("{}.rotating", &handle.path);
     let temp_lock = VaultLock::acquire(&temp_path)?;
 
@@ -1278,12 +1277,11 @@ pub fn vault_rotate_key(
 
     // Close the previous vault.
     handle.wal.checkpoint()?;
+    handle.lock.release()?;
     let algorithm = handle.algorithm;
     let original_path = handle.path.clone();
-    // SAFETY: Dropping [`VaultHandle`] zeroizes everything, ensuring no ciphertext/keys are
-    // leaked into memory.
-    drop(handle);
-    lock.release()?;
+    // SAFETY: Dropping [`VaultHandle`] zeroizes everything (which happens at the end of this scope),
+    // ensuring no ciphertext/keys are // leaked into memory.
 
     // And move our vault into the new path
     std::fs::rename(&temp_path, &original_path)

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -19,7 +19,7 @@ use crate::core::evfs::wal::{VaultLock, WalOp, WriteAheadLog};
 use crate::core::format::Algorithm;
 use crate::frb_generated::StreamSink;
 use subtle::ConstantTimeEq;
-use zeroize::Zeroize;
+use zeroize::{Zeroize, Zeroizing};
 
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -1086,12 +1086,28 @@ pub fn vault_rotate_key(
 ) -> Result<VaultHandle, CryptoError> {
     // We acquire a lock on both the current vault and the new vault that we do the transition with.
     let temp_path = format!("{}.rotating", &handle.path);
+
+    // Clean up a stale .rotating file from a previous failed rotation so that
+    // create_new(true) below doesn't fail.
+    if std::path::Path::new(&temp_path).exists() {
+        let _ = std::fs::remove_file(&temp_path);
+        let _ = std::fs::remove_file(format!("{temp_path}.wal"));
+    }
+
     let temp_lock = VaultLock::acquire(&temp_path)?;
 
     // Generate the new key
     let capacity = handle.index.capacity;
-    let new_keys = segment::derive_vault_keys(&new_key)?;
-    new_key.zeroize();
+    let new_keys = match segment::derive_vault_keys(&new_key) {
+        Ok(k) => {
+            new_key.zeroize();
+            k
+        }
+        Err(e) => {
+            new_key.zeroize();
+            return Err(e);
+        }
+    };
     // Re-calc the same constants.
     let index_pad_size = format::compute_index_size(capacity);
     let total_size = format::total_vault_size(capacity, index_pad_size)?;
@@ -1117,9 +1133,9 @@ pub fn vault_rotate_key(
 
     for old_entry in segment_entries {
         if old_entry.is_streaming() {
-            // FIXME: @Adel-Ayoub is there a way to decrypt a segment if it isnt in chunked storage.
-            // It would be nice if we could use only decrypt_segment_raw.
-            let mut full_plaintext: Vec<u8> = Vec::new();
+            // NOTE: Streaming segments must be fully decrypted before re-chunking because
+            // the chunk boundaries are tied to the plaintext size, not the ciphertext layout.
+            let mut full_plaintext: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::new());
             decrypt_streaming_chunks(
                 old_file,
                 handle.mmap.as_ref(),
@@ -1146,7 +1162,7 @@ pub fn vault_rotate_key(
 
             // Re-encrypt chunk-by-chunk into the rotating vault using the new keys.
             use crate::core::streaming::{pad_last_chunk, CHUNK_SIZE};
-            let mut chunk_buf = vec![0u8; CHUNK_SIZE];
+            let mut chunk_buf: Zeroizing<Vec<u8>> = Zeroizing::new(vec![0u8; CHUNK_SIZE]);
             let mut buf_len: usize = 0;
             let mut chunk_index: u64 = 0;
             let mut pos: usize = 0;
@@ -1175,13 +1191,15 @@ pub fn vault_rotate_key(
                     buf_len = 0;
                 }
             }
-            full_plaintext.zeroize();
+            // full_plaintext is zeroized on drop via Zeroizing<Vec<u8>>.
+            drop(full_plaintext);
 
             // The final chunk always exists (even for empty segments) and must be padded.
-            let mut padded = pad_last_chunk(&chunk_buf[..buf_len])?;
-            chunk_buf.zeroize();
+            let padded = Zeroizing::new(pad_last_chunk(&chunk_buf[..buf_len])?);
+            // chunk_buf is zeroized on drop via Zeroizing<Vec<u8>>.
+            drop(chunk_buf);
             let final_off = chunk_abs_offset(data_off, new_offset, chunk_index)?;
-            let r = write_encrypted_chunk(
+            write_encrypted_chunk(
                 &mut temp_file,
                 new_keys.cipher_key.as_bytes(),
                 new_keys.nonce_key.as_bytes(),
@@ -1191,12 +1209,11 @@ pub fn vault_rotate_key(
                 new_gen,
                 true,
                 final_off,
-            );
-            padded.zeroize();
-            r?;
+            )?;
+            drop(padded);
 
             // Preserve the BLAKE3 checksum — it covers the plaintext, which hasn't changed.
-            // compression is None because decrypt_streaming_chunks already decompressed.
+            // Compression is None because decrypt_streaming_chunks already decompressed.
             let new_entry = SegmentEntry::new(
                 &old_entry.name,
                 new_offset,
@@ -1219,7 +1236,7 @@ pub fn vault_rotate_key(
             };
 
             // Decrypt with the old keys (also decompresses and verifies the BLAKE3 checksum).
-            let plaintext = decrypt_segment_raw(
+            let plaintext = Zeroizing::new(decrypt_segment_raw(
                 &encrypted,
                 handle.keys.cipher_key.as_bytes(),
                 handle.keys.nonce_key.as_bytes(),
@@ -1227,7 +1244,7 @@ pub fn vault_rotate_key(
                 old_entry.generation,
                 old_entry.compression,
                 &old_entry.checksum,
-            )?;
+            )?);
 
             // Re-encrypt with the new keys. No compression: plaintext is already decompressed.
             let new_gen = new_index.next_gen();
@@ -1277,7 +1294,7 @@ pub fn vault_rotate_key(
     )?;
     temp_file.sync_all()?;
 
-    // Open the WAL for the rotating file to ensure everything is file.
+    // Open the WAL for the rotating file to ensure everything is fine.
     let mut rotating_wal = WriteAheadLog::open(&temp_path)?;
     rotating_wal.checkpoint()?;
     drop(rotating_wal);
@@ -1285,17 +1302,21 @@ pub fn vault_rotate_key(
     drop(temp_file); // close the rotating vault fd before rename
     temp_lock.release()?;
 
-    // Close the previous vault.
+    // Checkpoint the original WAL while we still hold the original lock.
     handle.wal.checkpoint()?;
-    handle.lock.release()?;
     let algorithm = handle.algorithm;
     let original_path = handle.path.clone();
-    // SAFETY: Dropping [`VaultHandle`] zeroizes everything (which happens at the end of this scope),
-    // ensuring no ciphertext/keys are // leaked into memory.
 
-    // And move our vault into the new path
+    // Atomic rename is the commit point — must happen while the original lock is
+    // still held to prevent a concurrent vault_open() from seeing the stale file
+    // or deleting the .rotating file.
     std::fs::rename(&temp_path, &original_path)
         .map_err(|e| CryptoError::KeyRotationFailed(format!("rename failed: {e}")))?;
+
+    // Release the old lock only after the rename succeeded.
+    handle.lock.release()?;
+    // SAFETY: Remaining VaultHandle fields (keys, mmap, file) are dropped at end
+    // of scope — SecretBuffer/VaultKeys are ZeroizeOnDrop.
     let new_lock = VaultLock::acquire(&original_path)?;
     let new_file = OpenOptions::new()
         .read(true)

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -5,6 +5,10 @@ fn test_key() -> Vec<u8> {
     vec![0xAA; 32]
 }
 
+fn test_key2() -> Vec<u8> {
+    vec![0xAB; 32]
+}
+
 fn wrong_key() -> Vec<u8> {
     vec![0xBB; 32]
 }
@@ -2171,7 +2175,10 @@ fn test_stream_read_matches_oneshot_read() {
     let oneshot = vault_read(&mut handle, "video.bin".into()).expect("oneshot read");
     let (streamed, _, _) = stream_read_chunks(&mut handle, "video.bin").expect("stream read");
 
-    assert_eq!(streamed, oneshot, "streaming and one-shot must be byte-identical");
+    assert_eq!(
+        streamed, oneshot,
+        "streaming and one-shot must be byte-identical"
+    );
     assert_eq!(streamed, data);
 
     vault_close(handle).expect("close");
@@ -2204,8 +2211,7 @@ fn test_stream_read_progress_indices() {
     stream_write_chunks(&mut handle, "prog.bin", &data, chunk_size).expect("stream write");
 
     let chunk_count = handle.index.find("prog.bin").expect("find").chunk_count;
-    let (collected, indices, _) =
-        stream_read_chunks(&mut handle, "prog.bin").expect("stream read");
+    let (collected, indices, _) = stream_read_chunks(&mut handle, "prog.bin").expect("stream read");
 
     assert_eq!(collected, data);
     assert_eq!(indices.len(), chunk_count as usize);
@@ -2223,8 +2229,7 @@ fn test_stream_read_single_byte() {
     let data = vec![0xCC; 1];
     stream_write_chunks(&mut handle, "tiny.bin", &data, 1).expect("stream write");
 
-    let (collected, indices, _) =
-        stream_read_chunks(&mut handle, "tiny.bin").expect("stream read");
+    let (collected, indices, _) = stream_read_chunks(&mut handle, "tiny.bin").expect("stream read");
 
     assert_eq!(collected, data);
     assert_eq!(indices.len(), 1);
@@ -2368,15 +2373,18 @@ fn test_stream_read_chacha20() {
         .to_str()
         .expect("path")
         .to_string();
-    let mut handle =
-        vault_create(path, test_key(), "chacha20-poly1305".into(), 2 * 1024 * 1024)
-            .expect("create");
+    let mut handle = vault_create(
+        path,
+        test_key(),
+        "chacha20-poly1305".into(),
+        2 * 1024 * 1024,
+    )
+    .expect("create");
 
     let data = vec![0x77; 200_000];
     stream_write_chunks(&mut handle, "chacha.bin", &data, 4096).expect("stream write");
 
-    let (collected, _, _) =
-        stream_read_chunks(&mut handle, "chacha.bin").expect("stream read");
+    let (collected, _, _) = stream_read_chunks(&mut handle, "chacha.bin").expect("stream read");
     assert_eq!(collected, data);
 
     vault_close(handle).expect("close");
@@ -2487,16 +2495,239 @@ fn test_write_file_empty() {
     use crate::core::streaming::CHUNK_SIZE;
     let file_data = std::fs::read(&file_path).expect("read file");
     let chunks: Vec<Vec<u8>> = file_data.chunks(CHUNK_SIZE).map(|c| c.to_vec()).collect();
-    vault_write_stream(
-        &mut handle,
-        "empty.bin".into(),
-        0,
-        chunks.into_iter(),
-    )
-    .expect("write stream");
+    vault_write_stream(&mut handle, "empty.bin".into(), 0, chunks.into_iter())
+        .expect("write stream");
 
     let readback = vault_read(&mut handle, "empty.bin".into()).expect("read");
     assert!(readback.is_empty());
 
     vault_close(handle).expect("close");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// -- Key Rotation -----------------------------------------------------------
+
+#[test]
+fn test_rotate_key_basic() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write a");
+    vault_write(&mut handle, "b.txt".into(), b"world".to_vec(), None).expect("write b");
+
+    let mut handle = vault_rotate_key(handle, test_key2()).expect("rotate");
+
+    assert_eq!(
+        vault_read(&mut handle, "a.txt".into()).expect("read a"),
+        b"hello"
+    );
+    assert_eq!(
+        vault_read(&mut handle, "b.txt".into()).expect("read b"),
+        b"world"
+    );
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_old_key_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    {
+        let mut handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+            .expect("create");
+        vault_write(
+            &mut handle,
+            "secret.txt".into(),
+            b"top secret".to_vec(),
+            None,
+        )
+        .expect("write");
+        let handle = vault_rotate_key(handle, test_key2()).expect("rotate");
+        vault_close(handle).expect("close");
+    }
+
+    // Old key must be rejected
+    assert!(vault_open(path.clone(), test_key()).is_err());
+
+    // New key must still work and data must be intact
+    let mut handle = vault_open(path, test_key2()).expect("open with new key");
+    assert_eq!(
+        vault_read(&mut handle, "secret.txt".into()).expect("read"),
+        b"top secret"
+    );
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_streaming_segment_survives() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 2 * 1024 * 1024);
+
+    let data = vec![0x42u8; 200_000]; // spans multiple chunks
+    stream_write_chunks(&mut handle, "video.bin", &data, 4096).expect("stream write");
+
+    let mut handle = vault_rotate_key(handle, test_key2()).expect("rotate");
+
+    let readback = vault_read(&mut handle, "video.bin".into()).expect("read after rotate");
+    assert_eq!(readback, data);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_compressed_segment_survives() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    let data = b"compressible repeated payload ".repeat(100);
+    let config = CompressionConfig {
+        algorithm: CompressionAlgorithm::Zstd,
+        level: None,
+    };
+    vault_write(&mut handle, "data.bin".into(), data.clone(), Some(config)).expect("write");
+
+    let mut handle = vault_rotate_key(handle, test_key2()).expect("rotate");
+
+    let readback = vault_read(&mut handle, "data.bin".into()).expect("read after rotate");
+    assert_eq!(readback, data);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_checksum_preserved() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(
+        &mut handle,
+        "doc.txt".into(),
+        b"checksum test data".to_vec(),
+        None,
+    )
+    .expect("write");
+
+    let checksum_before = handle.index.find("doc.txt").expect("find before").checksum;
+
+    let handle = vault_rotate_key(handle, test_key2()).expect("rotate");
+
+    let checksum_after = handle.index.find("doc.txt").expect("find after").checksum;
+
+    assert_eq!(
+        checksum_before, checksum_after,
+        "BLAKE3 checksum must be identical before and after rotation"
+    );
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_crash_recovery_rotating_cleaned_up() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    {
+        let handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+            .expect("create");
+        vault_close(handle).expect("close");
+    }
+
+    // Plant a stale .rotating file to simulate a crash mid-rotation.
+    let rotating_path = format!("{path}.rotating");
+    std::fs::write(&rotating_path, b"stale junk").expect("plant stale file");
+    assert!(std::path::Path::new(&rotating_path).exists());
+
+    // vault_open must silently remove the orphan and succeed normally.
+    let handle = vault_open(path, test_key()).expect("open after simulated crash");
+    vault_close(handle).expect("close");
+
+    assert!(
+        !std::path::Path::new(&rotating_path).exists(),
+        ".rotating file must be cleaned up by vault_open"
+    );
+}
+
+#[test]
+fn test_rotate_key_empty_vault() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let handle = create_test_vault(&dir, 1_048_576);
+
+    // Rotate with no segments written at all.
+    let handle = vault_rotate_key(handle, test_key2()).expect("rotate empty vault");
+
+    assert!(
+        vault_list(&handle).is_empty(),
+        "rotated empty vault must have no segments"
+    );
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_chacha20() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir
+        .path()
+        .join("chacha.vault")
+        .to_str()
+        .expect("path")
+        .to_string();
+
+    let mut handle =
+        vault_create(path, test_key(), "chacha20-poly1305".into(), 1_048_576).expect("create");
+    vault_write(
+        &mut handle,
+        "msg.txt".into(),
+        b"chacha payload".to_vec(),
+        None,
+    )
+    .expect("write");
+
+    let mut handle = vault_rotate_key(handle, test_key2()).expect("rotate chacha20 vault");
+
+    let readback = vault_read(&mut handle, "msg.txt".into()).expect("read after rotate");
+    assert_eq!(readback, b"chacha payload");
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_multiple_rotations() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(
+        &mut handle,
+        "doc.txt".into(),
+        b"original data".to_vec(),
+        None,
+    )
+    .expect("write");
+
+    // First rotation: test_key → new_key
+    let handle = vault_rotate_key(handle, test_key2()).expect("first rotation");
+    // Second rotation: new_key → wrong_key
+    let mut handle = vault_rotate_key(handle, wrong_key()).expect("second rotation");
+
+    let readback = vault_read(&mut handle, "doc.txt".into()).expect("read after two rotations");
+    assert_eq!(readback, b"original data");
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rotate_key_empty_new_key_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let handle = create_test_vault(&dir, 1_048_576);
+
+    let result = vault_rotate_key(handle, vec![]);
+    assert!(
+        result.is_err(),
+        "rotation with an empty new key must return an error"
+    );
 }

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -46,6 +46,9 @@ pub enum CryptoError {
 
     #[error("Vault corrupted: {0}")]
     VaultCorrupted(String),
+
+    #[error("Key rotation failed: {0}")]
+    KeyRotationFailed(String),
 }
 
 impl From<std::io::Error> for CryptoError {


### PR DESCRIPTION
Closes #110

## TODO

- [x] After rotation, `vault_open(old_key)` fails
- [x] After rotation, `vault_open(new_key)` succeeds with all data intact
- [x] If interrupted, original vault recoverable with old key
- [x] Old sub-keys zeroized (ZeroizeOnDrop)
- [x] All existing tests pass (no regressions)