### PR TITLE
feat(evfs): add vault_rename_segment with WAL-safe index renaming

### DIFF
--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -756,6 +756,11 @@ pub fn vault_rename_segment(
     old_name: String,
     new_name: String,
 ) -> Result<(), CryptoError> {
+    // No-op when names are identical
+    if old_name == new_name {
+        return Ok(());
+    }
+
     // Pre-flight read-only checks to avoid unnecessary WAL I/O on failure
     if new_name.is_empty() || new_name.len() > MAX_SEGMENT_NAME_LEN {
         return Err(CryptoError::InvalidParameter(format!(
@@ -763,11 +768,11 @@ pub fn vault_rename_segment(
             new_name.len()
         )));
     }
-    if handle.index.find(&new_name).is_some() {
-        return Err(CryptoError::DuplicateSegment(new_name));
-    }
     if handle.index.find(&old_name).is_none() {
         return Err(CryptoError::SegmentNotFound(old_name));
+    }
+    if handle.index.find(&new_name).is_some() {
+        return Err(CryptoError::DuplicateSegment(new_name));
     }
 
     // WAL journal old index snapshot

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -12,7 +12,8 @@ pub use types::*;
 use crate::api::compression::{CompressionAlgorithm, CompressionConfig};
 use crate::core::error::CryptoError;
 use crate::core::evfs::format::{
-    self, SegmentEntry, SegmentIndex, VaultHeader, PRIMARY_INDEX_OFFSET, VAULT_HEADER_SIZE,
+    self, SegmentEntry, SegmentIndex, VaultHeader, MAX_SEGMENT_NAME_LEN, PRIMARY_INDEX_OFFSET,
+    VAULT_HEADER_SIZE,
 };
 use crate::core::evfs::segment::{self, SegmentCryptoParams};
 use crate::core::evfs::wal::{VaultLock, WalOp, WriteAheadLog};
@@ -747,6 +748,58 @@ fn write_encrypted_chunk(
     Ok(())
 }
 
+/// Renames an existing segment in the vault index without modifying its encrypted data.
+/// Index-only operation — no data I/O, no re-encryption.
+#[cfg(feature = "compression")]
+pub fn vault_rename_segment(
+    handle: &mut VaultHandle,
+    old_name: String,
+    new_name: String,
+) -> Result<(), CryptoError> {
+    // Pre-flight read-only checks to avoid unnecessary WAL I/O on failure
+    if new_name.is_empty() || new_name.len() > MAX_SEGMENT_NAME_LEN {
+        return Err(CryptoError::InvalidParameter(format!(
+            "invalid new segment name length: {}",
+            new_name.len()
+        )));
+    }
+    if handle.index.find(&new_name).is_some() {
+        return Err(CryptoError::DuplicateSegment(new_name));
+    }
+    if handle.index.find(&old_name).is_none() {
+        return Err(CryptoError::SegmentNotFound(old_name));
+    }
+
+    // WAL journal old index snapshot
+    let old_encrypted_index = read_encrypted_index(
+        &mut handle.file,
+        PRIMARY_INDEX_OFFSET,
+        format::encrypted_index_size(handle.index_pad_size),
+    )?;
+    handle.wal.begin(WalOp::UpdateIndex, &old_encrypted_index)?;
+
+    // Update entry in memory
+    handle.index.rename(&old_name, &new_name)?;
+
+    // Flush index (primary + shadow) + fsync
+    handle.index_dirty = true;
+    flush_index(
+        &mut handle.file,
+        &handle.index,
+        &handle.keys,
+        handle.algorithm,
+        handle.index.capacity,
+        handle.index_pad_size,
+    )?;
+    handle.index_dirty = false;
+
+    // WAL commit + refresh mmap
+    handle.wal.commit()?;
+    handle.refresh_mmap();
+
+    Ok(())
+}
+
 /// Delete a named segment. The region is secure-erased and returned to the
 /// free list for reuse by future writes.
 #[cfg(feature = "compression")]
@@ -961,10 +1014,7 @@ pub fn vault_health(handle: &VaultHandle) -> VaultHealthInfo {
 ///
 /// Falls back to sequential file-based reads when mmap is unavailable.
 #[cfg(feature = "compression")]
-pub fn vault_read_parallel(
-    handle: &VaultHandle,
-    names: Vec<String>,
-) -> Vec<SegmentResult> {
+pub fn vault_read_parallel(handle: &VaultHandle, names: Vec<String>) -> Vec<SegmentResult> {
     if names.is_empty() {
         return Vec::new();
     }
@@ -1208,9 +1258,7 @@ pub fn vault_flush(handle: &mut VaultHandle) -> Result<(), CryptoError> {
         PRIMARY_INDEX_OFFSET,
         format::encrypted_index_size(handle.index_pad_size),
     )?;
-    handle
-        .wal
-        .begin(WalOp::UpdateIndex, &old_encrypted_index)?;
+    handle.wal.begin(WalOp::UpdateIndex, &old_encrypted_index)?;
     flush_index(
         &mut handle.file,
         &handle.index,

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -2760,7 +2760,9 @@ fn parse_archive(
     assert!(data.len() >= ARCHIVE_HEADER_SIZE + WRAPPED_KEY_SIZE + ARCHIVE_TRAILER_SIZE);
 
     let header = ArchiveHeader::from_bytes(
-        data[..ARCHIVE_HEADER_SIZE].try_into().expect("header slice"),
+        data[..ARCHIVE_HEADER_SIZE]
+            .try_into()
+            .expect("header slice"),
     )
     .expect("parse header");
 
@@ -2784,8 +2786,9 @@ fn parse_archive(
         });
     }
 
-    let trailer_bytes: [u8; ARCHIVE_TRAILER_SIZE] =
-        data[pos..pos + ARCHIVE_TRAILER_SIZE].try_into().expect("trailer slice");
+    let trailer_bytes: [u8; ARCHIVE_TRAILER_SIZE] = data[pos..pos + ARCHIVE_TRAILER_SIZE]
+        .try_into()
+        .expect("trailer slice");
     let trailer = ArchiveTrailer::from_bytes(&trailer_bytes).expect("parse trailer");
 
     // Verify BLAKE3 trailer covers everything before the trailer
@@ -3413,8 +3416,8 @@ fn test_index_dirty_false_after_create() {
 fn test_index_dirty_false_after_open() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = vault_path(&dir);
-    let handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
-        .expect("create");
+    let handle =
+        vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
     vault_close(handle).expect("close");
 
     let handle = vault_open(path, test_key()).expect("open");
@@ -3619,8 +3622,13 @@ fn test_parallel_read_mixed_monolithic_and_streaming() {
 
     let stream_data: Vec<u8> = (0..=255u8).cycle().take(100_000).collect();
     let stream_iter = stream_data.chunks(8192).map(|c| c.to_vec());
-    vault_write_stream(&mut handle, "stream".into(), stream_data.len() as u64, stream_iter)
-        .expect("write stream");
+    vault_write_stream(
+        &mut handle,
+        "stream".into(),
+        stream_data.len() as u64,
+        stream_iter,
+    )
+    .expect("write stream");
 
     let results = vault_read_parallel(&handle, vec!["mono".into(), "stream".into()]);
 
@@ -3647,7 +3655,11 @@ fn test_parallel_read_missing_segment() {
     assert_eq!(results[0].data, vec![1, 2, 3]);
     assert!(results[1].error.is_some());
     assert!(
-        results[1].error.as_ref().expect("error").contains("missing"),
+        results[1]
+            .error
+            .as_ref()
+            .expect("error")
+            .contains("missing"),
         "error should mention segment name"
     );
     assert!(results[1].data.is_empty());
@@ -3743,6 +3755,165 @@ fn test_parallel_read_fallback_sequential() {
     assert_eq!(results[0].data, b"alpha");
     assert!(results[1].error.is_none());
     assert_eq!(results[1].data, b"bravo");
+
+    vault_close(handle).expect("close");
+}
+
+// -- Rename Segment Tests -----------------------------------------------
+
+#[test]
+fn test_rename_read_success() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "old.txt".into(), b"data".to_vec(), None).expect("write");
+    vault_rename_segment(&mut handle, "old.txt".into(), "new.txt".into()).expect("rename");
+
+    let data = vault_read(&mut handle, "new.txt".into()).expect("read new");
+    assert_eq!(data, b"data");
+
+    let result = vault_read(&mut handle, "old.txt".into());
+    assert!(matches!(result, Err(CryptoError::SegmentNotFound(_))));
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_duplicate_name_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "a.txt".into(), b"a".to_vec(), None).expect("write a");
+    vault_write(&mut handle, "b.txt".into(), b"b".to_vec(), None).expect("write b");
+
+    let result = vault_rename_segment(&mut handle, "a.txt".into(), "b.txt".into());
+    assert!(matches!(result, Err(CryptoError::DuplicateSegment(_))));
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_nonexistent_fails() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    let result = vault_rename_segment(&mut handle, "missing.txt".into(), "new.txt".into());
+    assert!(matches!(result, Err(CryptoError::SegmentNotFound(_))));
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_preserves_metadata() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "old.txt".into(), b"data".to_vec(), None).expect("write");
+    let old_entry = handle.index.find("old.txt").expect("find").clone();
+
+    vault_rename_segment(&mut handle, "old.txt".into(), "new.txt".into()).expect("rename");
+    let new_entry = handle.index.find("new.txt").expect("find");
+
+    assert_eq!(old_entry.offset, new_entry.offset);
+    assert_eq!(old_entry.size, new_entry.size);
+    assert_eq!(old_entry.generation, new_entry.generation);
+    assert_eq!(old_entry.checksum, new_entry.checksum);
+    assert_eq!(old_entry.compression, new_entry.compression);
+    assert_eq!(old_entry.chunk_count, new_entry.chunk_count);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_multiple_sequence() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "1.txt".into(), b"sequence".to_vec(), None).expect("write");
+    vault_rename_segment(&mut handle, "1.txt".into(), "2.txt".into()).expect("r1");
+    vault_rename_segment(&mut handle, "2.txt".into(), "3.txt".into()).expect("r2");
+
+    assert!(handle.index.find("1.txt").is_none());
+    assert!(handle.index.find("2.txt").is_none());
+
+    let data = vault_read(&mut handle, "3.txt".into()).expect("read");
+    assert_eq!(data, b"sequence");
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_streaming_segment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 2_097_152);
+
+    let data = vec![0x77; 150_000];
+    let chunks: Vec<Vec<u8>> = data.chunks(65536).map(|c| c.to_vec()).collect();
+    vault_write_stream(
+        &mut handle,
+        "stream.bin".into(),
+        data.len() as u64,
+        chunks.into_iter(),
+    )
+    .expect("write stream");
+
+    vault_rename_segment(
+        &mut handle,
+        "stream.bin".into(),
+        "renamed_stream.bin".into(),
+    )
+    .expect("rename");
+
+    // Interop read on streaming segment
+    let readback = vault_read(&mut handle, "renamed_stream.bin".into()).expect("read");
+    assert_eq!(readback, data);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_and_defragment() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "a.txt".into(), vec![0xAA; 100], None).expect("A");
+    vault_write(&mut handle, "b.txt".into(), vec![0xBB; 100], None).expect("B");
+    vault_write(&mut handle, "c.txt".into(), vec![0xCC; 100], None).expect("C");
+
+    vault_delete(&mut handle, "b.txt".into()).expect("del B");
+    vault_rename_segment(&mut handle, "c.txt".into(), "c_renamed.txt".into()).expect("rename");
+
+    vault_defragment(&mut handle).expect("defrag");
+
+    let data = vault_read(&mut handle, "c_renamed.txt".into()).expect("read");
+    assert_eq!(data, vec![0xCC; 100]);
+
+    vault_close(handle).expect("close");
+}
+
+#[test]
+fn test_rename_chacha20() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+    let mut handle =
+        vault_create(path, test_key(), "chacha20-poly1305".into(), 1_048_576).expect("create");
+
+    vault_write(
+        &mut handle,
+        "old_chacha.txt".into(),
+        b"chacha".to_vec(),
+        None,
+    )
+    .expect("write");
+    vault_rename_segment(
+        &mut handle,
+        "old_chacha.txt".into(),
+        "new_chacha.txt".into(),
+    )
+    .expect("rename");
+
+    let data = vault_read(&mut handle, "new_chacha.txt".into()).expect("read");
+    assert_eq!(data, b"chacha");
 
     vault_close(handle).expect("close");
 }

