### PR TITLE
feat(evfs): add vault_export() and .mvex archive format

### DIFF
--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -1342,6 +1342,169 @@ pub fn vault_rotate_key(
     })
 }
 
+/// Export all vault segments into a self-contained `.mvex` encrypted archive.
+///
+/// Each segment is decrypted from the vault, then re-encrypted under an
+/// ephemeral export key with a random per-segment nonce. The export key is
+/// AEAD-wrapped with the caller's `wrapping_key`.
+///
+/// The vault is not modified by this operation.
+#[cfg(feature = "compression")]
+pub fn vault_export(
+    handle: &mut VaultHandle,
+    mut wrapping_key: Vec<u8>,
+    export_path: String,
+) -> Result<(), CryptoError> {
+    use crate::core::evfs::archive::{
+        ArchiveHeader, ArchiveTrailer, SegmentRecord, KEY_WRAP_AAD,
+    };
+    use rand::{rngs::OsRng, RngCore};
+
+    if wrapping_key.len() != 32 {
+        let actual = wrapping_key.len();
+        wrapping_key.zeroize();
+        return Err(CryptoError::InvalidKeyLength {
+            expected: 32,
+            actual,
+        });
+    }
+
+    // 1. Generate random 32-byte ephemeral export key
+    let mut export_key = Zeroizing::new(vec![0u8; 32]);
+    OsRng.fill_bytes(&mut export_key);
+
+    // 2. Wrap export_key with wrapping_key (AEAD, AAD = KEY_WRAP_AAD)
+    //    Result: nonce(12) || ciphertext(32) || tag(16) = 60 bytes
+    let wrapped_key = segment::aead_encrypt_random_nonce(
+        &wrapping_key,
+        &export_key,
+        KEY_WRAP_AAD,
+        handle.algorithm,
+    )?;
+    wrapping_key.zeroize();
+
+    // 3. Write header + wrapped key
+    let segment_count = u32::try_from(handle.index.entries.len()).map_err(|_| {
+        CryptoError::ExportFailed("segment count exceeds u32".into())
+    })?;
+    let header = ArchiveHeader::new(handle.algorithm.to_byte(), segment_count);
+
+    let mut out = std::fs::File::create(&export_path)
+        .map_err(|e| CryptoError::IoError(format!("cannot create export file: {e}")))?;
+
+    let header_bytes = header.to_bytes();
+    out.write_all(&header_bytes)?;
+    out.write_all(&wrapped_key)?;
+
+    // BLAKE3 hasher covers everything before the trailer
+    let mut archive_hasher = blake3::Hasher::new();
+    archive_hasher.update(&header_bytes);
+    archive_hasher.update(&wrapped_key);
+
+    // 4. For each segment: decrypt -> re-encrypt under export_key -> write record
+    //    Clone entry metadata to avoid borrow conflict with handle
+    let entries: Vec<_> = handle.index.entries.iter().map(|e| {
+        (
+            e.name.clone(),
+            e.offset,
+            e.size,
+            e.generation,
+            e.compression,
+            e.checksum,
+            e.chunk_count,
+        )
+    }).collect();
+
+    for (name, offset, size, generation, compression, checksum, chunk_count) in &entries {
+        // Decrypt the segment plaintext (handles both monolithic and streaming)
+        let plaintext = if *chunk_count > 0 {
+            let mut full_plaintext = Vec::new();
+            let computed_checksum = decrypt_streaming_chunks(
+                &mut handle.file,
+                handle.mmap.as_ref(),
+                handle.keys.cipher_key.as_bytes(),
+                handle.keys.nonce_key.as_bytes(),
+                handle.algorithm,
+                handle.index_pad_size,
+                *offset,
+                *generation,
+                *compression,
+                *chunk_count,
+                |data, _| {
+                    full_plaintext.extend_from_slice(&data);
+                    Ok(())
+                },
+            )?;
+            if computed_checksum.ct_ne(checksum).into() {
+                return Err(CryptoError::VaultCorrupted(format!(
+                    "integrity check failed for segment '{name}'"
+                )));
+            }
+            Zeroizing::new(full_plaintext)
+        } else {
+            let abs_offset = format::data_region_offset(handle.index_pad_size) + offset;
+            let params = SegmentCryptoParams {
+                cipher_key: handle.keys.cipher_key.as_bytes(),
+                nonce_key: handle.keys.nonce_key.as_bytes(),
+                algorithm: handle.algorithm,
+                segment_index: 0,
+                generation: *generation,
+            };
+            let pt = if let Some(ref mmap) = handle.mmap {
+                let encrypted = mmap.slice(abs_offset, *size)?;
+                segment::decrypt_segment(&params, encrypted, *compression)?
+            } else {
+                handle.file.seek(SeekFrom::Start(abs_offset))?;
+                let mut buf = vec![0u8; *size as usize];
+                handle.file.read_exact(&mut buf)?;
+                segment::decrypt_segment(&params, &buf, *compression)?
+            };
+            if !segment::verify_checksum(&pt, checksum) {
+                return Err(CryptoError::VaultCorrupted(format!(
+                    "integrity check failed for segment '{name}'"
+                )));
+            }
+            Zeroizing::new(pt)
+        };
+
+        // Re-encrypt under the ephemeral export key with segment name as AAD
+        let encrypted_data = segment::aead_encrypt_random_nonce(
+            &export_key,
+            &plaintext,
+            name.as_bytes(),
+            handle.algorithm,
+        )?;
+        // plaintext is zeroized on drop via Zeroizing
+
+        // Compute BLAKE3 checksum of the original plaintext for the archive record
+        let record_checksum = segment::compute_checksum(&plaintext);
+
+        let record = SegmentRecord {
+            name: name.clone(),
+            compression: compression.to_u8(),
+            checksum: record_checksum,
+            encrypted_data,
+        };
+
+        let record_header = record.write_header()?;
+        out.write_all(&record_header)?;
+        out.write_all(&record.encrypted_data)?;
+
+        archive_hasher.update(&record_header);
+        archive_hasher.update(&record.encrypted_data);
+    }
+
+    // 5. Write BLAKE3 trailer + fsync
+    let trailer = ArchiveTrailer {
+        checksum: archive_hasher.finalize().into(),
+    };
+    out.write_all(&trailer.to_bytes())?;
+    out.sync_all()?;
+
+    // 6. export_key is zeroized on drop via Zeroizing
+    Ok(())
+}
+
 /// Close the vault — checkpoint WAL, release lock, zeroize keys on drop.
 #[cfg(feature = "compression")]
 pub fn vault_close(mut handle: VaultHandle) -> Result<(), CryptoError> {

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -1352,20 +1352,19 @@ pub fn vault_rotate_key(
 #[cfg(feature = "compression")]
 pub fn vault_export(
     handle: &mut VaultHandle,
-    mut wrapping_key: Vec<u8>,
+    wrapping_key: Vec<u8>,
     export_path: String,
 ) -> Result<(), CryptoError> {
-    use crate::core::evfs::archive::{
-        ArchiveHeader, ArchiveTrailer, SegmentRecord, KEY_WRAP_AAD,
-    };
+    use crate::core::evfs::archive::{ArchiveHeader, KEY_WRAP_AAD};
     use rand::{rngs::OsRng, RngCore};
 
+    // Wrap immediately so wrapping_key is zeroized on all paths (including errors).
+    let wrapping_key = Zeroizing::new(wrapping_key);
+
     if wrapping_key.len() != 32 {
-        let actual = wrapping_key.len();
-        wrapping_key.zeroize();
         return Err(CryptoError::InvalidKeyLength {
             expected: 32,
-            actual,
+            actual: wrapping_key.len(),
         });
     }
 
@@ -1381,28 +1380,53 @@ pub fn vault_export(
         KEY_WRAP_AAD,
         handle.algorithm,
     )?;
-    wrapping_key.zeroize();
 
-    // 3. Write header + wrapped key
+    // 3. Prepare header
     let segment_count = u32::try_from(handle.index.entries.len()).map_err(|_| {
         CryptoError::ExportFailed("segment count exceeds u32".into())
     })?;
     let header = ArchiveHeader::new(handle.algorithm.to_byte(), segment_count);
 
-    let mut out = std::fs::File::create(&export_path)
+    // Use create_new to fail atomically if the file already exists.
+    let mut out = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&export_path)
         .map_err(|e| CryptoError::IoError(format!("cannot create export file: {e}")))?;
+
+    // Run the inner export logic; delete the partial file on any error.
+    match vault_export_write(handle, &export_key, &wrapped_key, &header, &mut out) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            drop(out);
+            let _ = std::fs::remove_file(&export_path);
+            Err(e)
+        }
+    }
+}
+
+/// Write the archive contents. Separated from `vault_export` so the caller
+/// can delete the partial file if this returns an error.
+#[cfg(feature = "compression")]
+fn vault_export_write(
+    handle: &mut VaultHandle,
+    export_key: &[u8],
+    wrapped_key: &[u8],
+    header: &crate::core::evfs::archive::ArchiveHeader,
+    out: &mut std::fs::File,
+) -> Result<(), CryptoError> {
+    use crate::core::evfs::archive::{ArchiveTrailer, SegmentRecord};
 
     let header_bytes = header.to_bytes();
     out.write_all(&header_bytes)?;
-    out.write_all(&wrapped_key)?;
+    out.write_all(wrapped_key)?;
 
     // BLAKE3 hasher covers everything before the trailer
     let mut archive_hasher = blake3::Hasher::new();
     archive_hasher.update(&header_bytes);
-    archive_hasher.update(&wrapped_key);
+    archive_hasher.update(wrapped_key);
 
-    // 4. For each segment: decrypt -> re-encrypt under export_key -> write record
-    //    Clone entry metadata to avoid borrow conflict with handle
+    // Clone entry metadata to avoid borrow conflict with handle
     let entries: Vec<_> = handle.index.entries.iter().map(|e| {
         (
             e.name.clone(),
@@ -1415,10 +1439,12 @@ pub fn vault_export(
         )
     }).collect();
 
+    let vault_capacity = handle.index.capacity;
+
     for (name, offset, size, generation, compression, checksum, chunk_count) in &entries {
         // Decrypt the segment plaintext (handles both monolithic and streaming)
-        let plaintext = if *chunk_count > 0 {
-            let mut full_plaintext = Vec::new();
+        let plaintext: Zeroizing<Vec<u8>> = if *chunk_count > 0 {
+            let mut full_plaintext: Zeroizing<Vec<u8>> = Zeroizing::new(Vec::new());
             let computed_checksum = decrypt_streaming_chunks(
                 &mut handle.file,
                 handle.mmap.as_ref(),
@@ -1440,8 +1466,14 @@ pub fn vault_export(
                     "integrity check failed for segment '{name}'"
                 )));
             }
-            Zeroizing::new(full_plaintext)
+            full_plaintext
         } else {
+            // Cap allocation at vault capacity to prevent OOM from a corrupted index.
+            if *size > vault_capacity {
+                return Err(CryptoError::VaultCorrupted(format!(
+                    "segment '{name}' size {size} exceeds vault capacity {vault_capacity}"
+                )));
+            }
             let abs_offset = format::data_region_offset(handle.index_pad_size) + offset;
             let params = SegmentCryptoParams {
                 cipher_key: handle.keys.cipher_key.as_bytes(),
@@ -1467,17 +1499,17 @@ pub fn vault_export(
             Zeroizing::new(pt)
         };
 
+        // Compute BLAKE3 checksum before re-encryption (while plaintext is live)
+        let record_checksum = segment::compute_checksum(&plaintext);
+
         // Re-encrypt under the ephemeral export key with segment name as AAD
         let encrypted_data = segment::aead_encrypt_random_nonce(
-            &export_key,
+            export_key,
             &plaintext,
             name.as_bytes(),
             handle.algorithm,
         )?;
         // plaintext is zeroized on drop via Zeroizing
-
-        // Compute BLAKE3 checksum of the original plaintext for the archive record
-        let record_checksum = segment::compute_checksum(&plaintext);
 
         let record = SegmentRecord {
             name: name.clone(),
@@ -1494,14 +1526,13 @@ pub fn vault_export(
         archive_hasher.update(&record.encrypted_data);
     }
 
-    // 5. Write BLAKE3 trailer + fsync
+    // Write BLAKE3 trailer + fsync
     let trailer = ArchiveTrailer {
         checksum: archive_hasher.finalize().into(),
     };
     out.write_all(&trailer.to_bytes())?;
     out.sync_all()?;
 
-    // 6. export_key is zeroized on drop via Zeroizing
     Ok(())
 }
 

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -2731,3 +2731,357 @@ fn test_rotate_key_empty_new_key_rejected() {
         "rotation with an empty new key must return an error"
     );
 }
+
+// -- Export ----------------------------------------------------------------
+
+fn wrapping_key() -> Vec<u8> {
+    vec![0xCC; 32]
+}
+
+fn export_path(dir: &tempfile::TempDir) -> String {
+    dir.path()
+        .join("export.mvex")
+        .to_str()
+        .expect("path")
+        .to_string()
+}
+
+/// Parse an exported `.mvex` archive, returning (header, wrapped_key, records, trailer_checksum).
+fn parse_archive(
+    path: &str,
+) -> (
+    crate::core::evfs::archive::ArchiveHeader,
+    Vec<u8>,
+    Vec<crate::core::evfs::archive::SegmentRecord>,
+    [u8; 32],
+) {
+    use crate::core::evfs::archive::*;
+    let data = std::fs::read(path).expect("read archive");
+    assert!(data.len() >= ARCHIVE_HEADER_SIZE + WRAPPED_KEY_SIZE + ARCHIVE_TRAILER_SIZE);
+
+    let header = ArchiveHeader::from_bytes(data[..ARCHIVE_HEADER_SIZE].try_into().unwrap())
+        .expect("parse header");
+
+    let wk_start = ARCHIVE_HEADER_SIZE;
+    let wrapped_key = data[wk_start..wk_start + WRAPPED_KEY_SIZE].to_vec();
+
+    let mut pos = wk_start + WRAPPED_KEY_SIZE;
+    let mut records = Vec::new();
+
+    for _ in 0..header.segment_count {
+        let (name, compression, checksum, data_len, hdr_size) =
+            SegmentRecord::read_header(&data[pos..]).expect("parse record header");
+        pos += hdr_size;
+        let enc_data = data[pos..pos + data_len as usize].to_vec();
+        pos += data_len as usize;
+        records.push(SegmentRecord {
+            name,
+            compression,
+            checksum,
+            encrypted_data: enc_data,
+        });
+    }
+
+    let trailer_bytes: [u8; ARCHIVE_TRAILER_SIZE] =
+        data[pos..pos + ARCHIVE_TRAILER_SIZE].try_into().unwrap();
+    let trailer = ArchiveTrailer::from_bytes(&trailer_bytes).expect("parse trailer");
+
+    // Verify BLAKE3 trailer covers everything before the trailer
+    let computed = blake3::hash(&data[..pos]);
+    assert_eq!(
+        trailer.checksum,
+        <[u8; 32]>::from(computed),
+        "trailer checksum mismatch"
+    );
+
+    (header, wrapped_key, records, trailer.checksum)
+}
+
+/// Unwrap the export key and decrypt a segment record.
+fn decrypt_record(
+    record: &crate::core::evfs::archive::SegmentRecord,
+    wrapped_key: &[u8],
+    wk: &[u8],
+    algorithm: crate::core::format::Algorithm,
+) -> Vec<u8> {
+    use crate::core::evfs::archive::KEY_WRAP_AAD;
+    use crate::core::evfs::segment;
+
+    let export_key = segment::aead_decrypt_with_stored_nonce(wk, wrapped_key, KEY_WRAP_AAD, algorithm)
+        .expect("unwrap export key");
+    segment::aead_decrypt_with_stored_nonce(
+        &export_key,
+        &record.encrypted_data,
+        record.name.as_bytes(),
+        algorithm,
+    )
+    .expect("decrypt record")
+}
+
+// -- Archive format unit tests ---------------------------------------------
+
+#[test]
+fn test_archive_header_roundtrip() {
+    use crate::core::evfs::archive::*;
+
+    let header = ArchiveHeader::new(0x01, 42);
+    let bytes = header.to_bytes();
+    let parsed = ArchiveHeader::from_bytes(&bytes).expect("parse");
+    assert_eq!(parsed.version, ARCHIVE_VERSION);
+    assert_eq!(parsed.algorithm, 0x01);
+    assert_eq!(parsed.segment_count, 42);
+    assert_eq!(parsed.flags, 0);
+}
+
+#[test]
+fn test_archive_header_bad_magic_rejected() {
+    use crate::core::evfs::archive::*;
+
+    let mut bytes = ArchiveHeader::new(0x01, 1).to_bytes();
+    bytes[0] = b'X'; // corrupt magic
+    assert!(ArchiveHeader::from_bytes(&bytes).is_err());
+}
+
+#[test]
+fn test_archive_header_bad_version_rejected() {
+    use crate::core::evfs::archive::*;
+
+    let mut bytes = ArchiveHeader::new(0x01, 1).to_bytes();
+    bytes[4] = 99; // unsupported version
+    assert!(ArchiveHeader::from_bytes(&bytes).is_err());
+}
+
+#[test]
+fn test_archive_trailer_roundtrip() {
+    use crate::core::evfs::archive::*;
+
+    let checksum = [0xAB; 32];
+    let trailer = ArchiveTrailer { checksum };
+    let bytes = trailer.to_bytes();
+    let parsed = ArchiveTrailer::from_bytes(&bytes).expect("parse");
+    assert_eq!(parsed.checksum, checksum);
+}
+
+#[test]
+fn test_archive_trailer_bad_magic_rejected() {
+    use crate::core::evfs::archive::*;
+
+    let mut bytes = (ArchiveTrailer { checksum: [0; 32] }).to_bytes();
+    bytes[35] = b'Z'; // corrupt reverse magic
+    assert!(ArchiveTrailer::from_bytes(&bytes).is_err());
+}
+
+#[test]
+fn test_segment_record_header_roundtrip() {
+    use crate::core::evfs::archive::*;
+
+    let record = SegmentRecord {
+        name: "hello.txt".into(),
+        compression: 0x01,
+        checksum: [0xDD; 32],
+        encrypted_data: vec![0xFF; 100],
+    };
+    let header = record.write_header().expect("write header");
+    let (name, comp, cksum, data_len, consumed) =
+        SegmentRecord::read_header(&header).expect("read header");
+    assert_eq!(name, "hello.txt");
+    assert_eq!(comp, 0x01);
+    assert_eq!(cksum, [0xDD; 32]);
+    assert_eq!(data_len, 100);
+    assert_eq!(consumed, header.len());
+}
+
+#[test]
+fn test_wrapped_key_size() {
+    use crate::core::evfs::archive::WRAPPED_KEY_SIZE;
+    // nonce(12) + ciphertext(32) + tag(16) = 60
+    assert_eq!(WRAPPED_KEY_SIZE, 60);
+}
+
+#[test]
+fn test_archive_trailer_size() {
+    use crate::core::evfs::archive::ARCHIVE_TRAILER_SIZE;
+    // blake3(32) + reverse_magic(4) = 36
+    assert_eq!(ARCHIVE_TRAILER_SIZE, 36);
+}
+
+// -- Export integration tests ---------------------------------------------
+
+#[test]
+fn test_export_produces_valid_archive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write");
+    vault_write(&mut handle, "b.txt".into(), b"world".to_vec(), None).expect("write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+
+    let (header, wrapped_key, records, _) = parse_archive(&epath);
+    assert_eq!(header.segment_count, 2);
+    assert_eq!(header.version, 1);
+    assert_eq!(records.len(), 2);
+
+    // Decrypt and verify contents
+    let algo = crate::core::format::Algorithm::AesGcm;
+    for record in &records {
+        let plaintext = decrypt_record(record, &wrapped_key, &wrapping_key(), algo);
+        match record.name.as_str() {
+            "a.txt" => assert_eq!(plaintext, b"hello"),
+            "b.txt" => assert_eq!(plaintext, b"world"),
+            other => panic!("unexpected segment: {other}"),
+        }
+        // Verify BLAKE3 checksum in record matches plaintext
+        let expected = crate::core::evfs::segment::compute_checksum(&plaintext);
+        assert_eq!(record.checksum, expected);
+    }
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_export_empty_vault() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+
+    let (header, _, records, _) = parse_archive(&epath);
+    assert_eq!(header.segment_count, 0);
+    assert!(records.is_empty());
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_export_with_streaming_segments() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    // Write a streaming segment (> 64KB to trigger chunking)
+    let data: Vec<u8> = (0..200_000).map(|i| (i % 251) as u8).collect();
+    let chunks: Vec<Vec<u8>> = data.chunks(65536).map(|c| c.to_vec()).collect();
+    vault_write_stream(
+        &mut handle,
+        "big.bin".into(),
+        data.len() as u64,
+        chunks.into_iter(),
+    )
+    .expect("stream write");
+
+    // Also write a monolithic segment
+    vault_write(&mut handle, "small.txt".into(), b"tiny".to_vec(), None).expect("write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+
+    let (header, wrapped_key, records, _) = parse_archive(&epath);
+    assert_eq!(header.segment_count, 2);
+
+    let algo = crate::core::format::Algorithm::AesGcm;
+    for record in &records {
+        let plaintext = decrypt_record(record, &wrapped_key, &wrapping_key(), algo);
+        match record.name.as_str() {
+            "big.bin" => assert_eq!(plaintext, data),
+            "small.txt" => assert_eq!(plaintext, b"tiny"),
+            other => panic!("unexpected segment: {other}"),
+        }
+    }
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_export_with_compressed_segments() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    let data = b"compress me please ".repeat(100);
+    let config = CompressionConfig {
+        algorithm: CompressionAlgorithm::Zstd,
+        level: None,
+    };
+    vault_write(&mut handle, "compressed.txt".into(), data.clone(), Some(config)).expect("write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+
+    let (_, wrapped_key, records, _) = parse_archive(&epath);
+    assert_eq!(records.len(), 1);
+
+    let algo = crate::core::format::Algorithm::AesGcm;
+    let plaintext = decrypt_record(&records[0], &wrapped_key, &wrapping_key(), algo);
+    assert_eq!(plaintext, data);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_export_does_not_modify_vault() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "a.txt".into(), b"data-A".to_vec(), None).expect("write");
+    vault_write(&mut handle, "b.txt".into(), b"data-B".to_vec(), None).expect("write");
+
+    // Snapshot state before export
+    let names_before: Vec<String> = vault_list(&handle).into_iter().collect();
+    let health_before = vault_health(&handle);
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+
+    // Verify vault unchanged
+    let names_after: Vec<String> = vault_list(&handle).into_iter().collect();
+    let health_after = vault_health(&handle);
+    assert_eq!(names_before, names_after);
+    assert_eq!(health_before, health_after);
+
+    // Verify data still readable
+    let a = vault_read(&mut handle, "a.txt".into()).expect("read a");
+    assert_eq!(a, b"data-A");
+    let b = vault_read(&mut handle, "b.txt".into()).expect("read b");
+    assert_eq!(b, b"data-B");
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_export_wrong_wrapping_key_cannot_decrypt() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "secret.txt".into(), b"top secret".to_vec(), None).expect("write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+
+    let (_, wrapped_key, _records, _) = parse_archive(&epath);
+    let algo = crate::core::format::Algorithm::AesGcm;
+
+    // Try to unwrap with wrong key
+    let wrong_wk = vec![0xEE; 32];
+    let result = crate::core::evfs::segment::aead_decrypt_with_stored_nonce(
+        &wrong_wk,
+        &wrapped_key,
+        crate::core::evfs::archive::KEY_WRAP_AAD,
+        algo,
+    );
+    assert!(result.is_err(), "wrong wrapping key must fail to unwrap export key");
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_export_invalid_wrapping_key_length_rejected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    let epath = export_path(&dir);
+    let result = vault_export(&mut handle, vec![0xAA; 16], epath); // 16 bytes, not 32
+    assert!(result.is_err());
+
+    vault_close(handle).expect("close");
+}

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -49,6 +49,9 @@ pub enum CryptoError {
 
     #[error("Key rotation failed: {0}")]
     KeyRotationFailed(String),
+
+    #[error("Export failed: {0}")]
+    ExportFailed(String),
 }
 
 impl From<std::io::Error> for CryptoError {

--- a/rust/src/core/evfs/archive.rs
+++ b/rust/src/core/evfs/archive.rs
@@ -1,0 +1,191 @@
+//! `.mvex` portable encrypted archive format — types, constants, and serialization.
+
+use crate::core::error::CryptoError;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+pub const ARCHIVE_MAGIC: &[u8; 4] = b"MVEX";
+pub const REVERSE_MAGIC: &[u8; 4] = b"XEVM";
+pub const ARCHIVE_VERSION: u8 = 1;
+
+pub const ARCHIVE_HEADER_SIZE: usize = 32;
+pub const WRAPPED_KEY_SIZE: usize = 60; // 12 nonce + 32 ciphertext + 16 tag
+pub const ARCHIVE_TRAILER_SIZE: usize = 36; // 32 BLAKE3 + 4 reverse magic
+
+/// AAD used when wrapping the ephemeral export key with the caller's wrapping key.
+pub const KEY_WRAP_AAD: &[u8] = b"msec-export-key-wrap";
+
+// ---------------------------------------------------------------------------
+// ArchiveHeader (32 bytes)
+// ---------------------------------------------------------------------------
+
+/// Fixed-size header at the start of every `.mvex` archive.
+///
+/// ```text
+/// [0..4]   magic "MVEX"
+/// [4]      version (1)
+/// [5]      algorithm byte (matches vault Algorithm enum)
+/// [6..8]   flags (reserved, LE u16)
+/// [8..12]  segment_count (LE u32)
+/// [12..32] reserved (zeros)
+/// ```
+pub struct ArchiveHeader {
+    pub version: u8,
+    pub algorithm: u8,
+    pub flags: u16,
+    pub segment_count: u32,
+}
+
+impl ArchiveHeader {
+    pub fn new(algorithm: u8, segment_count: u32) -> Self {
+        Self {
+            version: ARCHIVE_VERSION,
+            algorithm,
+            flags: 0,
+            segment_count,
+        }
+    }
+
+    pub fn to_bytes(&self) -> [u8; ARCHIVE_HEADER_SIZE] {
+        let mut buf = [0u8; ARCHIVE_HEADER_SIZE];
+        buf[0..4].copy_from_slice(ARCHIVE_MAGIC);
+        buf[4] = self.version;
+        buf[5] = self.algorithm;
+        buf[6..8].copy_from_slice(&self.flags.to_le_bytes());
+        buf[8..12].copy_from_slice(&self.segment_count.to_le_bytes());
+        // [12..32] reserved zeros
+        buf
+    }
+
+    pub fn from_bytes(buf: &[u8; ARCHIVE_HEADER_SIZE]) -> Result<Self, CryptoError> {
+        if &buf[0..4] != ARCHIVE_MAGIC {
+            return Err(CryptoError::ExportFailed("invalid archive magic".into()));
+        }
+        let version = buf[4];
+        if version != ARCHIVE_VERSION {
+            return Err(CryptoError::ExportFailed(format!(
+                "unsupported archive version: {version}"
+            )));
+        }
+        let algorithm = buf[5];
+        let flags = u16::from_le_bytes([buf[6], buf[7]]);
+        let segment_count = u32::from_le_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        Ok(Self {
+            version,
+            algorithm,
+            flags,
+            segment_count,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SegmentRecord — per-segment entry in the archive
+// ---------------------------------------------------------------------------
+
+/// A single segment record in the archive.
+///
+/// ```text
+/// [name_len: u16 LE] [name: UTF-8 bytes]
+/// [compression: u8]
+/// [checksum: 32 bytes BLAKE3]
+/// [data_len: u64 LE]  (length of encrypted_data: nonce + ciphertext + tag)
+/// [encrypted_data: data_len bytes]
+/// ```
+pub struct SegmentRecord {
+    pub name: String,
+    pub compression: u8,
+    pub checksum: [u8; 32],
+    pub encrypted_data: Vec<u8>,
+}
+
+impl SegmentRecord {
+    /// Serialize the record header (everything before encrypted_data) into bytes.
+    /// Returns the header bytes. The caller writes encrypted_data separately.
+    pub fn write_header(&self) -> Result<Vec<u8>, CryptoError> {
+        let name_bytes = self.name.as_bytes();
+        let name_len = u16::try_from(name_bytes.len()).map_err(|_| {
+            CryptoError::ExportFailed("segment name too long for archive".into())
+        })?;
+        let data_len = self.encrypted_data.len() as u64;
+
+        // name_len(2) + name + compression(1) + checksum(32) + data_len(8)
+        let header_size = 2 + name_bytes.len() + 1 + 32 + 8;
+        let mut buf = Vec::with_capacity(header_size);
+
+        buf.extend_from_slice(&name_len.to_le_bytes());
+        buf.extend_from_slice(name_bytes);
+        buf.push(self.compression);
+        buf.extend_from_slice(&self.checksum);
+        buf.extend_from_slice(&data_len.to_le_bytes());
+
+        Ok(buf)
+    }
+
+    /// Read a segment record header from a byte slice, returning (record_minus_data, bytes_consumed).
+    /// The caller must then read `data_len` bytes of encrypted_data.
+    pub fn read_header(data: &[u8]) -> Result<(String, u8, [u8; 32], u64, usize), CryptoError> {
+        if data.len() < 2 {
+            return Err(CryptoError::ExportFailed("truncated segment record".into()));
+        }
+        let name_len = u16::from_le_bytes([data[0], data[1]]) as usize;
+        let mut pos = 2;
+
+        if data.len() < pos + name_len + 1 + 32 + 8 {
+            return Err(CryptoError::ExportFailed("truncated segment record".into()));
+        }
+
+        let name = std::str::from_utf8(&data[pos..pos + name_len])
+            .map_err(|_| CryptoError::ExportFailed("invalid UTF-8 segment name".into()))?
+            .to_string();
+        pos += name_len;
+
+        let compression = data[pos];
+        pos += 1;
+
+        let mut checksum = [0u8; 32];
+        checksum.copy_from_slice(&data[pos..pos + 32]);
+        pos += 32;
+
+        let data_len = u64::from_le_bytes(data[pos..pos + 8].try_into().unwrap());
+        pos += 8;
+
+        Ok((name, compression, checksum, data_len, pos))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ArchiveTrailer (36 bytes)
+// ---------------------------------------------------------------------------
+
+/// Trailer at the end of every `.mvex` archive.
+///
+/// ```text
+/// [0..32]  BLAKE3 hash of everything before the trailer
+/// [32..36] reverse magic "XEVM"
+/// ```
+pub struct ArchiveTrailer {
+    pub checksum: [u8; 32],
+}
+
+impl ArchiveTrailer {
+    pub fn to_bytes(&self) -> [u8; ARCHIVE_TRAILER_SIZE] {
+        let mut buf = [0u8; ARCHIVE_TRAILER_SIZE];
+        buf[0..32].copy_from_slice(&self.checksum);
+        buf[32..36].copy_from_slice(REVERSE_MAGIC);
+        buf
+    }
+
+    pub fn from_bytes(buf: &[u8; ARCHIVE_TRAILER_SIZE]) -> Result<Self, CryptoError> {
+        if &buf[32..36] != REVERSE_MAGIC {
+            return Err(CryptoError::ExportFailed(
+                "invalid archive trailer magic".into(),
+            ));
+        }
+        let mut checksum = [0u8; 32];
+        checksum.copy_from_slice(&buf[0..32]);
+        Ok(Self { checksum })
+    }
+}

--- a/rust/src/core/evfs/mod.rs
+++ b/rust/src/core/evfs/mod.rs
@@ -4,6 +4,7 @@
 //! does not scan them. Only the public vault API in `api/evfs/` is
 //! exposed to Flutter.
 
+pub mod archive;
 pub mod format;
 pub mod segment;
 pub mod wal;


### PR DESCRIPTION
## Summary

  - Define the `.mvex` portable encrypted archive format with header, per-segment records, and BLAKE3 trailer
  - Implement `vault_export(handle, wrapping_key, export_path)` that produces a self-contained encrypted backup of
  all vault segments
  - Add `ExportFailed` error variant to `CryptoError`

  ### Archive format (.mvex)

  Each segment is decrypted from the vault, then re-encrypted under an ephemeral 32-byte export key (CSPRNG) with a
  per-segment random nonce. The export key is AEAD-wrapped with the caller's wrapping key.

  ArchiveHeader (32B): magic "MVEX" | version | algorithm | flags | segment_count | reserved
  WrappedExportKey (60B): nonce(12) | encrypt(wrapping_key, export_key)(32) | tag(16)
  SegmentRecord[]: name_len | name(UTF-8) | compression | checksum(BLAKE3) | data_len | encrypted_data
  ArchiveTrailer (36B): blake3(everything above) | reverse_magic "XEVM"

  ### Security hardening

  - `wrapping_key` wrapped in `Zeroizing` on entry — zeroized on all paths including errors
  - Streaming plaintext accumulator uses `Zeroizing<Vec<u8>>` — no plaintext leaks on error
  - Partial `.mvex` file deleted on any error (split into `vault_export` + `vault_export_write`)
  - Segment size capped at vault capacity before heap allocation (OOM protection)
  - `OpenOptions::create_new(true)` prevents clobbering existing files
  - BLAKE3 checksum computed before re-encryption (safe ordering)
  - Segment name bound as AAD on re-encryption (prevents segment-swap attacks)
  - Export key zeroized on drop via `Zeroizing`

  ## Changes

  | File | Change |
  |------|--------|
  | `rust/src/core/error.rs` | `ExportFailed(String)` variant |
  | `rust/src/core/evfs/archive.rs` | **New** — `.mvex` format types and serialization |
  | `rust/src/core/evfs/mod.rs` | Register `archive` module |
  | `rust/src/api/evfs/mod.rs` | `vault_export()` + `vault_export_write()` |
  | `rust/src/api/evfs/tests.rs` | 15 tests (8 format + 7 export) |

  ## Test plan

  - [x] Archive header roundtrip + bad magic/version rejection
  - [x] Archive trailer roundtrip + bad magic rejection
  - [x] Segment record header roundtrip
  - [x] Wrapped key and trailer size constants
  - [x] Export produces valid archive with correct magic/version/segment count
  - [x] Export of empty vault (0 segments)
  - [x] Export with monolithic and streaming segments
  - [x] Export with compressed (zstd) segments
  - [x] Source vault unmodified after export
  - [x] Wrong wrapping key cannot decrypt archive
  - [x] Invalid wrapping key length rejected
  - [x] Full test suite: 356 passed, 0 failed