### PR TITLE
EVFS: concurrent segment reads with rayon mmap parallelism

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -338,6 +338,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +425,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "env_filter"
@@ -747,6 +778,7 @@ dependencies = [
  "log",
  "memmap2",
  "rand",
+ "rayon",
  "sha2",
  "sha3",
  "subtle",
@@ -964,6 +996,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -48,6 +48,9 @@ fs4 = "0.12"
 memmap2 = "0.9"
 libc = "0.2"
 
+# Parallel segment reads
+rayon = "1.10"
+
 # Compression
 zstd = { version = "0.13", optional = true }
 brotli = { version = "7.0", optional = true }

--- a/rust/src/api/evfs/helpers.rs
+++ b/rust/src/api/evfs/helpers.rs
@@ -190,6 +190,88 @@ pub(crate) fn decrypt_streaming_chunks(
     Ok(hasher.finalize().into())
 }
 
+/// Decrypt all chunks of a streaming segment using mmap only (no File I/O).
+/// Returns `(reassembled_plaintext, blake3_checksum)`.
+///
+/// This is the parallel-read variant of [`decrypt_streaming_chunks`] — it takes
+/// an immutable `&VaultMmap` instead of `&mut File`, making it safe to call from
+/// multiple threads concurrently.
+#[allow(clippy::too_many_arguments)]
+#[cfg(feature = "compression")]
+pub(crate) fn decrypt_streaming_chunks_mmap(
+    mmap: &super::types::VaultMmap,
+    cipher_key: &[u8],
+    nonce_key: &[u8],
+    algorithm: Algorithm,
+    index_pad_size: usize,
+    seg_offset: u64,
+    generation: u64,
+    compression: CompressionAlgorithm,
+    chunk_count: u32,
+) -> Result<(Vec<u8>, [u8; 32]), CryptoError> {
+    let data_region = format::data_region_offset(index_pad_size);
+    let enc_chunk_size = crate::core::streaming::ENCRYPTED_CHUNK_SIZE;
+    let mut hasher = blake3::Hasher::new();
+    let mut decompressor = if compression != CompressionAlgorithm::None {
+        Some(crate::core::compression::streaming::new_decompressor(
+            compression,
+        )?)
+    } else {
+        None
+    };
+    let mut decomp_buf = Vec::with_capacity(crate::core::streaming::CHUNK_SIZE * 2);
+    let mut full_plaintext = Vec::new();
+
+    for i in 0..chunk_count {
+        let chunk_offset = (i as u64)
+            .checked_mul(enc_chunk_size as u64)
+            .and_then(|co| data_region.checked_add(seg_offset)?.checked_add(co))
+            .ok_or_else(|| CryptoError::InvalidParameter("chunk offset overflow".into()))?;
+
+        let encrypted_ref = mmap.slice(chunk_offset, enc_chunk_size as u64)?;
+
+        let expected_nonce = segment::derive_chunk_nonce(nonce_key, i as u64, generation)?;
+        let (stored_nonce, _) = encrypted_ref.split_at(crate::core::streaming::NONCE_SIZE);
+        if stored_nonce.ct_ne(&expected_nonce).into() {
+            return Err(CryptoError::AuthenticationFailed);
+        }
+
+        let is_final = i == chunk_count - 1;
+        let aad = segment::VaultChunkAad {
+            generation,
+            chunk_index: i as u64,
+            is_final,
+        }
+        .to_bytes();
+
+        let decrypted =
+            segment::aead_decrypt_with_stored_nonce(cipher_key, encrypted_ref, &aad, algorithm)?;
+
+        let plaintext = if is_final {
+            crate::core::streaming::strip_last_chunk_padding(&decrypted)?
+        } else {
+            decrypted
+        };
+
+        let final_data = if let Some(ref mut dec) = decompressor {
+            dec.decompress_chunk(&plaintext, &mut decomp_buf)?;
+            if is_final {
+                dec.finish(&mut decomp_buf)?;
+            }
+            let data = decomp_buf.clone();
+            decomp_buf.clear();
+            data
+        } else {
+            plaintext
+        };
+
+        hasher.update(&final_data);
+        full_plaintext.extend_from_slice(&final_data);
+    }
+
+    Ok((full_plaintext, hasher.finalize().into()))
+}
+
 /// Decrypt a raw encrypted monolithic segment blob (`nonce || ciphertext || tag`)
 /// without going through a `VaultHandle` read path.
 ///

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -950,6 +950,188 @@ pub fn vault_health(handle: &VaultHandle) -> VaultHealthInfo {
     handle.health()
 }
 
+/// Read multiple segments concurrently using mmap zero-copy + rayon.
+///
+/// Returns results in the same order as `names`. Each entry is either the
+/// decrypted segment data or a per-segment error (e.g. `SegmentNotFound`).
+/// All segments are decrypted into memory simultaneously — callers should
+/// be mindful of total memory when reading many large segments at once.
+///
+/// Falls back to sequential file-based reads when mmap is unavailable.
+#[cfg(feature = "compression")]
+pub fn vault_read_parallel(
+    handle: &VaultHandle,
+    names: Vec<String>,
+) -> Vec<Result<SegmentResult, CryptoError>> {
+    if names.is_empty() {
+        return Vec::new();
+    }
+
+    if let Some(ref mmap) = handle.mmap {
+        use rayon::prelude::*;
+        names
+            .par_iter()
+            .map(|name| {
+                read_segment_from_mmap(
+                    name,
+                    mmap,
+                    &handle.keys,
+                    handle.algorithm,
+                    handle.index_pad_size,
+                    &handle.index,
+                )
+            })
+            .collect()
+    } else {
+        // No mmap — sequential fallback, each read opens its own fd
+        names
+            .iter()
+            .map(|name| {
+                read_segment_with_file(
+                    name,
+                    &handle.path,
+                    &handle.keys,
+                    handle.algorithm,
+                    handle.index_pad_size,
+                    &handle.index,
+                )
+            })
+            .collect()
+    }
+}
+
+/// Read a single segment using only the mmap (no file I/O).
+#[cfg(feature = "compression")]
+fn read_segment_from_mmap(
+    name: &str,
+    mmap: &types::VaultMmap,
+    keys: &segment::VaultKeys,
+    algorithm: Algorithm,
+    index_pad_size: usize,
+    index: &format::SegmentIndex,
+) -> Result<SegmentResult, CryptoError> {
+    let entry = index
+        .find(name)
+        .ok_or_else(|| CryptoError::SegmentNotFound(name.to_string()))?;
+
+    let data = if entry.chunk_count > 0 {
+        let (plaintext, checksum) = decrypt_streaming_chunks_mmap(
+            mmap,
+            keys.cipher_key.as_bytes(),
+            keys.nonce_key.as_bytes(),
+            algorithm,
+            index_pad_size,
+            entry.offset,
+            entry.generation,
+            entry.compression,
+            entry.chunk_count,
+        )?;
+        if checksum.ct_ne(&entry.checksum).into() {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "integrity check failed for segment '{name}'"
+            )));
+        }
+        plaintext
+    } else {
+        let abs_offset = format::data_region_offset(index_pad_size) + entry.offset;
+        let encrypted = mmap.slice(abs_offset, entry.size)?;
+        let params = SegmentCryptoParams {
+            cipher_key: keys.cipher_key.as_bytes(),
+            nonce_key: keys.nonce_key.as_bytes(),
+            algorithm,
+            segment_index: 0,
+            generation: entry.generation,
+        };
+        let plaintext = segment::decrypt_segment(&params, encrypted, entry.compression)?;
+        if !segment::verify_checksum(&plaintext, &entry.checksum) {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "integrity check failed for segment '{name}'"
+            )));
+        }
+        plaintext
+    };
+
+    Ok(SegmentResult {
+        name: name.to_string(),
+        data,
+    })
+}
+
+/// Read a single segment by opening a temporary read-only file handle.
+/// Used as fallback when mmap is unavailable.
+#[cfg(feature = "compression")]
+fn read_segment_with_file(
+    name: &str,
+    path: &str,
+    keys: &segment::VaultKeys,
+    algorithm: Algorithm,
+    index_pad_size: usize,
+    index: &format::SegmentIndex,
+) -> Result<SegmentResult, CryptoError> {
+    let entry = index
+        .find(name)
+        .ok_or_else(|| CryptoError::SegmentNotFound(name.to_string()))?;
+
+    let mut file = File::open(path)
+        .map_err(|e| CryptoError::IoError(format!("cannot open vault for read: {e}")))?;
+
+    let data = if entry.chunk_count > 0 {
+        let mut full_plaintext = Vec::new();
+        let checksum = decrypt_streaming_chunks(
+            &mut file,
+            None,
+            keys.cipher_key.as_bytes(),
+            keys.nonce_key.as_bytes(),
+            algorithm,
+            index_pad_size,
+            entry.offset,
+            entry.generation,
+            entry.compression,
+            entry.chunk_count,
+            |chunk_data, _| {
+                full_plaintext.extend_from_slice(&chunk_data);
+                Ok(())
+            },
+        )?;
+        if checksum.ct_ne(&entry.checksum).into() {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "integrity check failed for segment '{name}'"
+            )));
+        }
+        full_plaintext
+    } else {
+        let abs_offset = format::data_region_offset(index_pad_size) + entry.offset;
+        let read_len = usize::try_from(entry.size).map_err(|_| {
+            CryptoError::VaultCorrupted(format!(
+                "segment size {} exceeds platform address space",
+                entry.size
+            ))
+        })?;
+        file.seek(SeekFrom::Start(abs_offset))?;
+        let mut buf = vec![0u8; read_len];
+        file.read_exact(&mut buf)?;
+        let params = SegmentCryptoParams {
+            cipher_key: keys.cipher_key.as_bytes(),
+            nonce_key: keys.nonce_key.as_bytes(),
+            algorithm,
+            segment_index: 0,
+            generation: entry.generation,
+        };
+        let plaintext = segment::decrypt_segment(&params, &buf, entry.compression)?;
+        if !segment::verify_checksum(&plaintext, &entry.checksum) {
+            return Err(CryptoError::VaultCorrupted(format!(
+                "integrity check failed for segment '{name}'"
+            )));
+        }
+        plaintext
+    };
+
+    Ok(SegmentResult {
+        name: name.to_string(),
+        data,
+    })
+}
+
 /// Explicitly flush the in-memory index to disk if it has been modified.
 /// No-op if the index is clean (no mutations since last flush).
 #[cfg(feature = "compression")]

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -952,8 +952,10 @@ pub fn vault_health(handle: &VaultHandle) -> VaultHealthInfo {
 
 /// Read multiple segments concurrently using mmap zero-copy + rayon.
 ///
-/// Returns results in the same order as `names`. Each entry is either the
-/// decrypted segment data or a per-segment error (e.g. `SegmentNotFound`).
+/// Returns results in the same order as `names`. On success, `data` contains
+/// decrypted plaintext and `error` is `None`. On failure, `data` is empty and
+/// `error` describes the problem (e.g. segment not found).
+///
 /// All segments are decrypted into memory simultaneously — callers should
 /// be mindful of total memory when reading many large segments at once.
 ///
@@ -962,7 +964,7 @@ pub fn vault_health(handle: &VaultHandle) -> VaultHealthInfo {
 pub fn vault_read_parallel(
     handle: &VaultHandle,
     names: Vec<String>,
-) -> Vec<Result<SegmentResult, CryptoError>> {
+) -> Vec<SegmentResult> {
     if names.is_empty() {
         return Vec::new();
     }
@@ -983,13 +985,31 @@ pub fn vault_read_parallel(
             })
             .collect()
     } else {
-        // No mmap — sequential fallback, each read opens its own fd
+        // No mmap — sequential fallback with a single shared read-only fd.
+        // NOTE: this fd is separate from handle.file. A non-cooperating writer
+        // between index lookup and file read will be caught by AEAD authentication,
+        // but the error is indistinguishable from normal corruption.
+        let file_result = File::open(&handle.path)
+            .map_err(|e| CryptoError::IoError(format!("cannot open vault for read: {e}")));
+        let mut file = match file_result {
+            Ok(f) => f,
+            Err(e) => {
+                return names
+                    .iter()
+                    .map(|n| SegmentResult {
+                        name: n.clone(),
+                        data: Vec::new(),
+                        error: Some(e.to_string()),
+                    })
+                    .collect();
+            }
+        };
         names
             .iter()
             .map(|name| {
                 read_segment_with_file(
                     name,
-                    &handle.path,
+                    &mut file,
                     &handle.keys,
                     handle.algorithm,
                     handle.index_pad_size,
@@ -1009,13 +1029,36 @@ fn read_segment_from_mmap(
     algorithm: Algorithm,
     index_pad_size: usize,
     index: &format::SegmentIndex,
-) -> Result<SegmentResult, CryptoError> {
+) -> SegmentResult {
+    match read_segment_from_mmap_inner(name, mmap, keys, algorithm, index_pad_size, index) {
+        Ok(data) => SegmentResult {
+            name: name.to_string(),
+            data,
+            error: None,
+        },
+        Err(e) => SegmentResult {
+            name: name.to_string(),
+            data: Vec::new(),
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[cfg(feature = "compression")]
+fn read_segment_from_mmap_inner(
+    name: &str,
+    mmap: &types::VaultMmap,
+    keys: &segment::VaultKeys,
+    algorithm: Algorithm,
+    index_pad_size: usize,
+    index: &format::SegmentIndex,
+) -> Result<Vec<u8>, CryptoError> {
     let entry = index
         .find(name)
         .ok_or_else(|| CryptoError::SegmentNotFound(name.to_string()))?;
 
-    let data = if entry.chunk_count > 0 {
-        let (plaintext, checksum) = decrypt_streaming_chunks_mmap(
+    if entry.chunk_count > 0 {
+        let (mut plaintext, checksum) = decrypt_streaming_chunks_mmap(
             mmap,
             keys.cipher_key.as_bytes(),
             keys.nonce_key.as_bytes(),
@@ -1027,13 +1070,18 @@ fn read_segment_from_mmap(
             entry.chunk_count,
         )?;
         if checksum.ct_ne(&entry.checksum).into() {
+            plaintext.zeroize();
             return Err(CryptoError::VaultCorrupted(format!(
                 "integrity check failed for segment '{name}'"
             )));
         }
-        plaintext
+        Ok(plaintext)
     } else {
-        let abs_offset = format::data_region_offset(index_pad_size) + entry.offset;
+        let abs_offset = format::data_region_offset(index_pad_size)
+            .checked_add(entry.offset)
+            .ok_or_else(|| {
+                CryptoError::VaultCorrupted(format!("segment offset overflow for '{name}'"))
+            })?;
         let encrypted = mmap.slice(abs_offset, entry.size)?;
         let params = SegmentCryptoParams {
             cipher_key: keys.cipher_key.as_bytes(),
@@ -1042,43 +1090,58 @@ fn read_segment_from_mmap(
             segment_index: 0,
             generation: entry.generation,
         };
-        let plaintext = segment::decrypt_segment(&params, encrypted, entry.compression)?;
+        let mut plaintext = segment::decrypt_segment(&params, encrypted, entry.compression)?;
         if !segment::verify_checksum(&plaintext, &entry.checksum) {
+            plaintext.zeroize();
             return Err(CryptoError::VaultCorrupted(format!(
                 "integrity check failed for segment '{name}'"
             )));
         }
-        plaintext
-    };
-
-    Ok(SegmentResult {
-        name: name.to_string(),
-        data,
-    })
+        Ok(plaintext)
+    }
 }
 
-/// Read a single segment by opening a temporary read-only file handle.
-/// Used as fallback when mmap is unavailable.
+/// Read a single segment via file I/O (no-mmap fallback).
 #[cfg(feature = "compression")]
 fn read_segment_with_file(
     name: &str,
-    path: &str,
+    file: &mut File,
     keys: &segment::VaultKeys,
     algorithm: Algorithm,
     index_pad_size: usize,
     index: &format::SegmentIndex,
-) -> Result<SegmentResult, CryptoError> {
+) -> SegmentResult {
+    match read_segment_with_file_inner(name, file, keys, algorithm, index_pad_size, index) {
+        Ok(data) => SegmentResult {
+            name: name.to_string(),
+            data,
+            error: None,
+        },
+        Err(e) => SegmentResult {
+            name: name.to_string(),
+            data: Vec::new(),
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[cfg(feature = "compression")]
+fn read_segment_with_file_inner(
+    name: &str,
+    file: &mut File,
+    keys: &segment::VaultKeys,
+    algorithm: Algorithm,
+    index_pad_size: usize,
+    index: &format::SegmentIndex,
+) -> Result<Vec<u8>, CryptoError> {
     let entry = index
         .find(name)
         .ok_or_else(|| CryptoError::SegmentNotFound(name.to_string()))?;
 
-    let mut file = File::open(path)
-        .map_err(|e| CryptoError::IoError(format!("cannot open vault for read: {e}")))?;
-
-    let data = if entry.chunk_count > 0 {
+    if entry.chunk_count > 0 {
         let mut full_plaintext = Vec::new();
         let checksum = decrypt_streaming_chunks(
-            &mut file,
+            file,
             None,
             keys.cipher_key.as_bytes(),
             keys.nonce_key.as_bytes(),
@@ -1094,13 +1157,18 @@ fn read_segment_with_file(
             },
         )?;
         if checksum.ct_ne(&entry.checksum).into() {
+            full_plaintext.zeroize();
             return Err(CryptoError::VaultCorrupted(format!(
                 "integrity check failed for segment '{name}'"
             )));
         }
-        full_plaintext
+        Ok(full_plaintext)
     } else {
-        let abs_offset = format::data_region_offset(index_pad_size) + entry.offset;
+        let abs_offset = format::data_region_offset(index_pad_size)
+            .checked_add(entry.offset)
+            .ok_or_else(|| {
+                CryptoError::VaultCorrupted(format!("segment offset overflow for '{name}'"))
+            })?;
         let read_len = usize::try_from(entry.size).map_err(|_| {
             CryptoError::VaultCorrupted(format!(
                 "segment size {} exceeds platform address space",
@@ -1117,19 +1185,15 @@ fn read_segment_with_file(
             segment_index: 0,
             generation: entry.generation,
         };
-        let plaintext = segment::decrypt_segment(&params, &buf, entry.compression)?;
+        let mut plaintext = segment::decrypt_segment(&params, &buf, entry.compression)?;
         if !segment::verify_checksum(&plaintext, &entry.checksum) {
+            plaintext.zeroize();
             return Err(CryptoError::VaultCorrupted(format!(
                 "integrity check failed for segment '{name}'"
             )));
         }
-        plaintext
-    };
-
-    Ok(SegmentResult {
-        name: name.to_string(),
-        data,
-    })
+        Ok(plaintext)
+    }
 }
 
 /// Explicitly flush the in-memory index to disk if it has been modified.

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -3548,3 +3548,179 @@ fn test_index_clean_after_resize() {
     assert!(!handle.index_dirty);
     vault_close(handle).expect("close");
 }
+
+// -- Parallel reads -------------------------------------------------------
+
+// Compile-time assertion: VaultHandle must be Sync for &VaultHandle across rayon threads
+#[allow(dead_code)]
+const _: () = {
+    fn assert_sync<T: Sync>() {}
+    fn _check() {
+        assert_sync::<super::types::VaultHandle>();
+    }
+};
+
+#[test]
+fn test_parallel_read_matches_sequential() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    vault_write(&mut handle, "a.txt".into(), b"alpha".to_vec(), None).expect("write a");
+    vault_write(&mut handle, "b.txt".into(), b"bravo".to_vec(), None).expect("write b");
+    vault_write(&mut handle, "c.txt".into(), b"charlie".to_vec(), None).expect("write c");
+
+    // Sequential reads for comparison
+    let seq_a = vault_read(&mut handle, "a.txt".into()).expect("read a");
+    let seq_b = vault_read(&mut handle, "b.txt".into()).expect("read b");
+    let seq_c = vault_read(&mut handle, "c.txt".into()).expect("read c");
+
+    // Parallel read
+    let results = vault_read_parallel(
+        &handle,
+        vec!["a.txt".into(), "b.txt".into(), "c.txt".into()],
+    );
+
+    assert_eq!(results.len(), 3);
+    assert_eq!(results[0].as_ref().expect("par a").data, seq_a);
+    assert_eq!(results[1].as_ref().expect("par b").data, seq_b);
+    assert_eq!(results[2].as_ref().expect("par c").data, seq_c);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_10_segments() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    let mut expected = Vec::new();
+    for i in 0..10u8 {
+        let name = format!("seg_{i}");
+        let data = vec![i; 1024];
+        vault_write(&mut handle, name, data.clone(), None).expect("write");
+        expected.push(data);
+    }
+
+    let names: Vec<String> = (0..10).map(|i| format!("seg_{i}")).collect();
+    let results = vault_read_parallel(&handle, names);
+
+    assert_eq!(results.len(), 10);
+    for (i, result) in results.iter().enumerate() {
+        let sr = result.as_ref().expect("parallel read");
+        assert_eq!(sr.name, format!("seg_{i}"));
+        assert_eq!(sr.data, expected[i]);
+    }
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_mixed_monolithic_and_streaming() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    // Monolithic segment
+    let mono_data = vec![0xAA; 512];
+    vault_write(&mut handle, "mono".into(), mono_data.clone(), None).expect("write mono");
+
+    // Streaming segment (>64KB triggers chunking)
+    let stream_data: Vec<u8> = (0..=255u8).cycle().take(100_000).collect();
+    let stream_iter = stream_data.chunks(8192).map(|c| c.to_vec());
+    vault_write_stream(&mut handle, "stream".into(), stream_data.len() as u64, stream_iter)
+        .expect("write stream");
+
+    let results = vault_read_parallel(&handle, vec!["mono".into(), "stream".into()]);
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].as_ref().expect("mono").data, mono_data);
+    assert_eq!(results[1].as_ref().expect("stream").data, stream_data);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_missing_segment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "exists".into(), vec![1, 2, 3], None).expect("write");
+
+    let results = vault_read_parallel(&handle, vec!["exists".into(), "missing".into()]);
+
+    assert_eq!(results.len(), 2);
+    assert!(results[0].is_ok());
+    assert!(matches!(
+        results[1],
+        Err(CryptoError::SegmentNotFound(_))
+    ));
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_empty_names() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let handle = create_test_vault(&dir, 1_048_576);
+
+    let results = vault_read_parallel(&handle, vec![]);
+    assert!(results.is_empty());
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_single_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "only".into(), b"solo".to_vec(), None).expect("write");
+
+    let seq = vault_read(&mut handle, "only".into()).expect("sequential");
+    let results = vault_read_parallel(&handle, vec!["only".into()]);
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].as_ref().expect("parallel").data, seq);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_preserves_order() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    for i in 0..10u8 {
+        vault_write(&mut handle, format!("seg_{i}"), vec![i; 256], None).expect("write");
+    }
+
+    // Request in reverse order
+    let names: Vec<String> = (0..10).rev().map(|i| format!("seg_{i}")).collect();
+    let results = vault_read_parallel(&handle, names.clone());
+
+    assert_eq!(results.len(), 10);
+    for (i, result) in results.iter().enumerate() {
+        let sr = result.as_ref().expect("read");
+        assert_eq!(sr.name, names[i]);
+    }
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_chacha20() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    let mut handle =
+        vault_create(path, test_key(), "chacha20-poly1305".into(), 4_194_304).expect("create");
+
+    vault_write(&mut handle, "x".into(), b"chacha-data".to_vec(), None).expect("write");
+    vault_write(&mut handle, "y".into(), b"poly1305-data".to_vec(), None).expect("write");
+
+    let results = vault_read_parallel(&handle, vec!["x".into(), "y".into()]);
+
+    assert_eq!(results[0].as_ref().expect("x").data, b"chacha-data");
+    assert_eq!(results[1].as_ref().expect("y").data, b"poly1305-data");
+
+    vault_close(handle).expect("close");
+}

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -3553,12 +3553,8 @@ fn test_index_clean_after_resize() {
 
 // Compile-time assertion: VaultHandle must be Sync for &VaultHandle across rayon threads
 #[allow(dead_code)]
-const _: () = {
-    fn assert_sync<T: Sync>() {}
-    fn _check() {
-        assert_sync::<super::types::VaultHandle>();
-    }
-};
+trait AssertSync: Sync {}
+impl AssertSync for super::types::VaultHandle {}
 
 #[test]
 fn test_parallel_read_matches_sequential() {
@@ -3569,21 +3565,20 @@ fn test_parallel_read_matches_sequential() {
     vault_write(&mut handle, "b.txt".into(), b"bravo".to_vec(), None).expect("write b");
     vault_write(&mut handle, "c.txt".into(), b"charlie".to_vec(), None).expect("write c");
 
-    // Sequential reads for comparison
     let seq_a = vault_read(&mut handle, "a.txt".into()).expect("read a");
     let seq_b = vault_read(&mut handle, "b.txt".into()).expect("read b");
     let seq_c = vault_read(&mut handle, "c.txt".into()).expect("read c");
 
-    // Parallel read
     let results = vault_read_parallel(
         &handle,
         vec!["a.txt".into(), "b.txt".into(), "c.txt".into()],
     );
 
     assert_eq!(results.len(), 3);
-    assert_eq!(results[0].as_ref().expect("par a").data, seq_a);
-    assert_eq!(results[1].as_ref().expect("par b").data, seq_b);
-    assert_eq!(results[2].as_ref().expect("par c").data, seq_c);
+    assert!(results[0].error.is_none());
+    assert_eq!(results[0].data, seq_a);
+    assert_eq!(results[1].data, seq_b);
+    assert_eq!(results[2].data, seq_c);
 
     vault_close(handle).expect("close");
 }
@@ -3605,8 +3600,8 @@ fn test_parallel_read_10_segments() {
     let results = vault_read_parallel(&handle, names);
 
     assert_eq!(results.len(), 10);
-    for (i, result) in results.iter().enumerate() {
-        let sr = result.as_ref().expect("parallel read");
+    for (i, sr) in results.iter().enumerate() {
+        assert!(sr.error.is_none(), "segment {i} had error: {:?}", sr.error);
         assert_eq!(sr.name, format!("seg_{i}"));
         assert_eq!(sr.data, expected[i]);
     }
@@ -3619,11 +3614,9 @@ fn test_parallel_read_mixed_monolithic_and_streaming() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut handle = create_test_vault(&dir, 4_194_304);
 
-    // Monolithic segment
     let mono_data = vec![0xAA; 512];
     vault_write(&mut handle, "mono".into(), mono_data.clone(), None).expect("write mono");
 
-    // Streaming segment (>64KB triggers chunking)
     let stream_data: Vec<u8> = (0..=255u8).cycle().take(100_000).collect();
     let stream_iter = stream_data.chunks(8192).map(|c| c.to_vec());
     vault_write_stream(&mut handle, "stream".into(), stream_data.len() as u64, stream_iter)
@@ -3632,8 +3625,10 @@ fn test_parallel_read_mixed_monolithic_and_streaming() {
     let results = vault_read_parallel(&handle, vec!["mono".into(), "stream".into()]);
 
     assert_eq!(results.len(), 2);
-    assert_eq!(results[0].as_ref().expect("mono").data, mono_data);
-    assert_eq!(results[1].as_ref().expect("stream").data, stream_data);
+    assert!(results[0].error.is_none());
+    assert_eq!(results[0].data, mono_data);
+    assert!(results[1].error.is_none());
+    assert_eq!(results[1].data, stream_data);
 
     vault_close(handle).expect("close");
 }
@@ -3648,11 +3643,14 @@ fn test_parallel_read_missing_segment() {
     let results = vault_read_parallel(&handle, vec!["exists".into(), "missing".into()]);
 
     assert_eq!(results.len(), 2);
-    assert!(results[0].is_ok());
-    assert!(matches!(
-        results[1],
-        Err(CryptoError::SegmentNotFound(_))
-    ));
+    assert!(results[0].error.is_none());
+    assert_eq!(results[0].data, vec![1, 2, 3]);
+    assert!(results[1].error.is_some());
+    assert!(
+        results[1].error.as_ref().expect("error").contains("missing"),
+        "error should mention segment name"
+    );
+    assert!(results[1].data.is_empty());
 
     vault_close(handle).expect("close");
 }
@@ -3679,7 +3677,8 @@ fn test_parallel_read_single_name() {
     let results = vault_read_parallel(&handle, vec!["only".into()]);
 
     assert_eq!(results.len(), 1);
-    assert_eq!(results[0].as_ref().expect("parallel").data, seq);
+    assert!(results[0].error.is_none());
+    assert_eq!(results[0].data, seq);
 
     vault_close(handle).expect("close");
 }
@@ -3693,13 +3692,12 @@ fn test_parallel_read_preserves_order() {
         vault_write(&mut handle, format!("seg_{i}"), vec![i; 256], None).expect("write");
     }
 
-    // Request in reverse order
     let names: Vec<String> = (0..10).rev().map(|i| format!("seg_{i}")).collect();
     let results = vault_read_parallel(&handle, names.clone());
 
     assert_eq!(results.len(), 10);
-    for (i, result) in results.iter().enumerate() {
-        let sr = result.as_ref().expect("read");
+    for (i, sr) in results.iter().enumerate() {
+        assert!(sr.error.is_none());
         assert_eq!(sr.name, names[i]);
     }
 
@@ -3719,8 +3717,32 @@ fn test_parallel_read_chacha20() {
 
     let results = vault_read_parallel(&handle, vec!["x".into(), "y".into()]);
 
-    assert_eq!(results[0].as_ref().expect("x").data, b"chacha-data");
-    assert_eq!(results[1].as_ref().expect("y").data, b"poly1305-data");
+    assert!(results[0].error.is_none());
+    assert_eq!(results[0].data, b"chacha-data");
+    assert!(results[1].error.is_none());
+    assert_eq!(results[1].data, b"poly1305-data");
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_parallel_read_fallback_sequential() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 4_194_304);
+
+    vault_write(&mut handle, "a".into(), b"alpha".to_vec(), None).expect("write a");
+    vault_write(&mut handle, "b".into(), b"bravo".to_vec(), None).expect("write b");
+
+    // Force no-mmap fallback
+    handle.mmap = None;
+
+    let results = vault_read_parallel(&handle, vec!["a".into(), "b".into()]);
+
+    assert_eq!(results.len(), 2);
+    assert!(results[0].error.is_none());
+    assert_eq!(results[0].data, b"alpha");
+    assert!(results[1].error.is_none());
+    assert_eq!(results[1].data, b"bravo");
 
     vault_close(handle).expect("close");
 }

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -134,10 +134,14 @@ pub struct DefragResult {
 }
 
 /// Result of a single segment read from `vault_read_parallel`.
+///
+/// On success, `data` contains the decrypted plaintext and `error` is `None`.
+/// On failure, `data` is empty and `error` contains the error description.
 #[frb(non_opaque)]
 pub struct SegmentResult {
     pub name: String,
     pub data: Vec<u8>,
+    pub error: Option<String>,
 }
 
 /// Vault health and diagnostic info returned to callers.

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -133,6 +133,13 @@ pub struct DefragResult {
     pub free_regions_before: u32,
 }
 
+/// Result of a single segment read from `vault_read_parallel`.
+#[frb(non_opaque)]
+pub struct SegmentResult {
+    pub name: String,
+    pub data: Vec<u8>,
+}
+
 /// Vault health and diagnostic info returned to callers.
 #[frb(non_opaque)]
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
## Summary

- Add `vault_read_parallel(&VaultHandle, names)` for concurrent segment reads via rayon + mmap zero-copy
- Takes `&VaultHandle` (immutable) — no shared mutable state between threads
- `SegmentResult` type with `name`, `data`, and `error` fields (FRB-compatible)
- mmap-only `decrypt_streaming_chunks_mmap()` helper for streaming segments without `&mut File`
- Sequential single-fd fallback when mmap is unavailable (32-bit targets)
- Checked offset arithmetic, plaintext zeroization on checksum failure
- Compile-time `Sync` assertion for `VaultHandle`

## Test plan

- [x] Parallel read matches sequential read (byte-for-byte)
- [x] Concurrent reads on 10 segments — no corruption
- [x] Mixed monolithic and streaming segments in parallel
- [x] Segment not found in batch — error in correct position, others succeed
- [x] Empty names list — returns empty vec
- [x] Single name — equivalent to vault_read
- [x] Order preserved (reverse input order)
- [x] ChaCha20-Poly1305 algorithm
- [x] Sequential fallback path (mmap = None)
- [x] All 385 tests pass, zero clippy warnings