--- a/rust/src/api/evfs/tests.rs
+++ b/rust/src/api/evfs/tests.rs
@@ -3917,3 +3917,17 @@ fn test_rename_chacha20() {
 
     vault_close(handle).expect("close");
 }
+
+#[test]
+fn test_rename_to_same_name_is_noop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut handle = create_test_vault(&dir, 1_048_576);
+
+    vault_write(&mut handle, "same.txt".into(), b"data".to_vec(), None).expect("write");
+    vault_rename_segment(&mut handle, "same.txt".into(), "same.txt".into()).expect("noop rename");
+
+    let data = vault_read(&mut handle, "same.txt".into()).expect("read");
+    assert_eq!(data, b"data");
+
+    vault_close(handle).expect("close");
+}

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -44,6 +44,9 @@ pub enum CryptoError {
     #[error("Segment not found: {0}")]
     SegmentNotFound(String),
 
+    #[error("Duplicate segment {0}")]
+    DuplicateSegment(String),
+
     #[error("Vault corrupted: {0}")]
     VaultCorrupted(String),
 

--- a/rust/src/core/evfs/format.rs
+++ b/rust/src/core/evfs/format.rs
@@ -553,20 +553,9 @@ impl SegmentIndex {
         self.entries.iter_mut().find(|e| e.name == name)
     }
 
-    /// Renames a segment in the index. Returns an error if the old name is missing,
-    /// the new name is invalid, or the new name is already taken.
+    /// Renames a segment in the index.
+    /// Caller must validate names and check for duplicates before calling.
     pub fn rename(&mut self, old_name: &str, new_name: &str) -> Result<(), CryptoError> {
-        if new_name.is_empty() || new_name.len() > MAX_SEGMENT_NAME_LEN {
-            return Err(CryptoError::InvalidParameter(format!(
-                "new segment name invalid: {}",
-                new_name.len()
-            )));
-        }
-
-        if self.find(new_name).is_some() {
-            return Err(CryptoError::DuplicateSegment(new_name.to_string()));
-        }
-
         let entry = self
             .entries
             .iter_mut()

--- a/rust/src/core/evfs/format.rs
+++ b/rust/src/core/evfs/format.rs
@@ -553,6 +553,31 @@ impl SegmentIndex {
         self.entries.iter_mut().find(|e| e.name == name)
     }
 
+    /// Renames a segment in the index. Returns an error if the old name is missing,
+    /// the new name is invalid, or the new name is already taken.
+    pub fn rename(&mut self, old_name: &str, new_name: &str) -> Result<(), CryptoError> {
+        if new_name.is_empty() || new_name.len() > MAX_SEGMENT_NAME_LEN {
+            return Err(CryptoError::InvalidParameter(format!(
+                "new segment name invalid: {}",
+                new_name.len()
+            )));
+        }
+
+        if self.find(new_name).is_some() {
+            return Err(CryptoError::DuplicateSegment(new_name.to_string()));
+        }
+
+        let entry = self
+            .entries
+            .iter_mut()
+            .find(|e| e.name == old_name)
+            .ok_or_else(|| CryptoError::SegmentNotFound(old_name.to_string()))?;
+
+        entry.name = new_name.to_string();
+
+        Ok(())
+    }
+
     pub fn remove(&mut self, name: &str) -> Option<SegmentEntry> {
         if let Some(pos) = self.entries.iter().position(|e| e.name == name) {
             Some(self.entries.remove(pos))


### PR DESCRIPTION
- Added `DuplicateSegment` error variant to `CryptoError`.
- Implemented `SegmentIndex::rename` for safe in-memory segment renaming.
- Exposed `vault_rename_segment` API with pre-flight checks and WAL safety.
- Ensured robust WAL crash recovery and index flush during rename.
- Added all kind of tests (all passing).

<img width="800" height="324" alt="image" src="https://github.com/user-attachments/assets/7060c167-d6c6-4349-9710-fb3f796af98c" />