### PR TITLE
feat(evfs): Dart wrappers for key rotation, export, and import

### DIFF
--- a/integration_test/vault_key_management_test.dart
+++ b/integration_test/vault_key_management_test.dart
@@ -1,0 +1,287 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:m_security/src/rust/api/encryption.dart';
+import 'package:m_security/src/rust/frb_generated.dart';
+import 'package:m_security/src/evfs/vault_service.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async => await RustLib.init());
+
+  group('Key Management', () {
+    late Directory tempDir;
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('key_mgmt_test');
+    });
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('rotateKey roundtrip: write, rotate, read back', () async {
+      final path = '${tempDir.path}/rotate.vault';
+      final key = await generateAes256GcmKey();
+      final newKey = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final dataA = Uint8List.fromList(List.generate(500, (i) => i % 256));
+      final dataB = Uint8List.fromList(List.generate(1000, (i) => (i * 7) % 256));
+      await VaultService.write(handle: handle, name: 'a.bin', data: dataA);
+      await VaultService.write(handle: handle, name: 'b.bin', data: dataB);
+
+      // Rotate
+      handle = await VaultService.rotateKey(handle: handle, newKey: newKey);
+
+      // All segments readable with new handle
+      expect(await VaultService.read(handle: handle, name: 'a.bin'), dataA);
+      expect(await VaultService.read(handle: handle, name: 'b.bin'), dataB);
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('old key rejected after rotation', () async {
+      final path = '${tempDir.path}/oldkey.vault';
+      final key = await generateAes256GcmKey();
+      final newKey = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+
+      await VaultService.write(
+        handle: handle,
+        name: 'secret.bin',
+        data: Uint8List.fromList([1, 2, 3]),
+      );
+
+      handle = await VaultService.rotateKey(handle: handle, newKey: newKey);
+      await VaultService.close(handle: handle);
+
+      // Old key must fail
+      expect(
+        () async => await VaultService.open(path: path, key: key),
+        throwsA(isA<Exception>()),
+      );
+
+      // New key works
+      final reopened = await VaultService.open(path: path, key: newKey);
+      expect(
+        await VaultService.read(handle: reopened, name: 'secret.bin'),
+        Uint8List.fromList([1, 2, 3]),
+      );
+      await VaultService.close(handle: reopened);
+    });
+
+    test('export-import roundtrip: data matches byte-for-byte', () async {
+      final vaultPath = '${tempDir.path}/source.vault';
+      final archivePath = '${tempDir.path}/export.mvex';
+      final importPath = '${tempDir.path}/imported.vault';
+      final key = await generateAes256GcmKey();
+      final wrappingKey = await generateAes256GcmKey();
+      final importKey = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: vaultPath,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data1 = Uint8List.fromList(List.generate(800, (i) => i % 256));
+      final data2 = Uint8List.fromList(List.generate(1200, (i) => (i * 3) % 256));
+      await VaultService.write(handle: handle, name: 'file1.dat', data: data1);
+      await VaultService.write(handle: handle, name: 'file2.dat', data: data2);
+
+      // Export
+      await VaultService.export(
+        handle: handle,
+        wrappingKey: wrappingKey,
+        exportPath: archivePath,
+      );
+      await VaultService.close(handle: handle);
+
+      expect(File(archivePath).existsSync(), isTrue);
+
+      // Import into new vault
+      final imported = await VaultService.importVault(
+        archivePath: archivePath,
+        wrappingKey: wrappingKey,
+        destPath: importPath,
+        newMasterKey: importKey,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      expect(await VaultService.read(handle: imported, name: 'file1.dat'), data1);
+      expect(await VaultService.read(handle: imported, name: 'file2.dat'), data2);
+
+      await VaultService.close(handle: imported);
+    });
+
+    test('import with wrong wrapping key throws', () async {
+      final vaultPath = '${tempDir.path}/wk.vault';
+      final archivePath = '${tempDir.path}/wk.mvex';
+      final key = await generateAes256GcmKey();
+      final wrappingKey = await generateAes256GcmKey();
+      final wrongKey = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: vaultPath,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      await VaultService.write(
+        handle: handle,
+        name: 'x.bin',
+        data: Uint8List.fromList([42]),
+      );
+      await VaultService.export(
+        handle: handle,
+        wrappingKey: wrappingKey,
+        exportPath: archivePath,
+      );
+      await VaultService.close(handle: handle);
+
+      expect(
+        () async => await VaultService.importVault(
+          archivePath: archivePath,
+          wrappingKey: wrongKey,
+          destPath: '${tempDir.path}/bad.vault',
+          newMasterKey: await generateAes256GcmKey(),
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('large segment (1MB+) survives export-import', () async {
+      final vaultPath = '${tempDir.path}/big.vault';
+      final archivePath = '${tempDir.path}/big.mvex';
+      final importPath = '${tempDir.path}/big_imported.vault';
+      final key = await generateAes256GcmKey();
+      final wrappingKey = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: vaultPath,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 5 * 1024 * 1024,
+      );
+
+      final bigData = Uint8List.fromList(
+        List.generate(1024 * 1024 + 37, (i) => (i * 13) % 256),
+      );
+      await VaultService.write(handle: handle, name: 'big.bin', data: bigData);
+
+      await VaultService.export(
+        handle: handle,
+        wrappingKey: wrappingKey,
+        exportPath: archivePath,
+      );
+      await VaultService.close(handle: handle);
+
+      final imported = await VaultService.importVault(
+        archivePath: archivePath,
+        wrappingKey: wrappingKey,
+        destPath: importPath,
+        newMasterKey: await generateAes256GcmKey(),
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 5 * 1024 * 1024,
+      );
+
+      expect(await VaultService.read(handle: imported, name: 'big.bin'), bigData);
+      await VaultService.close(handle: imported);
+    });
+
+    test('multiple sequential rotations', () async {
+      final path = '${tempDir.path}/multi_rot.vault';
+      final key1 = await generateAes256GcmKey();
+      final key2 = await generateAes256GcmKey();
+      final key3 = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: path,
+        key: key1,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([10, 20, 30, 40, 50]);
+      await VaultService.write(handle: handle, name: 'data.bin', data: data);
+
+      // Rotate twice
+      handle = await VaultService.rotateKey(handle: handle, newKey: key2);
+      expect(await VaultService.read(handle: handle, name: 'data.bin'), data);
+
+      handle = await VaultService.rotateKey(handle: handle, newKey: key3);
+      expect(await VaultService.read(handle: handle, name: 'data.bin'), data);
+
+      await VaultService.close(handle: handle);
+
+      // Only key3 works
+      final reopened = await VaultService.open(path: path, key: key3);
+      expect(await VaultService.read(handle: reopened, name: 'data.bin'), data);
+      await VaultService.close(handle: reopened);
+    });
+
+    test('rotate then export-import the rotated vault', () async {
+      final vaultPath = '${tempDir.path}/rot_exp.vault';
+      final archivePath = '${tempDir.path}/rot_exp.mvex';
+      final importPath = '${tempDir.path}/rot_exp_imported.vault';
+      final key = await generateAes256GcmKey();
+      final rotatedKey = await generateAes256GcmKey();
+      final wrappingKey = await generateAes256GcmKey();
+      final importKey = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: vaultPath,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList(List.generate(256, (i) => i));
+      await VaultService.write(handle: handle, name: 'payload.bin', data: data);
+
+      // Rotate first
+      handle = await VaultService.rotateKey(handle: handle, newKey: rotatedKey);
+
+      // Then export
+      await VaultService.export(
+        handle: handle,
+        wrappingKey: wrappingKey,
+        exportPath: archivePath,
+      );
+      await VaultService.close(handle: handle);
+
+      // Import
+      final imported = await VaultService.importVault(
+        archivePath: archivePath,
+        wrappingKey: wrappingKey,
+        destPath: importPath,
+        newMasterKey: importKey,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      expect(
+        await VaultService.read(handle: imported, name: 'payload.bin'),
+        data,
+      );
+      await VaultService.close(handle: imported);
+    });
+  });
+}

--- a/lib/src/evfs/vault_service.dart
+++ b/lib/src/evfs/vault_service.dart
@@ -265,6 +265,54 @@ class VaultService {
     );
   }
 
+  /// Rotate the vault's master key (re-encrypts all data).
+  ///
+  /// Returns a new [VaultHandle] — the old handle is invalidated.
+  /// If interrupted, open the vault with the old key to recover.
+  static Future<rust_types.VaultHandle> rotateKey({
+    required rust_types.VaultHandle handle,
+    required Uint8List newKey,
+  }) {
+    return rust_evfs.vaultRotateKey(handle: handle, newKey: newKey);
+  }
+
+  /// Export the vault to a portable encrypted archive (.mvex).
+  ///
+  /// The archive is encrypted with a random ephemeral key wrapped by
+  /// [wrappingKey]. Share the wrapping key out-of-band for import.
+  static Future<void> export({
+    required rust_types.VaultHandle handle,
+    required Uint8List wrappingKey,
+    required String exportPath,
+  }) {
+    return rust_evfs.vaultExport(
+      handle: handle,
+      wrappingKey: wrappingKey,
+      exportPath: exportPath,
+    );
+  }
+
+  /// Import a vault from an encrypted archive (.mvex).
+  ///
+  /// Creates a new vault at [destPath] re-encrypted under [newMasterKey].
+  static Future<rust_types.VaultHandle> importVault({
+    required String archivePath,
+    required Uint8List wrappingKey,
+    required String destPath,
+    required Uint8List newMasterKey,
+    required String algorithm,
+    required int capacityBytes,
+  }) {
+    return rust_evfs.vaultImport(
+      archivePath: archivePath,
+      wrappingKey: wrappingKey,
+      destPath: destPath,
+      newMasterKey: newMasterKey,
+      algorithm: algorithm,
+      capacityBytes: BigInt.from(capacityBytes),
+    );
+  }
+
   /// Close the vault (release lock, zeroize keys).
   static Future<void> close({required rust_types.VaultHandle handle}) {
     return rust_evfs.vaultClose(handle: handle);

--- a/lib/src/rust/api/evfs.dart
+++ b/lib/src/rust/api/evfs.dart
@@ -9,7 +9,7 @@ import 'compression.dart';
 import 'evfs/types.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `chunk_abs_offset`, `vault_resize_grow_impl`, `vault_resize_shrink_impl`, `write_encrypted_chunk`
+// These functions are ignored because they are not marked as `pub`: `chunk_abs_offset`, `vault_export_write`, `vault_resize_grow_impl`, `vault_resize_shrink_impl`, `write_encrypted_chunk`
 // These functions have error during generation (see debug logs or enable `stop_on_error: true` for more details): `vault_write_stream`
 
 /// Create a new vault file at `path` with the given capacity.
@@ -123,6 +123,49 @@ Future<VaultHealthInfo> vaultHealth({required VaultHandle handle}) =>
 Future<DefragResult> vaultDefragment({required VaultHandle handle}) =>
     RustLib.instance.api.crateApiEvfsVaultDefragment(handle: handle);
 
+/// Consumes old handle (keys invalidated after rename). Returns new handle with new keys.
+Future<VaultHandle> vaultRotateKey({
+  required VaultHandle handle,
+  required List<int> newKey,
+}) => RustLib.instance.api.crateApiEvfsVaultRotateKey(
+  handle: handle,
+  newKey: newKey,
+);
+
+/// Export all vault segments into a self-contained `.mvex` encrypted archive.
+///
+/// Each segment is decrypted from the vault, then re-encrypted under an
+/// ephemeral export key with a random per-segment nonce. The export key is
+/// AEAD-wrapped with the caller's `wrapping_key`.
+///
+/// The vault is not modified by this operation.
+Future<void> vaultExport({
+  required VaultHandle handle,
+  required List<int> wrappingKey,
+  required String exportPath,
+}) => RustLib.instance.api.crateApiEvfsVaultExport(
+  handle: handle,
+  wrappingKey: wrappingKey,
+  exportPath: exportPath,
+);
+
 /// Close the vault — checkpoint WAL, release lock, zeroize keys on drop.
 Future<void> vaultClose({required VaultHandle handle}) =>
     RustLib.instance.api.crateApiEvfsVaultClose(handle: handle);
+
+/// Unwraps export key, creates new vault at dest_path, writes all segments under new_master_key.
+Future<VaultHandle> vaultImport({
+  required String archivePath,
+  required List<int> wrappingKey,
+  required String destPath,
+  required List<int> newMasterKey,
+  required String algorithm,
+  required BigInt capacityBytes,
+}) => RustLib.instance.api.crateApiEvfsVaultImport(
+  archivePath: archivePath,
+  wrappingKey: wrappingKey,
+  destPath: destPath,
+  newMasterKey: newMasterKey,
+  algorithm: algorithm,
+  capacityBytes: capacityBytes,
+);

--- a/lib/src/rust/core/error.dart
+++ b/lib/src/rust/core/error.dart
@@ -39,4 +39,10 @@ sealed class CryptoError with _$CryptoError implements FrbException {
       CryptoError_SegmentNotFound;
   const factory CryptoError.vaultCorrupted(String field0) =
       CryptoError_VaultCorrupted;
+  const factory CryptoError.keyRotationFailed(String field0) =
+      CryptoError_KeyRotationFailed;
+  const factory CryptoError.exportFailed(String field0) =
+      CryptoError_ExportFailed;
+  const factory CryptoError.importFailed(String field0) =
+      CryptoError_ImportFailed;
 }

--- a/lib/src/rust/core/error.freezed.dart
+++ b/lib/src/rust/core/error.freezed.dart
@@ -55,7 +55,7 @@ extension CryptoErrorPatterns on CryptoError {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -72,7 +72,10 @@ return authenticationFailed(_that);case CryptoError_VaultFull() when vaultFull !
 return vaultFull(_that);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked(_that);case CryptoError_SegmentNotFound() when segmentNotFound != null:
 return segmentNotFound(_that);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
-return vaultCorrupted(_that);case _:
+return vaultCorrupted(_that);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
+return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFailed != null:
+return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
+return importFailed(_that);case _:
   return orElse();
 
 }
@@ -90,7 +93,7 @@ return vaultCorrupted(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
@@ -107,7 +110,10 @@ return authenticationFailed(_that);case CryptoError_VaultFull():
 return vaultFull(_that);case CryptoError_VaultLocked():
 return vaultLocked(_that);case CryptoError_SegmentNotFound():
 return segmentNotFound(_that);case CryptoError_VaultCorrupted():
-return vaultCorrupted(_that);}
+return vaultCorrupted(_that);case CryptoError_KeyRotationFailed():
+return keyRotationFailed(_that);case CryptoError_ExportFailed():
+return exportFailed(_that);case CryptoError_ImportFailed():
+return importFailed(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -121,7 +127,7 @@ return vaultCorrupted(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -138,7 +144,10 @@ return authenticationFailed(_that);case CryptoError_VaultFull() when vaultFull !
 return vaultFull(_that);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked(_that);case CryptoError_SegmentNotFound() when segmentNotFound != null:
 return segmentNotFound(_that);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
-return vaultCorrupted(_that);case _:
+return vaultCorrupted(_that);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
+return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFailed != null:
+return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
+return importFailed(_that);case _:
   return null;
 
 }
@@ -155,7 +164,7 @@ return vaultCorrupted(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  vaultCorrupted,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -171,7 +180,10 @@ return authenticationFailed();case CryptoError_VaultFull() when vaultFull != nul
 return vaultFull(_that.needed,_that.available);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked();case CryptoError_SegmentNotFound() when segmentNotFound != null:
 return segmentNotFound(_that.field0);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
-return vaultCorrupted(_that.field0);case _:
+return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
+return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when exportFailed != null:
+return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
+return importFailed(_that.field0);case _:
   return orElse();
 
 }
@@ -189,7 +201,7 @@ return vaultCorrupted(_that.field0);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  vaultCorrupted,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce():
@@ -205,7 +217,10 @@ return authenticationFailed();case CryptoError_VaultFull():
 return vaultFull(_that.needed,_that.available);case CryptoError_VaultLocked():
 return vaultLocked();case CryptoError_SegmentNotFound():
 return segmentNotFound(_that.field0);case CryptoError_VaultCorrupted():
-return vaultCorrupted(_that.field0);}
+return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed():
+return keyRotationFailed(_that.field0);case CryptoError_ExportFailed():
+return exportFailed(_that.field0);case CryptoError_ImportFailed():
+return importFailed(_that.field0);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -219,7 +234,7 @@ return vaultCorrupted(_that.field0);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  vaultCorrupted,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -235,7 +250,10 @@ return authenticationFailed();case CryptoError_VaultFull() when vaultFull != nul
 return vaultFull(_that.needed,_that.available);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked();case CryptoError_SegmentNotFound() when segmentNotFound != null:
 return segmentNotFound(_that.field0);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
-return vaultCorrupted(_that.field0);case _:
+return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
+return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when exportFailed != null:
+return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
+return importFailed(_that.field0);case _:
   return null;
 
 }
@@ -1027,6 +1045,204 @@ class _$CryptoError_VaultCorruptedCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
   return _then(CryptoError_VaultCorrupted(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CryptoError_KeyRotationFailed extends CryptoError {
+  const CryptoError_KeyRotationFailed(this.field0): super._();
+  
+
+ final  String field0;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CryptoError_KeyRotationFailedCopyWith<CryptoError_KeyRotationFailed> get copyWith => _$CryptoError_KeyRotationFailedCopyWithImpl<CryptoError_KeyRotationFailed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_KeyRotationFailed&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'CryptoError.keyRotationFailed(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CryptoError_KeyRotationFailedCopyWith<$Res> implements $CryptoErrorCopyWith<$Res> {
+  factory $CryptoError_KeyRotationFailedCopyWith(CryptoError_KeyRotationFailed value, $Res Function(CryptoError_KeyRotationFailed) _then) = _$CryptoError_KeyRotationFailedCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$CryptoError_KeyRotationFailedCopyWithImpl<$Res>
+    implements $CryptoError_KeyRotationFailedCopyWith<$Res> {
+  _$CryptoError_KeyRotationFailedCopyWithImpl(this._self, this._then);
+
+  final CryptoError_KeyRotationFailed _self;
+  final $Res Function(CryptoError_KeyRotationFailed) _then;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(CryptoError_KeyRotationFailed(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CryptoError_ExportFailed extends CryptoError {
+  const CryptoError_ExportFailed(this.field0): super._();
+  
+
+ final  String field0;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CryptoError_ExportFailedCopyWith<CryptoError_ExportFailed> get copyWith => _$CryptoError_ExportFailedCopyWithImpl<CryptoError_ExportFailed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_ExportFailed&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'CryptoError.exportFailed(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CryptoError_ExportFailedCopyWith<$Res> implements $CryptoErrorCopyWith<$Res> {
+  factory $CryptoError_ExportFailedCopyWith(CryptoError_ExportFailed value, $Res Function(CryptoError_ExportFailed) _then) = _$CryptoError_ExportFailedCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$CryptoError_ExportFailedCopyWithImpl<$Res>
+    implements $CryptoError_ExportFailedCopyWith<$Res> {
+  _$CryptoError_ExportFailedCopyWithImpl(this._self, this._then);
+
+  final CryptoError_ExportFailed _self;
+  final $Res Function(CryptoError_ExportFailed) _then;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(CryptoError_ExportFailed(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CryptoError_ImportFailed extends CryptoError {
+  const CryptoError_ImportFailed(this.field0): super._();
+  
+
+ final  String field0;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CryptoError_ImportFailedCopyWith<CryptoError_ImportFailed> get copyWith => _$CryptoError_ImportFailedCopyWithImpl<CryptoError_ImportFailed>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_ImportFailed&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'CryptoError.importFailed(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CryptoError_ImportFailedCopyWith<$Res> implements $CryptoErrorCopyWith<$Res> {
+  factory $CryptoError_ImportFailedCopyWith(CryptoError_ImportFailed value, $Res Function(CryptoError_ImportFailed) _then) = _$CryptoError_ImportFailedCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$CryptoError_ImportFailedCopyWithImpl<$Res>
+    implements $CryptoError_ImportFailedCopyWith<$Res> {
+  _$CryptoError_ImportFailedCopyWithImpl(this._self, this._then);
+
+  final CryptoError_ImportFailed _self;
+  final $Res Function(CryptoError_ImportFailed) _then;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(CryptoError_ImportFailed(
 null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -74,7 +74,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 2084471439;
+  int get rustContentHash => 1455605677;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -254,8 +254,23 @@ abstract class RustLibApi extends BaseApi {
     required String name,
   });
 
+  Future<void> crateApiEvfsVaultExport({
+    required VaultHandle handle,
+    required List<int> wrappingKey,
+    required String exportPath,
+  });
+
   Future<VaultHealthInfo> crateApiEvfsVaultHealth({
     required VaultHandle handle,
+  });
+
+  Future<VaultHandle> crateApiEvfsVaultImport({
+    required String archivePath,
+    required List<int> wrappingKey,
+    required String destPath,
+    required List<int> newMasterKey,
+    required String algorithm,
+    required BigInt capacityBytes,
   });
 
   Future<List<String>> crateApiEvfsVaultList({required VaultHandle handle});
@@ -281,6 +296,11 @@ abstract class RustLibApi extends BaseApi {
   Future<void> crateApiEvfsVaultResize({
     required VaultHandle handle,
     required BigInt newCapacity,
+  });
+
+  Future<VaultHandle> crateApiEvfsVaultRotateKey({
+    required VaultHandle handle,
+    required List<int> newKey,
   });
 
   Future<void> crateApiEvfsVaultWrite({
@@ -1596,6 +1616,44 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<void> crateApiEvfsVaultExport({
+    required VaultHandle handle,
+    required List<int> wrappingKey,
+    required String exportPath,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_list_prim_u_8_loose(wrappingKey);
+          var arg2 = cst_encode_String(exportPath);
+          return wire.wire__crate__api__evfs__vault_export(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+          );
+        },
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEvfsVaultExportConstMeta,
+        argValues: [handle, wrappingKey, exportPath],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEvfsVaultExportConstMeta => const TaskConstMeta(
+    debugName: "vault_export",
+    argNames: ["handle", "wrappingKey", "exportPath"],
+  );
+
+  @override
   Future<VaultHealthInfo> crateApiEvfsVaultHealth({
     required VaultHandle handle,
   }) {
@@ -1621,6 +1679,65 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiEvfsVaultHealthConstMeta =>
       const TaskConstMeta(debugName: "vault_health", argNames: ["handle"]);
+
+  @override
+  Future<VaultHandle> crateApiEvfsVaultImport({
+    required String archivePath,
+    required List<int> wrappingKey,
+    required String destPath,
+    required List<int> newMasterKey,
+    required String algorithm,
+    required BigInt capacityBytes,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          var arg0 = cst_encode_String(archivePath);
+          var arg1 = cst_encode_list_prim_u_8_loose(wrappingKey);
+          var arg2 = cst_encode_String(destPath);
+          var arg3 = cst_encode_list_prim_u_8_loose(newMasterKey);
+          var arg4 = cst_encode_String(algorithm);
+          var arg5 = cst_encode_u_64(capacityBytes);
+          return wire.wire__crate__api__evfs__vault_import(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+            arg3,
+            arg4,
+            arg5,
+          );
+        },
+        codec: DcoCodec(
+          decodeSuccessData:
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
+          decodeErrorData: dco_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEvfsVaultImportConstMeta,
+        argValues: [
+          archivePath,
+          wrappingKey,
+          destPath,
+          newMasterKey,
+          algorithm,
+          capacityBytes,
+        ],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEvfsVaultImportConstMeta => const TaskConstMeta(
+    debugName: "vault_import",
+    argNames: [
+      "archivePath",
+      "wrappingKey",
+      "destPath",
+      "newMasterKey",
+      "algorithm",
+      "capacityBytes",
+    ],
+  );
 
   @override
   Future<List<String>> crateApiEvfsVaultList({required VaultHandle handle}) {
@@ -1779,6 +1896,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   TaskConstMeta get kCrateApiEvfsVaultResizeConstMeta => const TaskConstMeta(
     debugName: "vault_resize",
     argNames: ["handle", "newCapacity"],
+  );
+
+  @override
+  Future<VaultHandle> crateApiEvfsVaultRotateKey({
+    required VaultHandle handle,
+    required List<int> newKey,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          var arg0 =
+              cst_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_list_prim_u_8_loose(newKey);
+          return wire.wire__crate__api__evfs__vault_rotate_key(
+            port_,
+            arg0,
+            arg1,
+          );
+        },
+        codec: DcoCodec(
+          decodeSuccessData:
+              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
+          decodeErrorData: dco_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEvfsVaultRotateKeyConstMeta,
+        argValues: [handle, newKey],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEvfsVaultRotateKeyConstMeta => const TaskConstMeta(
+    debugName: "vault_rotate_key",
+    argNames: ["handle", "newKey"],
   );
 
   @override
@@ -2086,6 +2239,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return CryptoError_SegmentNotFound(dco_decode_String(raw[1]));
       case 13:
         return CryptoError_VaultCorrupted(dco_decode_String(raw[1]));
+      case 14:
+        return CryptoError_KeyRotationFailed(dco_decode_String(raw[1]));
+      case 15:
+        return CryptoError_ExportFailed(dco_decode_String(raw[1]));
+      case 16:
+        return CryptoError_ImportFailed(dco_decode_String(raw[1]));
       default:
         throw Exception("unreachable");
     }
@@ -2466,6 +2625,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 13:
         var var_field0 = sse_decode_String(deserializer);
         return CryptoError_VaultCorrupted(var_field0);
+      case 14:
+        var var_field0 = sse_decode_String(deserializer);
+        return CryptoError_KeyRotationFailed(var_field0);
+      case 15:
+        var var_field0 = sse_decode_String(deserializer);
+        return CryptoError_ExportFailed(var_field0);
+      case 16:
+        var var_field0 = sse_decode_String(deserializer);
+        return CryptoError_ImportFailed(var_field0);
       default:
         throw UnimplementedError('');
     }
@@ -3052,6 +3220,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(field0, serializer);
       case CryptoError_VaultCorrupted(field0: final field0):
         sse_encode_i_32(13, serializer);
+        sse_encode_String(field0, serializer);
+      case CryptoError_KeyRotationFailed(field0: final field0):
+        sse_encode_i_32(14, serializer);
+        sse_encode_String(field0, serializer);
+      case CryptoError_ExportFailed(field0: final field0):
+        sse_encode_i_32(15, serializer);
+        sse_encode_String(field0, serializer);
+      case CryptoError_ImportFailed(field0: final field0):
+        sse_encode_i_32(16, serializer);
         sse_encode_String(field0, serializer);
     }
   }

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -562,6 +562,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.VaultCorrupted.field0 = pre_field0;
       return;
     }
+    if (apiObj is CryptoError_KeyRotationFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 14;
+      wireObj.kind.KeyRotationFailed.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_ExportFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 15;
+      wireObj.kind.ExportFailed.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_ImportFailed) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 16;
+      wireObj.kind.ImportFailed.field0 = pre_field0;
+      return;
+    }
   }
 
   @protected
@@ -1858,6 +1876,42 @@ class RustLibWire implements BaseWire {
             void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
           >();
 
+  void wire__crate__api__evfs__vault_export(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> wrapping_key,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> export_path,
+  ) {
+    return _wire__crate__api__evfs__vault_export(
+      port_,
+      handle,
+      wrapping_key,
+      export_path,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_exportPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_export');
+  late final _wire__crate__api__evfs__vault_export =
+      _wire__crate__api__evfs__vault_exportPtr
+          .asFunction<
+            void Function(
+              int,
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
   void wire__crate__api__evfs__vault_health(int port_, int handle) {
     return _wire__crate__api__evfs__vault_health(port_, handle);
   }
@@ -1869,6 +1923,54 @@ class RustLibWire implements BaseWire {
   late final _wire__crate__api__evfs__vault_health =
       _wire__crate__api__evfs__vault_healthPtr
           .asFunction<void Function(int, int)>();
+
+  void wire__crate__api__evfs__vault_import(
+    int port_,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> archive_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> wrapping_key,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> dest_path,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> new_master_key,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> algorithm,
+    int capacity_bytes,
+  ) {
+    return _wire__crate__api__evfs__vault_import(
+      port_,
+      archive_path,
+      wrapping_key,
+      dest_path,
+      new_master_key,
+      algorithm,
+      capacity_bytes,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_importPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Uint64,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_import');
+  late final _wire__crate__api__evfs__vault_import =
+      _wire__crate__api__evfs__vault_importPtr
+          .asFunction<
+            void Function(
+              int,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              int,
+            )
+          >();
 
   void wire__crate__api__evfs__vault_list(int port_, int handle) {
     return _wire__crate__api__evfs__vault_list(port_, handle);
@@ -1995,6 +2097,30 @@ class RustLibWire implements BaseWire {
   late final _wire__crate__api__evfs__vault_resize =
       _wire__crate__api__evfs__vault_resizePtr
           .asFunction<void Function(int, int, int)>();
+
+  void wire__crate__api__evfs__vault_rotate_key(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_loose> new_key,
+  ) {
+    return _wire__crate__api__evfs__vault_rotate_key(port_, handle, new_key);
+  }
+
+  late final _wire__crate__api__evfs__vault_rotate_keyPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_rotate_key');
+  late final _wire__crate__api__evfs__vault_rotate_key =
+      _wire__crate__api__evfs__vault_rotate_keyPtr
+          .asFunction<
+            void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_loose>)
+          >();
 
   void wire__crate__api__evfs__vault_write(
     int port_,
@@ -2342,6 +2468,18 @@ final class wire_cst_CryptoError_VaultCorrupted extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 }
 
+final class wire_cst_CryptoError_KeyRotationFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_ExportFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
+final class wire_cst_CryptoError_ImportFailed extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
 final class CryptoErrorKind extends ffi.Union {
   external wire_cst_CryptoError_InvalidKeyLength InvalidKeyLength;
 
@@ -2362,6 +2500,12 @@ final class CryptoErrorKind extends ffi.Union {
   external wire_cst_CryptoError_SegmentNotFound SegmentNotFound;
 
   external wire_cst_CryptoError_VaultCorrupted VaultCorrupted;
+
+  external wire_cst_CryptoError_KeyRotationFailed KeyRotationFailed;
+
+  external wire_cst_CryptoError_ExportFailed ExportFailed;
+
+  external wire_cst_CryptoError_ImportFailed ImportFailed;
 }
 
 final class wire_cst_crypto_error extends ffi.Struct {
@@ -2433,6 +2577,14 @@ const int DEFAULT_LEVEL = 3;
 const int MIN_LEVEL = 1;
 
 const int MAX_LEVEL = 22;
+
+const int ARCHIVE_VERSION = 1;
+
+const int ARCHIVE_HEADER_SIZE = 32;
+
+const int WRAPPED_KEY_SIZE = 60;
+
+const int ARCHIVE_TRAILER_SIZE = 36;
 
 const int VAULT_VERSION = 1;
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -452,6 +452,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (raw is CryptoError_VaultCorrupted) {
       return [13, cst_encode_String(raw.field0)].jsify()!;
     }
+    if (raw is CryptoError_KeyRotationFailed) {
+      return [14, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_ExportFailed) {
+      return [15, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_ImportFailed) {
+      return [16, cst_encode_String(raw.field0)].jsify()!;
+    }
 
     throw Exception('unreachable');
   }
@@ -1131,8 +1140,38 @@ class RustLibWire implements BaseWire {
     String name,
   ) => wasmModule.wire__crate__api__evfs__vault_delete(port_, handle, name);
 
+  void wire__crate__api__evfs__vault_export(
+    NativePortType port_,
+    int handle,
+    JSAny wrapping_key,
+    String export_path,
+  ) => wasmModule.wire__crate__api__evfs__vault_export(
+    port_,
+    handle,
+    wrapping_key,
+    export_path,
+  );
+
   void wire__crate__api__evfs__vault_health(NativePortType port_, int handle) =>
       wasmModule.wire__crate__api__evfs__vault_health(port_, handle);
+
+  void wire__crate__api__evfs__vault_import(
+    NativePortType port_,
+    String archive_path,
+    JSAny wrapping_key,
+    String dest_path,
+    JSAny new_master_key,
+    String algorithm,
+    JSAny capacity_bytes,
+  ) => wasmModule.wire__crate__api__evfs__vault_import(
+    port_,
+    archive_path,
+    wrapping_key,
+    dest_path,
+    new_master_key,
+    algorithm,
+    capacity_bytes,
+  );
 
   void wire__crate__api__evfs__vault_list(NativePortType port_, int handle) =>
       wasmModule.wire__crate__api__evfs__vault_list(port_, handle);
@@ -1173,6 +1212,16 @@ class RustLibWire implements BaseWire {
     port_,
     handle,
     new_capacity,
+  );
+
+  void wire__crate__api__evfs__vault_rotate_key(
+    NativePortType port_,
+    int handle,
+    JSAny new_key,
+  ) => wasmModule.wire__crate__api__evfs__vault_rotate_key(
+    port_,
+    handle,
+    new_key,
   );
 
   void wire__crate__api__evfs__vault_write(
@@ -1480,9 +1529,26 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String name,
   );
 
+  external void wire__crate__api__evfs__vault_export(
+    NativePortType port_,
+    int handle,
+    JSAny wrapping_key,
+    String export_path,
+  );
+
   external void wire__crate__api__evfs__vault_health(
     NativePortType port_,
     int handle,
+  );
+
+  external void wire__crate__api__evfs__vault_import(
+    NativePortType port_,
+    String archive_path,
+    JSAny wrapping_key,
+    String dest_path,
+    JSAny new_master_key,
+    String algorithm,
+    JSAny capacity_bytes,
   );
 
   external void wire__crate__api__evfs__vault_list(
@@ -1515,6 +1581,12 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     NativePortType port_,
     int handle,
     JSAny new_capacity,
+  );
+
+  external void wire__crate__api__evfs__vault_rotate_key(
+    NativePortType port_,
+    int handle,
+    JSAny new_key,
   );
 
   external void wire__crate__api__evfs__vault_write(

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 2084471439;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1455605677;
 
 // Section: executor
 
@@ -1290,6 +1290,53 @@ fn wire__crate__api__evfs__vault_delete_impl(
         },
     )
 }
+fn wire__crate__api__evfs__vault_export_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    wrapping_key: impl CstDecode<Vec<u8>>,
+    export_path: impl CstDecode<String>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vault_export",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_handle = handle.cst_decode();
+            let api_wrapping_key = wrapping_key.cst_decode();
+            let api_export_path = export_path.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
+                    let mut api_handle_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_handle,
+                                0,
+                                true,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref_mut()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let mut api_handle_guard = api_handle_guard.unwrap();
+                    let output_ok = crate::api::evfs::vault_export(
+                        &mut *api_handle_guard,
+                        api_wrapping_key,
+                        api_export_path,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__evfs__vault_health_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     handle: impl CstDecode<
@@ -1324,6 +1371,44 @@ fn wire__crate__api__evfs__vault_health_impl(
                     let api_handle_guard = api_handle_guard.unwrap();
                     let output_ok =
                         Result::<_, ()>::Ok(crate::api::evfs::vault_health(&*api_handle_guard))?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__evfs__vault_import_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    archive_path: impl CstDecode<String>,
+    wrapping_key: impl CstDecode<Vec<u8>>,
+    dest_path: impl CstDecode<String>,
+    new_master_key: impl CstDecode<Vec<u8>>,
+    algorithm: impl CstDecode<String>,
+    capacity_bytes: impl CstDecode<u64>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vault_import",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_archive_path = archive_path.cst_decode();
+            let api_wrapping_key = wrapping_key.cst_decode();
+            let api_dest_path = dest_path.cst_decode();
+            let api_new_master_key = new_master_key.cst_decode();
+            let api_algorithm = algorithm.cst_decode();
+            let api_capacity_bytes = capacity_bytes.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
+                    let output_ok = crate::api::evfs::vault_import(
+                        api_archive_path,
+                        api_wrapping_key,
+                        api_dest_path,
+                        api_new_master_key,
+                        api_algorithm,
+                        api_capacity_bytes,
+                    )?;
                     Ok(output_ok)
                 })())
             }
@@ -1523,6 +1608,29 @@ fn wire__crate__api__evfs__vault_resize_impl(
                     let mut api_handle_guard = api_handle_guard.unwrap();
                     let output_ok =
                         crate::api::evfs::vault_resize(&mut *api_handle_guard, api_new_capacity)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__evfs__vault_rotate_key_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    handle: impl CstDecode<VaultHandle>,
+    new_key: impl CstDecode<Vec<u8>>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vault_rotate_key",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_handle = handle.cst_decode();
+            let api_new_key = new_key.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
+                    let output_ok = crate::api::evfs::vault_rotate_key(api_handle, api_new_key)?;
                     Ok(output_ok)
                 })())
             }
@@ -1897,6 +2005,18 @@ impl SseDecode for crate::core::error::CryptoError {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crate::core::error::CryptoError::VaultCorrupted(var_field0);
             }
+            14 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::core::error::CryptoError::KeyRotationFailed(var_field0);
+            }
+            15 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::core::error::CryptoError::ExportFailed(var_field0);
+            }
+            16 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::core::error::CryptoError::ImportFailed(var_field0);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -2248,6 +2368,15 @@ impl flutter_rust_bridge::IntoDart for crate::core::error::CryptoError {
             crate::core::error::CryptoError::VaultCorrupted(field0) => {
                 [13.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            crate::core::error::CryptoError::KeyRotationFailed(field0) => {
+                [14.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::core::error::CryptoError::ExportFailed(field0) => {
+                [15.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::core::error::CryptoError::ImportFailed(field0) => {
+                [16.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -2526,6 +2655,18 @@ impl SseEncode for crate::core::error::CryptoError {
             }
             crate::core::error::CryptoError::VaultCorrupted(field0) => {
                 <i32>::sse_encode(13, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::core::error::CryptoError::KeyRotationFailed(field0) => {
+                <i32>::sse_encode(14, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::core::error::CryptoError::ExportFailed(field0) => {
+                <i32>::sse_encode(15, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::core::error::CryptoError::ImportFailed(field0) => {
+                <i32>::sse_encode(16, serializer);
                 <String>::sse_encode(field0, serializer);
             }
             _ => {
@@ -2874,6 +3015,18 @@ mod io {
                 13 => {
                     let ans = unsafe { self.kind.VaultCorrupted };
                     crate::core::error::CryptoError::VaultCorrupted(ans.field0.cst_decode())
+                }
+                14 => {
+                    let ans = unsafe { self.kind.KeyRotationFailed };
+                    crate::core::error::CryptoError::KeyRotationFailed(ans.field0.cst_decode())
+                }
+                15 => {
+                    let ans = unsafe { self.kind.ExportFailed };
+                    crate::core::error::CryptoError::ExportFailed(ans.field0.cst_decode())
+                }
+                16 => {
+                    let ans = unsafe { self.kind.ImportFailed };
+                    crate::core::error::CryptoError::ImportFailed(ans.field0.cst_decode())
                 }
                 _ => unreachable!(),
             }
@@ -3393,11 +3546,42 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_export(
+        port_: i64,
+        handle: usize,
+        wrapping_key: *mut wire_cst_list_prim_u_8_loose,
+        export_path: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__evfs__vault_export_impl(port_, handle, wrapping_key, export_path)
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_health(
         port_: i64,
         handle: usize,
     ) {
         wire__crate__api__evfs__vault_health_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_import(
+        port_: i64,
+        archive_path: *mut wire_cst_list_prim_u_8_strict,
+        wrapping_key: *mut wire_cst_list_prim_u_8_loose,
+        dest_path: *mut wire_cst_list_prim_u_8_strict,
+        new_master_key: *mut wire_cst_list_prim_u_8_loose,
+        algorithm: *mut wire_cst_list_prim_u_8_strict,
+        capacity_bytes: u64,
+    ) {
+        wire__crate__api__evfs__vault_import_impl(
+            port_,
+            archive_path,
+            wrapping_key,
+            dest_path,
+            new_master_key,
+            algorithm,
+            capacity_bytes,
+        )
     }
 
     #[unsafe(no_mangle)]
@@ -3452,6 +3636,15 @@ mod io {
         new_capacity: u64,
     ) {
         wire__crate__api__evfs__vault_resize_impl(port_, handle, new_capacity)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_rotate_key(
+        port_: i64,
+        handle: usize,
+        new_key: *mut wire_cst_list_prim_u_8_loose,
+    ) {
+        wire__crate__api__evfs__vault_rotate_key_impl(port_, handle, new_key)
     }
 
     #[unsafe(no_mangle)]
@@ -3602,6 +3795,9 @@ mod io {
         VaultFull: wire_cst_CryptoError_VaultFull,
         SegmentNotFound: wire_cst_CryptoError_SegmentNotFound,
         VaultCorrupted: wire_cst_CryptoError_VaultCorrupted,
+        KeyRotationFailed: wire_cst_CryptoError_KeyRotationFailed,
+        ExportFailed: wire_cst_CryptoError_ExportFailed,
+        ImportFailed: wire_cst_CryptoError_ImportFailed,
         nil__: (),
     }
     #[repr(C)]
@@ -3654,6 +3850,21 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_CryptoError_VaultCorrupted {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_KeyRotationFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_ExportFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_ImportFailed {
         field0: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
@@ -3804,6 +4015,9 @@ mod web {
                 11 => crate::core::error::CryptoError::VaultLocked,
                 12 => crate::core::error::CryptoError::SegmentNotFound(self_.get(1).cst_decode()),
                 13 => crate::core::error::CryptoError::VaultCorrupted(self_.get(1).cst_decode()),
+                14 => crate::core::error::CryptoError::KeyRotationFailed(self_.get(1).cst_decode()),
+                15 => crate::core::error::CryptoError::ExportFailed(self_.get(1).cst_decode()),
+                16 => crate::core::error::CryptoError::ImportFailed(self_.get(1).cst_decode()),
                 _ => unreachable!(),
             }
         }
@@ -4458,11 +4672,42 @@ mod web {
     }
 
     #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_export(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        wrapping_key: Box<[u8]>,
+        export_path: String,
+    ) {
+        wire__crate__api__evfs__vault_export_impl(port_, handle, wrapping_key, export_path)
+    }
+
+    #[wasm_bindgen]
     pub fn wire__crate__api__evfs__vault_health(
         port_: flutter_rust_bridge::for_generated::MessagePort,
         handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) {
         wire__crate__api__evfs__vault_health_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_import(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        archive_path: String,
+        wrapping_key: Box<[u8]>,
+        dest_path: String,
+        new_master_key: Box<[u8]>,
+        algorithm: String,
+        capacity_bytes: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_import_impl(
+            port_,
+            archive_path,
+            wrapping_key,
+            dest_path,
+            new_master_key,
+            algorithm,
+            capacity_bytes,
+        )
     }
 
     #[wasm_bindgen]
@@ -4517,6 +4762,15 @@ mod web {
         new_capacity: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) {
         wire__crate__api__evfs__vault_resize_impl(port_, handle, new_capacity)
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_rotate_key(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        new_key: Box<[u8]>,
+    ) {
+        wire__crate__api__evfs__vault_rotate_key_impl(port_, handle, new_key)
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
## Summary                                                                                                         
  - Add `VaultService.rotateKey()`, `export()`, `importVault()` static methods wrapping FRB-generated bindings     
  - 7 integration tests covering full Dart→Rust roundtrips                                                           
   
  ## Changes                                                                                                         
  - `lib/src/evfs/vault_service.dart` — 3 new methods 
  - `integration_test/vault_key_management_test.dart` — new test file
  - `lib/src/rust/` — FRB codegen regenerated for `vaultRotateKey`, `vaultExport`, `vaultImport`
  - `rust/src/frb_generated.rs` — Rust-side FRB glue                                                                 
   
  ## Test plan                                                                                                       
  - [x] Rotate key roundtrip (write, rotate, read back)
  - [x] Old key rejected after rotation
  - [x] Export-import roundtrip (byte-for-byte match)
  - [x] Import with wrong wrapping key throws                                                                        
  - [x] Large segment (1MB+) export-import
  - [x] Multiple sequential rotations                                                                                
  - [x] Rotate then export-import the rotated vault   
  - [x] `flutter analyze` clean                                                                                      
  - [x] 365/365 Rust tests pass, clippy clean