### PR TITLE
feat(evfs): implement secure vault import with integrity verification and full test coverage

### DIFF
--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -263,9 +263,12 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
 pub fn vault_write(
     handle: &mut VaultHandle,
     name: String,
-    mut data: Vec<u8>,
+    data: Vec<u8>,
     compression: Option<CompressionConfig>,
 ) -> Result<(), CryptoError> {
+    // SAFETY: Zeroizing guarantees plaintext is wiped on all exit paths
+    let data = Zeroizing::new(data);
+
     let config = compression.unwrap_or(CompressionConfig {
         algorithm: CompressionAlgorithm::None,
         level: None,
@@ -284,7 +287,7 @@ pub fn vault_write(
         generation: gen,
     };
     let (encrypted, effective_algo) = segment::encrypt_segment(&params, &data, &name, &config)?;
-    data.zeroize();
+    drop(data);
 
     // 3. WAL journal old index
     let old_encrypted_index = read_encrypted_index(
@@ -1575,7 +1578,14 @@ pub fn vault_import(
     archive
         .read_exact(&mut header_buf)
         .map_err(|_| CryptoError::ImportFailed("Truncated archive header".into()))?;
-    let header = ArchiveHeader::from_bytes(&header_buf)?;
+    let header = ArchiveHeader::from_bytes(&header_buf)
+        .map_err(|_| CryptoError::ImportFailed("invalid archive header".into()))?;
+
+    if header.segment_count > 100_000 {
+        return Err(CryptoError::ImportFailed(
+            "archive segment count exceeds sanity limit".into(),
+        ));
+    }
 
     // Read WrappedExportKey
     let mut wrapped_key = [0u8; WRAPPED_KEY_SIZE];
@@ -1601,10 +1611,7 @@ pub fn vault_import(
 
     // Create new destination vault
     let mut dest_vault =
-        match vault_create(dest_path.clone(), new_master_key, algorithm, capacity_bytes) {
-            Ok(v) => v,
-            Err(e) => return Err(e),
-        };
+        vault_create(dest_path.clone(), new_master_key, algorithm, capacity_bytes)?;
 
     // Process all segments inside a closure to handle atomic crash recovery cleanup
     let mut process_records = || -> Result<(), CryptoError> {
@@ -1623,6 +1630,13 @@ pub fn vault_import(
             let name = String::from_utf8(name_buf)
                 .map_err(|_| CryptoError::ImportFailed("Invalid UTF-8 in segment name".into()))?;
 
+            if name.is_empty() || name.len() > 255 {
+                return Err(CryptoError::ImportFailed(format!(
+                    "invalid segment name length: {}",
+                    name.len()
+                )));
+            }
+
             let mut comp_buf = [0u8; 1];
             archive
                 .read_exact(&mut comp_buf)
@@ -1638,15 +1652,18 @@ pub fn vault_import(
             archive
                 .read_exact(&mut data_len_buf)
                 .map_err(|_| CryptoError::ImportFailed("Truncated segment data length".into()))?;
-            let data_len = u64::from_le_bytes(data_len_buf) as usize;
+            let data_len_u64 = u64::from_le_bytes(data_len_buf);
 
-            // OOM Crash Protection
-            if data_len > capacity_bytes as usize + 65536 {
+            // OOM guard — u64 arithmetic avoids truncation on 32-bit targets
+            if data_len_u64 > capacity_bytes.saturating_add(65536) {
                 return Err(CryptoError::VaultFull {
-                    needed: data_len as u64,
+                    needed: data_len_u64,
                     available: capacity_bytes,
                 });
             }
+            let data_len = usize::try_from(data_len_u64).map_err(|_| {
+                CryptoError::ImportFailed("segment data_len exceeds address space".into())
+            })?;
 
             let mut encrypted_data = vec![0u8; data_len];
             archive.read_exact(&mut encrypted_data).map_err(|_| {
@@ -1685,9 +1702,14 @@ pub fn vault_import(
             }
 
             let comp_algo = match compression {
+                0 => CompressionAlgorithm::None,
                 1 => CompressionAlgorithm::Zstd,
                 2 => CompressionAlgorithm::Brotli,
-                _ => CompressionAlgorithm::None,
+                _ => {
+                    return Err(CryptoError::ImportFailed(format!(
+                        "unknown compression byte: {compression}"
+                    )))
+                }
             };
 
             // vault_write takes ownership of plaintext and handles its zeroization internally
@@ -1707,7 +1729,8 @@ pub fn vault_import(
         archive
             .read_exact(&mut trailer_buf)
             .map_err(|_| CryptoError::ImportFailed("Truncated archive trailer".into()))?;
-        let trailer = ArchiveTrailer::from_bytes(&trailer_buf)?;
+        let trailer = ArchiveTrailer::from_bytes(&trailer_buf)
+            .map_err(|_| CryptoError::ImportFailed("invalid archive trailer".into()))?;
 
         let final_hash = archive_hasher.finalize();
         if trailer.checksum.ct_ne(final_hash.as_bytes()).into() {
@@ -1726,6 +1749,7 @@ pub fn vault_import(
             if archive.read_exact(&mut extra).is_ok() {
                 drop(dest_vault);
                 let _ = std::fs::remove_file(&dest_path);
+                let _ = std::fs::remove_file(format!("{dest_path}.lock"));
                 let _ = std::fs::remove_file(format!("{dest_path}.wal"));
                 let _ = std::fs::remove_file(format!("{dest_path}.defrag"));
                 return Err(CryptoError::ImportFailed(
@@ -1738,6 +1762,7 @@ pub fn vault_import(
             // Crash Recovery: safely delete partial/corrupted destination vault
             drop(dest_vault);
             let _ = std::fs::remove_file(&dest_path);
+            let _ = std::fs::remove_file(format!("{dest_path}.lock"));
             let _ = std::fs::remove_file(format!("{dest_path}.wal"));
             let _ = std::fs::remove_file(format!("{dest_path}.defrag"));
             Err(e)

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -1382,9 +1382,8 @@ pub fn vault_export(
     )?;
 
     // 3. Prepare header
-    let segment_count = u32::try_from(handle.index.entries.len()).map_err(|_| {
-        CryptoError::ExportFailed("segment count exceeds u32".into())
-    })?;
+    let segment_count = u32::try_from(handle.index.entries.len())
+        .map_err(|_| CryptoError::ExportFailed("segment count exceeds u32".into()))?;
     let header = ArchiveHeader::new(handle.algorithm.to_byte(), segment_count);
 
     // Use create_new to fail atomically if the file already exists.
@@ -1427,17 +1426,22 @@ fn vault_export_write(
     archive_hasher.update(wrapped_key);
 
     // Clone entry metadata to avoid borrow conflict with handle
-    let entries: Vec<_> = handle.index.entries.iter().map(|e| {
-        (
-            e.name.clone(),
-            e.offset,
-            e.size,
-            e.generation,
-            e.compression,
-            e.checksum,
-            e.chunk_count,
-        )
-    }).collect();
+    let entries: Vec<_> = handle
+        .index
+        .entries
+        .iter()
+        .map(|e| {
+            (
+                e.name.clone(),
+                e.offset,
+                e.size,
+                e.generation,
+                e.compression,
+                e.checksum,
+                e.chunk_count,
+            )
+        })
+        .collect();
 
     let vault_capacity = handle.index.capacity;
 
@@ -1543,4 +1547,200 @@ pub fn vault_close(mut handle: VaultHandle) -> Result<(), CryptoError> {
     handle.lock.release()?;
     // VaultKeys are zeroized on drop (ZeroizeOnDrop)
     Ok(())
+}
+
+/// Unwraps export key, creates new vault at dest_path, writes all segments under new_master_key.
+#[cfg(feature = "compression")]
+pub fn vault_import(
+    archive_path: String,
+    wrapping_key: Vec<u8>,
+    dest_path: String,
+    new_master_key: Vec<u8>,
+    algorithm: String,
+    capacity_bytes: u64,
+) -> Result<VaultHandle, CryptoError> {
+    use crate::core::evfs::archive::{
+        ArchiveHeader, ArchiveTrailer, ARCHIVE_HEADER_SIZE, ARCHIVE_TRAILER_SIZE, KEY_WRAP_AAD,
+        WRAPPED_KEY_SIZE,
+    };
+
+    // Ensure automatic zeroization on drop
+    let wrapping_key = Zeroizing::new(wrapping_key);
+
+    let mut archive = File::open(&archive_path)
+        .map_err(|e| CryptoError::IoError(format!("cannot open archive '{archive_path}': {e}")))?;
+
+    // Read & Validate Header
+    let mut header_buf = [0u8; ARCHIVE_HEADER_SIZE];
+    archive
+        .read_exact(&mut header_buf)
+        .map_err(|_| CryptoError::ImportFailed("Truncated archive header".into()))?;
+    let header = ArchiveHeader::from_bytes(&header_buf)?;
+
+    // Read WrappedExportKey
+    let mut wrapped_key = [0u8; WRAPPED_KEY_SIZE];
+    archive
+        .read_exact(&mut wrapped_key)
+        .map_err(|_| CryptoError::ImportFailed("Truncated wrapped key".into()))?;
+
+    let mut archive_hasher = blake3::Hasher::new();
+    archive_hasher.update(&header_buf);
+    archive_hasher.update(&wrapped_key);
+
+    let algo = Algorithm::from_byte(header.algorithm).map_err(|_| {
+        CryptoError::ImportFailed(format!("Unsupported algorithm byte: {}", header.algorithm))
+    })?;
+
+    // Unwrap the ephemeral export key
+    let export_key = Zeroizing::new(
+        segment::aead_decrypt_with_stored_nonce(&wrapping_key, &wrapped_key, KEY_WRAP_AAD, algo)
+            .map_err(|_| {
+                CryptoError::ImportFailed("Invalid wrapping key or corrupted wrapped key".into())
+            })?,
+    );
+
+    // Create new destination vault
+    let mut dest_vault =
+        match vault_create(dest_path.clone(), new_master_key, algorithm, capacity_bytes) {
+            Ok(v) => v,
+            Err(e) => return Err(e),
+        };
+
+    // Process all segments inside a closure to handle atomic crash recovery cleanup
+    let mut process_records = || -> Result<(), CryptoError> {
+        for _ in 0..header.segment_count {
+            // Read SegmentRecordHeader components sequentially
+            let mut name_len_buf = [0u8; 2];
+            archive
+                .read_exact(&mut name_len_buf)
+                .map_err(|_| CryptoError::ImportFailed("Truncated segment record".into()))?;
+            let name_len = u16::from_le_bytes(name_len_buf) as usize;
+
+            let mut name_buf = vec![0u8; name_len];
+            archive
+                .read_exact(&mut name_buf)
+                .map_err(|_| CryptoError::ImportFailed("Truncated segment name".into()))?;
+            let name = String::from_utf8(name_buf)
+                .map_err(|_| CryptoError::ImportFailed("Invalid UTF-8 in segment name".into()))?;
+
+            let mut comp_buf = [0u8; 1];
+            archive
+                .read_exact(&mut comp_buf)
+                .map_err(|_| CryptoError::ImportFailed("Truncated segment compression".into()))?;
+            let compression = comp_buf[0];
+
+            let mut checksum = [0u8; 32];
+            archive
+                .read_exact(&mut checksum)
+                .map_err(|_| CryptoError::ImportFailed("Truncated segment checksum".into()))?;
+
+            let mut data_len_buf = [0u8; 8];
+            archive
+                .read_exact(&mut data_len_buf)
+                .map_err(|_| CryptoError::ImportFailed("Truncated segment data length".into()))?;
+            let data_len = u64::from_le_bytes(data_len_buf) as usize;
+
+            // OOM Crash Protection
+            if data_len > capacity_bytes as usize + 65536 {
+                return Err(CryptoError::ImportFailed(format!(
+                    "Segment size {} exceeds destination capacity",
+                    data_len
+                )));
+            }
+
+            let mut encrypted_data = vec![0u8; data_len];
+            archive.read_exact(&mut encrypted_data).map_err(|_| {
+                CryptoError::ImportFailed("Truncated segment encrypted data".into())
+            })?;
+
+            // Feed global trailer hasher
+            let mut header_bytes = Vec::new();
+            header_bytes.extend_from_slice(&name_len_buf);
+            header_bytes.extend_from_slice(name.as_bytes());
+            header_bytes.push(compression);
+            header_bytes.extend_from_slice(&checksum);
+            header_bytes.extend_from_slice(&data_len_buf);
+
+            archive_hasher.update(&header_bytes);
+            archive_hasher.update(&encrypted_data);
+
+            // 4. Decrypt using export_key
+            let mut plaintext = segment::aead_decrypt_with_stored_nonce(
+                &export_key,
+                &encrypted_data,
+                name.as_bytes(),
+                algo,
+            )
+            .map_err(|_| {
+                CryptoError::ImportFailed(format!("Authentication failed for segment '{name}'"))
+            })?;
+
+            // Verify BLAKE3 checksum (constant-time verification)
+            let computed_checksum = segment::compute_checksum(&plaintext);
+            if computed_checksum.ct_ne(&checksum).into() {
+                plaintext.zeroize();
+                return Err(CryptoError::ImportFailed(format!(
+                    "Checksum mismatch for segment '{name}'"
+                )));
+            }
+
+            let comp_algo = match compression {
+                1 => CompressionAlgorithm::Zstd,
+                2 => CompressionAlgorithm::Brotli,
+                _ => CompressionAlgorithm::None,
+            };
+
+            // vault_write takes ownership of plaintext and handles its zeroization internally
+            vault_write(
+                &mut dest_vault,
+                name,
+                plaintext,
+                Some(CompressionConfig {
+                    algorithm: comp_algo,
+                    level: None,
+                }),
+            )?;
+        }
+
+        // 5. Verify archive trailer
+        let mut trailer_buf = [0u8; ARCHIVE_TRAILER_SIZE];
+        archive
+            .read_exact(&mut trailer_buf)
+            .map_err(|_| CryptoError::ImportFailed("Truncated archive trailer".into()))?;
+        let trailer = ArchiveTrailer::from_bytes(&trailer_buf)?;
+
+        let final_hash = archive_hasher.finalize();
+        if trailer.checksum.ct_ne(final_hash.as_bytes()).into() {
+            return Err(CryptoError::ImportFailed(
+                "Archive trailer checksum mismatch".into(),
+            ));
+        }
+
+        Ok(())
+    };
+
+    match process_records() {
+        Ok(()) => {
+            // Guard against appended malicious trailing payload
+            let mut extra = [0u8; 1];
+            if archive.read_exact(&mut extra).is_ok() {
+                drop(dest_vault);
+                let _ = std::fs::remove_file(&dest_path);
+                let _ = std::fs::remove_file(format!("{dest_path}.wal"));
+                let _ = std::fs::remove_file(format!("{dest_path}.defrag"));
+                return Err(CryptoError::ImportFailed(
+                    "Trailing garbage at end of archive".into(),
+                ));
+            }
+            Ok(dest_vault)
+        }
+        Err(e) => {
+            // Crash Recovery: safely delete partial/corrupted destination vault
+            drop(dest_vault);
+            let _ = std::fs::remove_file(&dest_path);
+            let _ = std::fs::remove_file(format!("{dest_path}.wal"));
+            let _ = std::fs::remove_file(format!("{dest_path}.defrag"));
+            Err(e)
+        }
+    }
 }

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -1642,10 +1642,10 @@ pub fn vault_import(
 
             // OOM Crash Protection
             if data_len > capacity_bytes as usize + 65536 {
-                return Err(CryptoError::ImportFailed(format!(
-                    "Segment size {} exceeds destination capacity",
-                    data_len
-                )));
+                return Err(CryptoError::VaultFull {
+                    needed: data_len as u64,
+                    available: capacity_bytes,
+                });
             }
 
             let mut encrypted_data = vec![0u8; data_len];

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -2807,8 +2807,9 @@ fn decrypt_record(
     use crate::core::evfs::archive::KEY_WRAP_AAD;
     use crate::core::evfs::segment;
 
-    let export_key = segment::aead_decrypt_with_stored_nonce(wk, wrapped_key, KEY_WRAP_AAD, algorithm)
-        .expect("unwrap export key");
+    let export_key =
+        segment::aead_decrypt_with_stored_nonce(wk, wrapped_key, KEY_WRAP_AAD, algorithm)
+            .expect("unwrap export key");
     segment::aead_decrypt_with_stored_nonce(
         &export_key,
         &record.encrypted_data,
@@ -3003,7 +3004,13 @@ fn test_export_with_compressed_segments() {
         algorithm: CompressionAlgorithm::Zstd,
         level: None,
     };
-    vault_write(&mut handle, "compressed.txt".into(), data.clone(), Some(config)).expect("write");
+    vault_write(
+        &mut handle,
+        "compressed.txt".into(),
+        data.clone(),
+        Some(config),
+    )
+    .expect("write");
 
     let epath = export_path(&dir);
     vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
@@ -3053,7 +3060,13 @@ fn test_export_wrong_wrapping_key_cannot_decrypt() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut handle = create_test_vault(&dir, 1_048_576);
 
-    vault_write(&mut handle, "secret.txt".into(), b"top secret".to_vec(), None).expect("write");
+    vault_write(
+        &mut handle,
+        "secret.txt".into(),
+        b"top secret".to_vec(),
+        None,
+    )
+    .expect("write");
 
     let epath = export_path(&dir);
     vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
@@ -3069,7 +3082,10 @@ fn test_export_wrong_wrapping_key_cannot_decrypt() {
         crate::core::evfs::archive::KEY_WRAP_AAD,
         algo,
     );
-    assert!(result.is_err(), "wrong wrapping key must fail to unwrap export key");
+    assert!(
+        result.is_err(),
+        "wrong wrapping key must fail to unwrap export key"
+    );
 
     vault_close(handle).expect("close");
 }
@@ -3084,4 +3100,299 @@ fn test_export_invalid_wrapping_key_length_rejected() {
     assert!(result.is_err());
 
     vault_close(handle).expect("close");
+}
+
+// -- Import integration tests ---------------------------------------------
+
+fn import_dest_path(dir: &tempfile::TempDir) -> String {
+    dir.path()
+        .join("imported.vault")
+        .to_str()
+        .expect("path")
+        .to_string()
+}
+
+#[test]
+fn test_import_full_roundtrip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 2_097_152);
+
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write");
+    vault_write(&mut handle, "b.txt".into(), b"world".to_vec(), None).expect("write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    let dest_path = import_dest_path(&dir);
+    let mut imported = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        2_097_152,
+    )
+    .expect("import");
+
+    assert_eq!(
+        vault_read(&mut imported, "a.txt".into()).expect("read a"),
+        b"hello"
+    );
+    assert_eq!(
+        vault_read(&mut imported, "b.txt".into()).expect("read b"),
+        b"world"
+    );
+
+    vault_close(imported).expect("close");
+}
+
+#[test]
+fn test_import_wrong_wrapping_key_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write");
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    let dest_path = import_dest_path(&dir);
+    let wrong_wk = vec![0xEE; 32];
+    let result = vault_import(
+        epath,
+        wrong_wk,
+        dest_path,
+        test_key2(),
+        "aes-256-gcm".into(),
+        1_048_576,
+    );
+
+    assert!(matches!(result, Err(CryptoError::ImportFailed(_))));
+}
+
+#[test]
+fn test_import_truncated_archive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write");
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    // Truncate the archive midway
+    let mut archive = std::fs::read(&epath).expect("read");
+    archive.truncate(archive.len() - 10);
+    std::fs::write(&epath, archive).expect("write");
+
+    let dest_path = import_dest_path(&dir);
+    let result = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        1_048_576,
+    );
+
+    assert!(matches!(result, Err(CryptoError::ImportFailed(_))));
+    assert!(
+        !std::path::Path::new(&dest_path).exists(),
+        "Partial vault must be deleted"
+    );
+}
+
+#[test]
+fn test_import_tampered_segment_data() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write");
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    // Tamper with the encrypted data part of the segment record
+    let mut archive = std::fs::read(&epath).expect("read");
+    let pos = archive.len() - 36 - 10; // slightly before the trailer
+    archive[pos] ^= 0xFF;
+    std::fs::write(&epath, archive).expect("write");
+
+    let dest_path = import_dest_path(&dir);
+    let result = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        1_048_576,
+    );
+
+    assert!(matches!(result, Err(CryptoError::ImportFailed(_))));
+}
+
+#[test]
+fn test_import_tampered_trailer_checksum() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+    vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None).expect("write");
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    // Tamper with the trailer checksum
+    let mut archive = std::fs::read(&epath).expect("read");
+    let pos = archive.len() - 36 + 5; // within the 32 byte checksum
+    archive[pos] ^= 0xFF;
+    std::fs::write(&epath, archive).expect("write");
+
+    let dest_path = import_dest_path(&dir);
+    let result = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        1_048_576,
+    );
+
+    assert!(matches!(result, Err(CryptoError::ImportFailed(_))));
+}
+
+#[test]
+fn test_import_insufficient_capacity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 5_000_000);
+    vault_write(&mut handle, "big.txt".into(), vec![0xBB; 2_000_000], None).expect("write");
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    let dest_path = import_dest_path(&dir);
+    let result = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        1_048_576, // Bound restriction triggers EVFS index allocation rejection
+    );
+
+    assert!(matches!(result, Err(CryptoError::VaultFull { .. })));
+}
+
+#[test]
+fn test_import_streaming_segment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    let data: Vec<u8> = (0..200_000).map(|i| (i % 251) as u8).collect();
+    let chunks: Vec<Vec<u8>> = data.chunks(65536).map(|c| c.to_vec()).collect();
+    vault_write_stream(
+        &mut handle,
+        "stream.bin".into(),
+        data.len() as u64,
+        chunks.into_iter(),
+    )
+    .expect("stream write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    let dest_path = import_dest_path(&dir);
+    let mut imported = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        4_194_304,
+    )
+    .expect("import");
+
+    let readback = vault_read(&mut imported, "stream.bin".into()).expect("read");
+    assert_eq!(readback, data);
+
+    vault_close(imported).expect("close");
+}
+
+#[test]
+fn test_import_compressed_segment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    let data = b"compress me please ".repeat(100);
+    let config = CompressionConfig {
+        algorithm: CompressionAlgorithm::Zstd,
+        level: None,
+    };
+    vault_write(
+        &mut handle,
+        "compressed.txt".into(),
+        data.clone(),
+        Some(config),
+    )
+    .expect("write");
+
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    let dest_path = import_dest_path(&dir);
+    let mut imported = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "aes-256-gcm".into(),
+        1_048_576,
+    )
+    .expect("import");
+
+    let entry = imported.index.find("compressed.txt").expect("find");
+    assert_eq!(entry.compression, CompressionAlgorithm::Zstd);
+
+    let readback = vault_read(&mut imported, "compressed.txt".into()).expect("read");
+    assert_eq!(readback, data);
+
+    vault_close(imported).expect("close");
+}
+
+#[test]
+fn test_import_chacha20() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = vault_create(
+        vault_path(&dir),
+        test_key(),
+        "chacha20-poly1305".into(),
+        1_048_576,
+    )
+    .expect("create");
+
+    vault_write(&mut handle, "c.txt".into(), b"chacha".to_vec(), None).expect("write");
+    let epath = export_path(&dir);
+    vault_export(&mut handle, wrapping_key(), epath.clone()).expect("export");
+    vault_close(handle).expect("close");
+
+    let dest_path = import_dest_path(&dir);
+    let mut imported = vault_import(
+        epath,
+        wrapping_key(),
+        dest_path.clone(),
+        test_key2(),
+        "chacha20-poly1305".into(),
+        1_048_576,
+    )
+    .expect("import");
+
+    assert_eq!(
+        imported.algorithm,
+        crate::core::format::Algorithm::ChaCha20Poly1305
+    );
+    assert_eq!(
+        vault_read(&mut imported, "c.txt".into()).expect("read c"),
+        b"chacha"
+    );
+
+    vault_close(imported).expect("close");
 }

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -55,9 +55,9 @@ impl VaultMmap {
         let size = usize::try_from(len).map_err(|_| {
             CryptoError::VaultCorrupted(format!("mmap length {len} exceeds address space"))
         })?;
-        let end = start.checked_add(size).ok_or_else(|| {
-            CryptoError::VaultCorrupted("mmap range overflow".into())
-        })?;
+        let end = start
+            .checked_add(size)
+            .ok_or_else(|| CryptoError::VaultCorrupted("mmap range overflow".into()))?;
         if end > self.mmap.len() {
             return Err(CryptoError::VaultCorrupted(format!(
                 "mmap read {start}..{end} exceeds file size {}",

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -52,6 +52,9 @@ pub enum CryptoError {
 
     #[error("Export failed: {0}")]
     ExportFailed(String),
+
+    #[error("Import failed: {0}")]
+    ImportFailed(String),
 }
 
 impl From<std::io::Error> for CryptoError {

--- a/rust/src/core/evfs/archive.rs
+++ b/rust/src/core/evfs/archive.rs
@@ -149,7 +149,11 @@ impl SegmentRecord {
         checksum.copy_from_slice(&data[pos..pos + 32]);
         pos += 32;
 
-        let data_len = u64::from_le_bytes(data[pos..pos + 8].try_into().unwrap());
+        let data_len = u64::from_le_bytes(
+            data[pos..pos + 8]
+                .try_into()
+                .map_err(|_| CryptoError::ExportFailed("truncated data_len field".into()))?,
+        );
         pos += 8;
 
         Ok((name, compression, checksum, data_len, pos))


### PR DESCRIPTION
- Add `ImportFailed(String)` variant to `CryptoError`
- Implement `vault_import()` for `.mvex` archives
- Validate archive header (magic, version)
- Unwrap export key using provided wrapping key
- Create destination vault via `vault_create`
- Stream and process all segment records
- Decrypt segments using export key (AAD = segment name)
- Verify segment integrity using BLAKE3 (constant-time)
- Re-write segments via `vault_write` (preserves generation logic)
- Verify archive trailer checksum and structure
- Reject malformed, truncated, or tampered archives
- Enforce capacity limits during import
- Ensure zeroization of wrapping key, export key, and plaintext
- Implement crash recovery by deleting partial vault on failure
- Add full import test suite (roundtrip, tampering, truncation, wrong key, capacity, compression, streaming, multi-algorithm)

Closes #112