### PR TITLE
feat(evfs): add Dart wrappers and integration tests for segment enhancements

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -711,12 +711,12 @@ class _VaultTabState extends State<_VaultTab> {
     if (!_vaultOpen || _handle == null) return;
     setState(() => _loading = true);
     try {
-      final data = await VaultService.read(handle: _handle!, name: name);
+      final result = await VaultService.read(handle: _handle!, name: name);
       // Try decoding as UTF-8, fallback to hex
       try {
-        _readResult = '[$name] ${utf8.decode(data)}';
+        _readResult = '[$name] ${utf8.decode(result.data)}';
       } catch (_) {
-        _readResult = '[$name] ${_hex(data)}';
+        _readResult = '[$name] ${_hex(result.data)}';
       }
     } catch (e) {
       _readResult = 'Error reading "$name": $e';

--- a/integration_test/evfs_enhancements_test.dart
+++ b/integration_test/evfs_enhancements_test.dart
@@ -210,8 +210,8 @@ void main() {
         data: Uint8List(10),
       );
 
-      expect(
-        () async => await VaultService.renameSegment(
+      await expectLater(
+        () => VaultService.renameSegment(
           handle: handle,
           oldName: 'a.bin',
           newName: 'b.bin',
@@ -235,8 +235,8 @@ void main() {
         capacityBytes: 1024 * 1024,
       );
 
-      expect(
-        () async => await VaultService.renameSegment(
+      await expectLater(
+        () => VaultService.renameSegment(
           handle: handle,
           oldName: 'ghost.bin',
           newName: 'new.bin',

--- a/integration_test/evfs_enhancements_test.dart
+++ b/integration_test/evfs_enhancements_test.dart
@@ -1,0 +1,546 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:m_security/src/rust/api/encryption.dart';
+import 'package:m_security/src/rust/frb_generated.dart';
+import 'package:m_security/src/evfs/vault_service.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async => await RustLib.init());
+
+  group('Segment Metadata', () {
+    late Directory tempDir;
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('meta_test');
+    });
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('write with metadata, read back matches', () async {
+      final path = '${tempDir.path}/meta.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final metadata = {'mime': 'application/octet-stream', 'author': 'test'};
+
+      await VaultService.write(
+        handle: handle,
+        name: 'doc.bin',
+        data: data,
+        metadata: metadata,
+      );
+
+      final result = await VaultService.read(handle: handle, name: 'doc.bin');
+      expect(result.data, data);
+      expect(result.metadata, metadata);
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('write without metadata returns empty map', () async {
+      final path = '${tempDir.path}/nometa.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([10, 20, 30]);
+      await VaultService.write(handle: handle, name: 'plain.bin', data: data);
+
+      final result = await VaultService.read(
+        handle: handle,
+        name: 'plain.bin',
+      );
+      expect(result.data, data);
+      expect(result.metadata, isEmpty);
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('overwrite with different metadata replaces old', () async {
+      final path = '${tempDir.path}/overwrite_meta.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([1, 2, 3]);
+      await VaultService.write(
+        handle: handle,
+        name: 'file.bin',
+        data: data,
+        metadata: {'version': '1'},
+      );
+
+      // Overwrite with new metadata
+      final newData = Uint8List.fromList([4, 5, 6]);
+      await VaultService.write(
+        handle: handle,
+        name: 'file.bin',
+        data: newData,
+        metadata: {'version': '2', 'updated': 'true'},
+      );
+
+      final result = await VaultService.read(handle: handle, name: 'file.bin');
+      expect(result.data, newData);
+      expect(result.metadata, {'version': '2', 'updated': 'true'});
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('metadata survives close and reopen', () async {
+      final path = '${tempDir.path}/persist_meta.vault';
+      final key = await generateAes256GcmKey();
+
+      var handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([7, 8, 9]);
+      await VaultService.write(
+        handle: handle,
+        name: 'persist.bin',
+        data: data,
+        metadata: {'created': '2026-04-09'},
+      );
+      await VaultService.close(handle: handle);
+
+      // Reopen and verify
+      handle = await VaultService.open(path: path, key: key);
+      final result = await VaultService.read(
+        handle: handle,
+        name: 'persist.bin',
+      );
+      expect(result.data, data);
+      expect(result.metadata['created'], '2026-04-09');
+
+      await VaultService.close(handle: handle);
+    });
+  });
+
+  group('Segment Rename', () {
+    late Directory tempDir;
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('rename_test');
+    });
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('rename then read under new name', () async {
+      final path = '${tempDir.path}/rename.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([1, 2, 3, 4, 5]);
+      await VaultService.write(handle: handle, name: 'old.bin', data: data);
+
+      await VaultService.renameSegment(
+        handle: handle,
+        oldName: 'old.bin',
+        newName: 'new.bin',
+      );
+
+      // Readable under new name
+      final result = await VaultService.read(handle: handle, name: 'new.bin');
+      expect(result.data, data);
+
+      // Old name gone
+      expect(
+        () async =>
+            await VaultService.read(handle: handle, name: 'old.bin'),
+        throwsA(isA<Exception>()),
+      );
+
+      // List reflects rename
+      final names = await VaultService.list(handle: handle);
+      expect(names, contains('new.bin'));
+      expect(names, isNot(contains('old.bin')));
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('rename to existing name throws DuplicateSegment', () async {
+      final path = '${tempDir.path}/dup.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      await VaultService.write(
+        handle: handle,
+        name: 'a.bin',
+        data: Uint8List(10),
+      );
+      await VaultService.write(
+        handle: handle,
+        name: 'b.bin',
+        data: Uint8List(10),
+      );
+
+      expect(
+        () async => await VaultService.renameSegment(
+          handle: handle,
+          oldName: 'a.bin',
+          newName: 'b.bin',
+        ),
+        throwsA(
+          predicate((e) => e.toString().contains('duplicateSegment')),
+        ),
+      );
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('rename nonexistent segment throws SegmentNotFound', () async {
+      final path = '${tempDir.path}/notfound.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+
+      expect(
+        () async => await VaultService.renameSegment(
+          handle: handle,
+          oldName: 'ghost.bin',
+          newName: 'new.bin',
+        ),
+        throwsA(
+          predicate((e) => e.toString().contains('segmentNotFound')),
+        ),
+      );
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('rename preserves metadata', () async {
+      final path = '${tempDir.path}/rename_meta.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList([42]);
+      await VaultService.write(
+        handle: handle,
+        name: 'before.bin',
+        data: data,
+        metadata: {'tag': 'important'},
+      );
+
+      await VaultService.renameSegment(
+        handle: handle,
+        oldName: 'before.bin',
+        newName: 'after.bin',
+      );
+
+      final result = await VaultService.read(handle: handle, name: 'after.bin');
+      expect(result.data, data);
+      expect(result.metadata['tag'], 'important');
+
+      await VaultService.close(handle: handle);
+    });
+  });
+
+  group('Flush', () {
+    late Directory tempDir;
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('flush_test');
+    });
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('explicit flush after write succeeds', () async {
+      final path = '${tempDir.path}/flush.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      await VaultService.write(
+        handle: handle,
+        name: 'data.bin',
+        data: Uint8List.fromList([1, 2, 3]),
+      );
+
+      // Flush should not throw
+      await VaultService.flush(handle: handle);
+
+      // Data still readable
+      final result = await VaultService.read(handle: handle, name: 'data.bin');
+      expect(result.data, Uint8List.fromList([1, 2, 3]));
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('flush on clean handle is no-op', () async {
+      final path = '${tempDir.path}/noop_flush.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+
+      // No writes — flush should be a safe no-op
+      await VaultService.flush(handle: handle);
+
+      await VaultService.close(handle: handle);
+    });
+  });
+
+  group('Parallel Read', () {
+    late Directory tempDir;
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('parallel_test');
+    });
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('parallel read 5 segments matches sequential', () async {
+      final path = '${tempDir.path}/parallel.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 5 * 1024 * 1024,
+      );
+
+      // Write 5 segments
+      final segments = <String, Uint8List>{};
+      for (var i = 0; i < 5; i++) {
+        final name = 'seg_$i.bin';
+        final data = Uint8List.fromList(
+          List.generate(1000 + i * 100, (j) => (j * (i + 1)) % 256),
+        );
+        segments[name] = data;
+        await VaultService.write(handle: handle, name: name, data: data);
+      }
+
+      // Parallel read all
+      final results = await VaultService.readParallel(
+        handle: handle,
+        names: segments.keys.toList(),
+      );
+
+      expect(results.length, 5);
+      for (final r in results) {
+        expect(r.error, isNull, reason: 'segment ${r.name} had error: ${r.error}');
+        expect(r.data, segments[r.name], reason: 'data mismatch for ${r.name}');
+      }
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('parallel read with missing name returns per-segment error', () async {
+      final path = '${tempDir.path}/partial.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 2 * 1024 * 1024,
+      );
+
+      await VaultService.write(
+        handle: handle,
+        name: 'exists.bin',
+        data: Uint8List.fromList([1, 2, 3]),
+      );
+
+      final results = await VaultService.readParallel(
+        handle: handle,
+        names: ['exists.bin', 'missing.bin'],
+      );
+
+      expect(results.length, 2);
+
+      final existing = results.firstWhere((r) => r.name == 'exists.bin');
+      expect(existing.error, isNull);
+      expect(existing.data, Uint8List.fromList([1, 2, 3]));
+
+      final missing = results.firstWhere((r) => r.name == 'missing.bin');
+      expect(missing.error, isNotNull);
+      expect(missing.data, isEmpty);
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('parallel read empty list returns empty result', () async {
+      final path = '${tempDir.path}/empty.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+
+      final results = await VaultService.readParallel(
+        handle: handle,
+        names: [],
+      );
+      expect(results, isEmpty);
+
+      await VaultService.close(handle: handle);
+    });
+  });
+
+  group('Combined Workflows', () {
+    late Directory tempDir;
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('combined_test');
+    });
+    tearDown(() async {
+      await tempDir.delete(recursive: true);
+    });
+
+    test('write with metadata, rename, parallel read — metadata preserved',
+        () async {
+      final path = '${tempDir.path}/combined.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 5 * 1024 * 1024,
+      );
+
+      final data = Uint8List.fromList(List.generate(500, (i) => i % 256));
+
+      // Write with metadata
+      await VaultService.write(
+        handle: handle,
+        name: 'original.bin',
+        data: data,
+        metadata: {'type': 'document', 'priority': 'high'},
+      );
+
+      // Rename
+      await VaultService.renameSegment(
+        handle: handle,
+        oldName: 'original.bin',
+        newName: 'renamed.bin',
+      );
+
+      // Write another segment (no metadata)
+      await VaultService.write(
+        handle: handle,
+        name: 'extra.bin',
+        data: Uint8List.fromList([99]),
+      );
+
+      // Parallel read both
+      final results = await VaultService.readParallel(
+        handle: handle,
+        names: ['renamed.bin', 'extra.bin'],
+      );
+
+      expect(results.length, 2);
+      final renamed = results.firstWhere((r) => r.name == 'renamed.bin');
+      expect(renamed.data, data);
+      expect(renamed.error, isNull);
+
+      // Verify metadata via single read (parallel read doesn't return metadata)
+      final detailed = await VaultService.read(
+        handle: handle,
+        name: 'renamed.bin',
+      );
+      expect(detailed.metadata['type'], 'document');
+      expect(detailed.metadata['priority'], 'high');
+
+      await VaultService.close(handle: handle);
+    });
+
+    test('write 10 segments, parallel read all, verify data', () async {
+      final path = '${tempDir.path}/bulk.vault';
+      final key = await generateAes256GcmKey();
+
+      final handle = await VaultService.create(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 10 * 1024 * 1024,
+      );
+
+      final segments = <String, Uint8List>{};
+      for (var i = 0; i < 10; i++) {
+        final name = 'bulk_$i.dat';
+        final data = Uint8List.fromList(
+          List.generate(2048, (j) => (j + i * 17) % 256),
+        );
+        segments[name] = data;
+        await VaultService.write(handle: handle, name: name, data: data);
+      }
+
+      // Flush before parallel read
+      await VaultService.flush(handle: handle);
+
+      final results = await VaultService.readParallel(
+        handle: handle,
+        names: segments.keys.toList(),
+      );
+
+      expect(results.length, 10);
+      for (final r in results) {
+        expect(r.error, isNull, reason: '${r.name} failed: ${r.error}');
+        expect(r.data, segments[r.name], reason: 'data mismatch: ${r.name}');
+      }
+
+      await VaultService.close(handle: handle);
+    });
+  });
+}

--- a/integration_test/evfs_test.dart
+++ b/integration_test/evfs_test.dart
@@ -49,7 +49,7 @@ void main() {
         handle: reopened,
         name: 'test.bin',
       );
-      expect(result, data);
+      expect(result.data, data);
 
       //close vault
       await VaultService.close(handle: reopened);
@@ -92,9 +92,9 @@ void main() {
         name: 'file3.dat',
       );
 
-      expect(result1, data1);
-      expect(result2, data2);
-      expect(result3, data3);
+      expect(result1.data, data1);
+      expect(result2.data, data2);
+      expect(result3.data, data3);
 
       await VaultService.close(handle: handle);
     });
@@ -125,8 +125,8 @@ void main() {
       // Read back
       final result = await VaultService.read(handle: handle, name: 'data.bin');
 
-      expect(result, updated);
-      expect(result, isNot(original));
+      expect(result.data, updated);
+      expect(result.data, isNot(original));
 
       await VaultService.close(handle: handle);
     });
@@ -166,7 +166,7 @@ void main() {
 
       //verify it exists
       final before = await VaultService.read(handle: handle, name: 'temp.dat');
-      expect(before, data);
+      expect(before.data, data);
 
       //delete it
       await VaultService.delete(handle: handle, name: 'temp.dat');
@@ -340,7 +340,7 @@ void main() {
         ),
       );
       final result = await VaultService.read(handle: handle, name: 'notes.txt');
-      expect(result, data);
+      expect(result.data, data);
       await VaultService.close(handle: handle);
     });
 
@@ -364,7 +364,7 @@ void main() {
         ),
       );
       final result = await VaultService.read(handle: handle, name: 'notes.txt');
-      expect(result, data);
+      expect(result.data, data);
       await VaultService.close(handle: handle);
     });
 
@@ -396,7 +396,7 @@ void main() {
 
       // Read back
       final result = await VaultService.read(handle: handle, name: 'photo.jpg');
-      expect(result, jpegData);
+      expect(result.data, jpegData);
 
       // Verify: if compression was applied, capacity used would be less
       // Since it was skipped, capacity used ≈ original size
@@ -469,17 +469,17 @@ void main() {
 
       // Verify all three match original data
       expect(
-        resultA,
+        resultA.data,
         dataA,
         reason: 'Zstd segment should decompress correctly',
       );
       expect(
-        resultB,
+        resultB.data,
         dataB,
         reason: 'Brotli segment should decompress correctly',
       );
       expect(
-        resultC,
+        resultC.data,
         dataC,
         reason: 'Uncompressed segment should read correctly',
       );
@@ -567,7 +567,7 @@ void main() {
         handle: reopened,
         name: 'initial.bin',
       );
-      expect(result, data1);
+      expect(result.data, data1);
 
       // Write more data after recovery
       final data2 = Uint8List.fromList([6, 7, 8, 9]);
@@ -591,8 +591,8 @@ void main() {
         name: 'after_recovery.bin',
       );
 
-      expect(result1, data1);
-      expect(result2, data2);
+      expect(result1.data, data1);
+      expect(result2.data, data2);
 
       await VaultService.close(handle: reopened2);
     });
@@ -646,7 +646,7 @@ void main() {
         name: 'important.bin',
       );
       expect(
-        result,
+        result.data,
         originalData,
         reason: 'Shadow index should have preserved the segment',
       );
@@ -659,7 +659,7 @@ void main() {
         handle: reopened2,
         name: 'important.bin',
       );
-      expect(result2, originalData);
+      expect(result2.data, originalData);
 
       await VaultService.close(handle: reopened2);
     });

--- a/integration_test/vault_key_management_test.dart
+++ b/integration_test/vault_key_management_test.dart
@@ -41,8 +41,8 @@ void main() {
       handle = await VaultService.rotateKey(handle: handle, newKey: newKey);
 
       // All segments readable with new handle
-      expect(await VaultService.read(handle: handle, name: 'a.bin'), dataA);
-      expect(await VaultService.read(handle: handle, name: 'b.bin'), dataB);
+      expect((await VaultService.read(handle: handle, name: 'a.bin')).data, dataA);
+      expect((await VaultService.read(handle: handle, name: 'b.bin')).data, dataB);
 
       await VaultService.close(handle: handle);
     });
@@ -77,7 +77,7 @@ void main() {
       // New key works
       final reopened = await VaultService.open(path: path, key: newKey);
       expect(
-        await VaultService.read(handle: reopened, name: 'secret.bin'),
+        (await VaultService.read(handle: reopened, name: 'secret.bin')).data,
         Uint8List.fromList([1, 2, 3]),
       );
       await VaultService.close(handle: reopened);
@@ -123,8 +123,8 @@ void main() {
         capacityBytes: 2 * 1024 * 1024,
       );
 
-      expect(await VaultService.read(handle: imported, name: 'file1.dat'), data1);
-      expect(await VaultService.read(handle: imported, name: 'file2.dat'), data2);
+      expect((await VaultService.read(handle: imported, name: 'file1.dat')).data, data1);
+      expect((await VaultService.read(handle: imported, name: 'file2.dat')).data, data2);
 
       await VaultService.close(handle: imported);
     });
@@ -202,7 +202,7 @@ void main() {
         capacityBytes: 5 * 1024 * 1024,
       );
 
-      expect(await VaultService.read(handle: imported, name: 'big.bin'), bigData);
+      expect((await VaultService.read(handle: imported, name: 'big.bin')).data, bigData);
       await VaultService.close(handle: imported);
     });
 
@@ -224,16 +224,16 @@ void main() {
 
       // Rotate twice
       handle = await VaultService.rotateKey(handle: handle, newKey: key2);
-      expect(await VaultService.read(handle: handle, name: 'data.bin'), data);
+      expect((await VaultService.read(handle: handle, name: 'data.bin')).data, data);
 
       handle = await VaultService.rotateKey(handle: handle, newKey: key3);
-      expect(await VaultService.read(handle: handle, name: 'data.bin'), data);
+      expect((await VaultService.read(handle: handle, name: 'data.bin')).data, data);
 
       await VaultService.close(handle: handle);
 
       // Only key3 works
       final reopened = await VaultService.open(path: path, key: key3);
-      expect(await VaultService.read(handle: reopened, name: 'data.bin'), data);
+      expect((await VaultService.read(handle: reopened, name: 'data.bin')).data, data);
       await VaultService.close(handle: reopened);
     });
 
@@ -278,7 +278,7 @@ void main() {
       );
 
       expect(
-        await VaultService.read(handle: imported, name: 'payload.bin'),
+        (await VaultService.read(handle: imported, name: 'payload.bin')).data,
         data,
       );
       await VaultService.close(handle: imported);

--- a/lib/src/evfs/vault_service.dart
+++ b/lib/src/evfs/vault_service.dart
@@ -45,17 +45,22 @@ class VaultService {
   /// [compression] is optional — defaults to no compression.
   /// MIME-aware skip: if [name] has an already-compressed extension
   /// (e.g., ".jpg"), compression is bypassed automatically.
+  ///
+  /// [metadata] is optional key-value tags stored alongside the segment
+  /// (encrypted in the index). Retrieved via [read].
   static Future<void> write({
     required rust_types.VaultHandle handle,
     required String name,
     required Uint8List data,
     CompressionConfig? compression,
+    Map<String, String>? metadata,
   }) {
     return rust_evfs.vaultWrite(
       handle: handle,
       name: name,
       data: data,
       compression: compression,
+      metadata: metadata,
     );
   }
 
@@ -130,7 +135,9 @@ class VaultService {
   }
 
   /// Read a named segment. Decompression is automatic.
-  static Future<Uint8List> read({
+  ///
+  /// Returns [SegmentReadResult] with decrypted data and metadata.
+  static Future<rust_types.SegmentReadResult> read({
     required rust_types.VaultHandle handle,
     required String name,
   }) {
@@ -311,6 +318,43 @@ class VaultService {
       algorithm: algorithm,
       capacityBytes: BigInt.from(capacityBytes),
     );
+  }
+
+  /// Rename a segment without re-encryption (index-only operation).
+  ///
+  /// Throws [DuplicateSegment] if [newName] already exists.
+  /// Throws [SegmentNotFound] if [oldName] does not exist.
+  static Future<void> renameSegment({
+    required rust_types.VaultHandle handle,
+    required String oldName,
+    required String newName,
+  }) {
+    return rust_evfs.vaultRenameSegment(
+      handle: handle,
+      oldName: oldName,
+      newName: newName,
+    );
+  }
+
+  /// Explicitly flush the in-memory index to disk.
+  ///
+  /// No-op if the index has not been modified since the last flush.
+  static Future<void> flush({required rust_types.VaultHandle handle}) {
+    return rust_evfs.vaultFlush(handle: handle);
+  }
+
+  /// Read multiple segments concurrently.
+  ///
+  /// Returns one [SegmentResult] per name in the same order as [names].
+  /// On per-segment failure, the result's [error] field describes the problem
+  /// (e.g. segment not found) and [data] is empty.
+  ///
+  /// Does not return per-segment metadata. Use [read] if metadata is needed.
+  static Future<List<rust_types.SegmentResult>> readParallel({
+    required rust_types.VaultHandle handle,
+    required List<String> names,
+  }) {
+    return rust_evfs.vaultReadParallel(handle: handle, names: names);
   }
 
   /// Close the vault (release lock, zeroize keys).

--- a/lib/src/evfs/vault_service.dart
+++ b/lib/src/evfs/vault_service.dart
@@ -70,12 +70,15 @@ class VaultService {
   /// is bounded to a single chunk. [totalSize] must equal the exact number
   /// of bytes that [data] will emit.
   ///
+  /// [metadata] is optional key-value tags stored alongside the segment.
+  ///
   /// [onProgress] is called with values in (0.0, 1.0] as chunks are encrypted.
   static Future<void> writeStream({
     required rust_types.VaultHandle handle,
     required String name,
     required int totalSize,
     required Stream<Uint8List> data,
+    Map<String, String>? metadata,
     void Function(double progress)? onProgress,
   }) async {
     final tempDir = await Directory.systemTemp.createTemp('vault_write_stream');
@@ -119,6 +122,7 @@ class VaultService {
           handle: handle,
           name: name,
           filePath: tempFile.path,
+          metadata: metadata,
         ),
       );
 
@@ -348,6 +352,9 @@ class VaultService {
   /// Returns one [SegmentResult] per name in the same order as [names].
   /// On per-segment failure, the result's [error] field describes the problem
   /// (e.g. segment not found) and [data] is empty.
+  ///
+  /// All segments are decrypted into memory simultaneously — callers should
+  /// be mindful of total memory when reading many large segments at once.
   ///
   /// Does not return per-segment metadata. Use [read] if metadata is needed.
   static Future<List<rust_types.SegmentResult>> readParallel({

--- a/lib/src/rust/api/evfs.dart
+++ b/lib/src/rust/api/evfs.dart
@@ -9,7 +9,7 @@ import 'compression.dart';
 import 'evfs/types.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `chunk_abs_offset`, `vault_export_write`, `vault_resize_grow_impl`, `vault_resize_shrink_impl`, `write_encrypted_chunk`
+// These functions are ignored because they are not marked as `pub`: `chunk_abs_offset`, `read_segment_from_mmap_inner`, `read_segment_from_mmap`, `read_segment_with_file_inner`, `read_segment_with_file`, `vault_export_write`, `vault_resize_grow_impl`, `vault_resize_shrink_impl`, `write_encrypted_chunk`
 // These functions have error during generation (see debug logs or enable `stop_on_error: true` for more details): `vault_write_stream`
 
 /// Create a new vault file at `path` with the given capacity.
@@ -41,16 +41,18 @@ Future<void> vaultWrite({
   required String name,
   required List<int> data,
   CompressionConfig? compression,
+  Map<String, String>? metadata,
 }) => RustLib.instance.api.crateApiEvfsVaultWrite(
   handle: handle,
   name: name,
   data: data,
   compression: compression,
+  metadata: metadata,
 );
 
 /// Read a named segment. Handles both monolithic and streaming segments.
 /// Decompression is automatic for monolithic segments.
-Future<Uint8List> vaultRead({
+Future<SegmentReadResult> vaultRead({
   required VaultHandle handle,
   required String name,
 }) => RustLib.instance.api.crateApiEvfsVaultRead(handle: handle, name: name);
@@ -84,6 +86,18 @@ Stream<double> vaultWriteFile({
   filePath: filePath,
 );
 
+/// Renames an existing segment in the vault index without modifying its encrypted data.
+/// Index-only operation — no data I/O, no re-encryption.
+Future<void> vaultRenameSegment({
+  required VaultHandle handle,
+  required String oldName,
+  required String newName,
+}) => RustLib.instance.api.crateApiEvfsVaultRenameSegment(
+  handle: handle,
+  oldName: oldName,
+  newName: newName,
+);
+
 /// Delete a named segment. The region is secure-erased and returned to the
 /// free list for reuse by future writes.
 Future<void> vaultDelete({required VaultHandle handle, required String name}) =>
@@ -113,6 +127,32 @@ Future<VaultCapacityInfo> vaultCapacity({required VaultHandle handle}) =>
 /// Get vault health/diagnostics (read-only).
 Future<VaultHealthInfo> vaultHealth({required VaultHandle handle}) =>
     RustLib.instance.api.crateApiEvfsVaultHealth(handle: handle);
+
+/// Read multiple segments concurrently using mmap zero-copy + rayon.
+///
+/// Returns results in the same order as `names`. On success, `data` contains
+/// decrypted plaintext and `error` is `None`. On failure, `data` is empty and
+/// `error` describes the problem (e.g. segment not found).
+///
+/// All segments are decrypted into memory simultaneously — callers should
+/// be mindful of total memory when reading many large segments at once.
+///
+/// Falls back to sequential file-based reads when mmap is unavailable.
+///
+/// **Note:** This API does not return per-segment metadata. Use [`vault_read`]
+/// if you need the `metadata` field from [`SegmentReadResult`].
+Future<List<SegmentResult>> vaultReadParallel({
+  required VaultHandle handle,
+  required List<String> names,
+}) => RustLib.instance.api.crateApiEvfsVaultReadParallel(
+  handle: handle,
+  names: names,
+);
+
+/// Explicitly flush the in-memory index to disk if it has been modified.
+/// No-op if the index is clean (no mutations since last flush).
+Future<void> vaultFlush({required VaultHandle handle}) =>
+    RustLib.instance.api.crateApiEvfsVaultFlush(handle: handle);
 
 /// Defragment the vault: compact all segments toward the data region start,
 /// coalesce free space into a single contiguous block at the end.
@@ -149,11 +189,14 @@ Future<void> vaultExport({
   exportPath: exportPath,
 );
 
-/// Close the vault — checkpoint WAL, release lock, zeroize keys on drop.
+/// Close the vault — flush dirty index, checkpoint WAL, release lock, zeroize keys on drop.
 Future<void> vaultClose({required VaultHandle handle}) =>
     RustLib.instance.api.crateApiEvfsVaultClose(handle: handle);
 
 /// Unwraps export key, creates new vault at dest_path, writes all segments under new_master_key.
+///
+/// Archives with version < 2 do not carry per-segment metadata; imported
+/// segments from those archives will have empty metadata.
 Future<VaultHandle> vaultImport({
   required String archivePath,
   required List<int> wrappingKey,

--- a/lib/src/rust/api/evfs.dart
+++ b/lib/src/rust/api/evfs.dart
@@ -80,10 +80,12 @@ Stream<double> vaultWriteFile({
   required VaultHandle handle,
   required String name,
   required String filePath,
+  Map<String, String>? metadata,
 }) => RustLib.instance.api.crateApiEvfsVaultWriteFile(
   handle: handle,
   name: name,
   filePath: filePath,
+  metadata: metadata,
 );
 
 /// Renames an existing segment in the vault index without modifying its encrypted data.

--- a/lib/src/rust/api/evfs/types.dart
+++ b/lib/src/rust/api/evfs/types.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `new`, `refresh_mmap`, `slice`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultMmap`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `drop`, `eq`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `drop`, `eq`, `eq`, `fmt`, `fmt`
 
 // Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
 abstract class VaultHandle implements RustOpaqueInterface {
@@ -47,6 +47,49 @@ class DefragResult {
           segmentsMoved == other.segmentsMoved &&
           bytesReclaimed == other.bytesReclaimed &&
           freeRegionsBefore == other.freeRegionsBefore;
+}
+
+/// Result of reading a segment — includes decrypted data and metadata.
+class SegmentReadResult {
+  final Uint8List data;
+  final Map<String, String> metadata;
+
+  const SegmentReadResult({required this.data, required this.metadata});
+
+  @override
+  int get hashCode => data.hashCode ^ metadata.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SegmentReadResult &&
+          runtimeType == other.runtimeType &&
+          data == other.data &&
+          metadata == other.metadata;
+}
+
+/// Result of a single segment read from `vault_read_parallel`.
+///
+/// On success, `data` contains the decrypted plaintext and `error` is `None`.
+/// On failure, `data` is empty and `error` contains the error description.
+class SegmentResult {
+  final String name;
+  final Uint8List data;
+  final String? error;
+
+  const SegmentResult({required this.name, required this.data, this.error});
+
+  @override
+  int get hashCode => name.hashCode ^ data.hashCode ^ error.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SegmentResult &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          data == other.data &&
+          error == other.error;
 }
 
 /// Capacity info returned to callers.

--- a/lib/src/rust/core/error.dart
+++ b/lib/src/rust/core/error.dart
@@ -37,6 +37,8 @@ sealed class CryptoError with _$CryptoError implements FrbException {
   const factory CryptoError.vaultLocked() = CryptoError_VaultLocked;
   const factory CryptoError.segmentNotFound(String field0) =
       CryptoError_SegmentNotFound;
+  const factory CryptoError.duplicateSegment(String field0) =
+      CryptoError_DuplicateSegment;
   const factory CryptoError.vaultCorrupted(String field0) =
       CryptoError_VaultCorrupted;
   const factory CryptoError.keyRotationFailed(String field0) =

--- a/lib/src/rust/core/error.freezed.dart
+++ b/lib/src/rust/core/error.freezed.dart
@@ -55,7 +55,7 @@ extension CryptoErrorPatterns on CryptoError {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -71,7 +71,8 @@ return compressionFailed(_that);case CryptoError_AuthenticationFailed() when aut
 return authenticationFailed(_that);case CryptoError_VaultFull() when vaultFull != null:
 return vaultFull(_that);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked(_that);case CryptoError_SegmentNotFound() when segmentNotFound != null:
-return segmentNotFound(_that);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
+return segmentNotFound(_that);case CryptoError_DuplicateSegment() when duplicateSegment != null:
+return duplicateSegment(_that);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
 return vaultCorrupted(_that);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
@@ -93,7 +94,7 @@ return importFailed(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_DuplicateSegment value)  duplicateSegment,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
@@ -109,7 +110,8 @@ return compressionFailed(_that);case CryptoError_AuthenticationFailed():
 return authenticationFailed(_that);case CryptoError_VaultFull():
 return vaultFull(_that);case CryptoError_VaultLocked():
 return vaultLocked(_that);case CryptoError_SegmentNotFound():
-return segmentNotFound(_that);case CryptoError_VaultCorrupted():
+return segmentNotFound(_that);case CryptoError_DuplicateSegment():
+return duplicateSegment(_that);case CryptoError_VaultCorrupted():
 return vaultCorrupted(_that);case CryptoError_KeyRotationFailed():
 return keyRotationFailed(_that);case CryptoError_ExportFailed():
 return exportFailed(_that);case CryptoError_ImportFailed():
@@ -127,7 +129,7 @@ return importFailed(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -143,7 +145,8 @@ return compressionFailed(_that);case CryptoError_AuthenticationFailed() when aut
 return authenticationFailed(_that);case CryptoError_VaultFull() when vaultFull != null:
 return vaultFull(_that);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked(_that);case CryptoError_SegmentNotFound() when segmentNotFound != null:
-return segmentNotFound(_that);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
+return segmentNotFound(_that);case CryptoError_DuplicateSegment() when duplicateSegment != null:
+return duplicateSegment(_that);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
 return vaultCorrupted(_that);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
@@ -164,7 +167,7 @@ return importFailed(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  duplicateSegment,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -179,7 +182,8 @@ return compressionFailed(_that.field0);case CryptoError_AuthenticationFailed() w
 return authenticationFailed();case CryptoError_VaultFull() when vaultFull != null:
 return vaultFull(_that.needed,_that.available);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked();case CryptoError_SegmentNotFound() when segmentNotFound != null:
-return segmentNotFound(_that.field0);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
+return segmentNotFound(_that.field0);case CryptoError_DuplicateSegment() when duplicateSegment != null:
+return duplicateSegment(_that.field0);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
 return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
@@ -201,7 +205,7 @@ return importFailed(_that.field0);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  duplicateSegment,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce():
@@ -216,7 +220,8 @@ return compressionFailed(_that.field0);case CryptoError_AuthenticationFailed():
 return authenticationFailed();case CryptoError_VaultFull():
 return vaultFull(_that.needed,_that.available);case CryptoError_VaultLocked():
 return vaultLocked();case CryptoError_SegmentNotFound():
-return segmentNotFound(_that.field0);case CryptoError_VaultCorrupted():
+return segmentNotFound(_that.field0);case CryptoError_DuplicateSegment():
+return duplicateSegment(_that.field0);case CryptoError_VaultCorrupted():
 return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed():
 return keyRotationFailed(_that.field0);case CryptoError_ExportFailed():
 return exportFailed(_that.field0);case CryptoError_ImportFailed():
@@ -234,7 +239,7 @@ return importFailed(_that.field0);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  duplicateSegment,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -249,7 +254,8 @@ return compressionFailed(_that.field0);case CryptoError_AuthenticationFailed() w
 return authenticationFailed();case CryptoError_VaultFull() when vaultFull != null:
 return vaultFull(_that.needed,_that.available);case CryptoError_VaultLocked() when vaultLocked != null:
 return vaultLocked();case CryptoError_SegmentNotFound() when segmentNotFound != null:
-return segmentNotFound(_that.field0);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
+return segmentNotFound(_that.field0);case CryptoError_DuplicateSegment() when duplicateSegment != null:
+return duplicateSegment(_that.field0);case CryptoError_VaultCorrupted() when vaultCorrupted != null:
 return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
@@ -979,6 +985,72 @@ class _$CryptoError_SegmentNotFoundCopyWithImpl<$Res>
 /// with the given fields replaced by the non-null parameter values.
 @pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
   return _then(CryptoError_SegmentNotFound(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CryptoError_DuplicateSegment extends CryptoError {
+  const CryptoError_DuplicateSegment(this.field0): super._();
+  
+
+ final  String field0;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CryptoError_DuplicateSegmentCopyWith<CryptoError_DuplicateSegment> get copyWith => _$CryptoError_DuplicateSegmentCopyWithImpl<CryptoError_DuplicateSegment>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_DuplicateSegment&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'CryptoError.duplicateSegment(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CryptoError_DuplicateSegmentCopyWith<$Res> implements $CryptoErrorCopyWith<$Res> {
+  factory $CryptoError_DuplicateSegmentCopyWith(CryptoError_DuplicateSegment value, $Res Function(CryptoError_DuplicateSegment) _then) = _$CryptoError_DuplicateSegmentCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$CryptoError_DuplicateSegmentCopyWithImpl<$Res>
+    implements $CryptoError_DuplicateSegmentCopyWith<$Res> {
+  _$CryptoError_DuplicateSegmentCopyWithImpl(this._self, this._then);
+
+  final CryptoError_DuplicateSegment _self;
+  final $Res Function(CryptoError_DuplicateSegment) _then;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(CryptoError_DuplicateSegment(
 null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -74,7 +74,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1455605677;
+  int get rustContentHash => 15652661;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -260,6 +260,8 @@ abstract class RustLibApi extends BaseApi {
     required String exportPath,
   });
 
+  Future<void> crateApiEvfsVaultFlush({required VaultHandle handle});
+
   Future<VaultHealthInfo> crateApiEvfsVaultHealth({
     required VaultHandle handle,
   });
@@ -280,9 +282,14 @@ abstract class RustLibApi extends BaseApi {
     required List<int> key,
   });
 
-  Future<Uint8List> crateApiEvfsVaultRead({
+  Future<SegmentReadResult> crateApiEvfsVaultRead({
     required VaultHandle handle,
     required String name,
+  });
+
+  Future<List<SegmentResult>> crateApiEvfsVaultReadParallel({
+    required VaultHandle handle,
+    required List<String> names,
   });
 
   Future<void> crateApiEvfsVaultReadStream({
@@ -291,6 +298,12 @@ abstract class RustLibApi extends BaseApi {
     required bool verifyChecksum,
     required RustStreamSink<Uint8List> sink,
     required RustStreamSink<double> onProgress,
+  });
+
+  Future<void> crateApiEvfsVaultRenameSegment({
+    required VaultHandle handle,
+    required String oldName,
+    required String newName,
   });
 
   Future<void> crateApiEvfsVaultResize({
@@ -308,6 +321,7 @@ abstract class RustLibApi extends BaseApi {
     required String name,
     required List<int> data,
     CompressionConfig? compression,
+    Map<String, String>? metadata,
   });
 
   Stream<double> crateApiEvfsVaultWriteFile({
@@ -1654,6 +1668,31 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<void> crateApiEvfsVaultFlush({required VaultHandle handle}) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          return wire.wire__crate__api__evfs__vault_flush(port_, arg0);
+        },
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEvfsVaultFlushConstMeta,
+        argValues: [handle],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEvfsVaultFlushConstMeta =>
+      const TaskConstMeta(debugName: "vault_flush", argNames: ["handle"]);
+
+  @override
   Future<VaultHealthInfo> crateApiEvfsVaultHealth({
     required VaultHandle handle,
   }) {
@@ -1792,7 +1831,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "vault_open", argNames: ["path", "key"]);
 
   @override
-  Future<Uint8List> crateApiEvfsVaultRead({
+  Future<SegmentReadResult> crateApiEvfsVaultRead({
     required VaultHandle handle,
     required String name,
   }) {
@@ -1807,7 +1846,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return wire.wire__crate__api__evfs__vault_read(port_, arg0, arg1);
         },
         codec: DcoCodec(
-          decodeSuccessData: dco_decode_list_prim_u_8_strict,
+          decodeSuccessData: dco_decode_segment_read_result,
           decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultReadConstMeta,
@@ -1821,6 +1860,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     debugName: "vault_read",
     argNames: ["handle", "name"],
   );
+
+  @override
+  Future<List<SegmentResult>> crateApiEvfsVaultReadParallel({
+    required VaultHandle handle,
+    required List<String> names,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          var arg0 =
+              cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_list_String(names);
+          return wire.wire__crate__api__evfs__vault_read_parallel(
+            port_,
+            arg0,
+            arg1,
+          );
+        },
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_list_segment_result,
+          decodeErrorData: null,
+        ),
+        constMeta: kCrateApiEvfsVaultReadParallelConstMeta,
+        argValues: [handle, names],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEvfsVaultReadParallelConstMeta =>
+      const TaskConstMeta(
+        debugName: "vault_read_parallel",
+        argNames: ["handle", "names"],
+      );
 
   @override
   Future<void> crateApiEvfsVaultReadStream({
@@ -1865,6 +1940,45 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(
         debugName: "vault_read_stream",
         argNames: ["handle", "name", "verifyChecksum", "sink", "onProgress"],
+      );
+
+  @override
+  Future<void> crateApiEvfsVaultRenameSegment({
+    required VaultHandle handle,
+    required String oldName,
+    required String newName,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          var arg0 =
+              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+                handle,
+              );
+          var arg1 = cst_encode_String(oldName);
+          var arg2 = cst_encode_String(newName);
+          return wire.wire__crate__api__evfs__vault_rename_segment(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+          );
+        },
+        codec: DcoCodec(
+          decodeSuccessData: dco_decode_unit,
+          decodeErrorData: dco_decode_crypto_error,
+        ),
+        constMeta: kCrateApiEvfsVaultRenameSegmentConstMeta,
+        argValues: [handle, oldName, newName],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiEvfsVaultRenameSegmentConstMeta =>
+      const TaskConstMeta(
+        debugName: "vault_rename_segment",
+        argNames: ["handle", "oldName", "newName"],
       );
 
   @override
@@ -1940,6 +2054,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required String name,
     required List<int> data,
     CompressionConfig? compression,
+    Map<String, String>? metadata,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1951,12 +2066,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           var arg1 = cst_encode_String(name);
           var arg2 = cst_encode_list_prim_u_8_loose(data);
           var arg3 = cst_encode_opt_box_autoadd_compression_config(compression);
+          var arg4 = cst_encode_opt_Map_String_String_None(metadata);
           return wire.wire__crate__api__evfs__vault_write(
             port_,
             arg0,
             arg1,
             arg2,
             arg3,
+            arg4,
           );
         },
         codec: DcoCodec(
@@ -1964,7 +2081,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultWriteConstMeta,
-        argValues: [handle, name, data, compression],
+        argValues: [handle, name, data, compression, metadata],
         apiImpl: this,
       ),
     );
@@ -1972,7 +2089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiEvfsVaultWriteConstMeta => const TaskConstMeta(
     debugName: "vault_write",
-    argNames: ["handle", "name", "data", "compression"],
+    argNames: ["handle", "name", "data", "compression", "metadata"],
   );
 
   @override
@@ -2113,6 +2230,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Map<String, String> dco_decode_Map_String_String_None(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return Map.fromEntries(
+      dco_decode_list_record_string_string(
+        raw,
+      ).map((e) => MapEntry(e.$1, e.$2)),
+    );
+  }
+
+  @protected
   CipherHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     dynamic raw,
@@ -2238,12 +2365,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 12:
         return CryptoError_SegmentNotFound(dco_decode_String(raw[1]));
       case 13:
-        return CryptoError_VaultCorrupted(dco_decode_String(raw[1]));
+        return CryptoError_DuplicateSegment(dco_decode_String(raw[1]));
       case 14:
-        return CryptoError_KeyRotationFailed(dco_decode_String(raw[1]));
+        return CryptoError_VaultCorrupted(dco_decode_String(raw[1]));
       case 15:
-        return CryptoError_ExportFailed(dco_decode_String(raw[1]));
+        return CryptoError_KeyRotationFailed(dco_decode_String(raw[1]));
       case 16:
+        return CryptoError_ExportFailed(dco_decode_String(raw[1]));
+      case 17:
         return CryptoError_ImportFailed(dco_decode_String(raw[1]));
       default:
         throw Exception("unreachable");
@@ -2294,6 +2423,30 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<(String, String)> dco_decode_list_record_string_string(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_record_string_string).toList();
+  }
+
+  @protected
+  List<SegmentResult> dco_decode_list_segment_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_segment_result).toList();
+  }
+
+  @protected
+  Map<String, String>? dco_decode_opt_Map_String_String_None(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_Map_String_String_None(raw);
+  }
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return raw == null ? null : dco_decode_String(raw);
+  }
+
+  @protected
   CompressionConfig? dco_decode_opt_box_autoadd_compression_config(
     dynamic raw,
   ) {
@@ -2311,6 +2464,41 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Uint8List? dco_decode_opt_list_prim_u_8_strict(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return raw == null ? null : dco_decode_list_prim_u_8_strict(raw);
+  }
+
+  @protected
+  (String, String) dco_decode_record_string_string(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2) {
+      throw Exception('Expected 2 elements, got ${arr.length}');
+    }
+    return (dco_decode_String(arr[0]), dco_decode_String(arr[1]));
+  }
+
+  @protected
+  SegmentReadResult dco_decode_segment_read_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return SegmentReadResult(
+      data: dco_decode_list_prim_u_8_strict(arr[0]),
+      metadata: dco_decode_Map_String_String_None(arr[1]),
+    );
+  }
+
+  @protected
+  SegmentResult dco_decode_segment_result(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    final arr = raw as List<dynamic>;
+    if (arr.length != 3)
+      throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    return SegmentResult(
+      name: dco_decode_String(arr[0]),
+      data: dco_decode_list_prim_u_8_strict(arr[1]),
+      error: dco_decode_opt_String(arr[2]),
+    );
   }
 
   @protected
@@ -2469,6 +2657,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  Map<String, String> sse_decode_Map_String_String_None(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_list_record_string_string(deserializer);
+    return Map.fromEntries(inner.map((e) => MapEntry(e.$1, e.$2)));
+  }
+
+  @protected
   CipherHandle
   sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     SseDeserializer deserializer,
@@ -2624,14 +2821,17 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return CryptoError_SegmentNotFound(var_field0);
       case 13:
         var var_field0 = sse_decode_String(deserializer);
-        return CryptoError_VaultCorrupted(var_field0);
+        return CryptoError_DuplicateSegment(var_field0);
       case 14:
         var var_field0 = sse_decode_String(deserializer);
-        return CryptoError_KeyRotationFailed(var_field0);
+        return CryptoError_VaultCorrupted(var_field0);
       case 15:
         var var_field0 = sse_decode_String(deserializer);
-        return CryptoError_ExportFailed(var_field0);
+        return CryptoError_KeyRotationFailed(var_field0);
       case 16:
+        var var_field0 = sse_decode_String(deserializer);
+        return CryptoError_ExportFailed(var_field0);
+      case 17:
         var var_field0 = sse_decode_String(deserializer);
         return CryptoError_ImportFailed(var_field0);
       default:
@@ -2691,6 +2891,58 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  List<(String, String)> sse_decode_list_record_string_string(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <(String, String)>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_record_string_string(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<SegmentResult> sse_decode_list_segment_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    var len_ = sse_decode_i_32(deserializer);
+    var ans_ = <SegmentResult>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_segment_result(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  Map<String, String>? sse_decode_opt_Map_String_String_None(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_Map_String_String_None(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    if (sse_decode_bool(deserializer)) {
+      return (sse_decode_String(deserializer));
+    } else {
+      return null;
+    }
+  }
+
+  @protected
   CompressionConfig? sse_decode_opt_box_autoadd_compression_config(
     SseDeserializer deserializer,
   ) {
@@ -2723,6 +2975,35 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     } else {
       return null;
     }
+  }
+
+  @protected
+  (String, String) sse_decode_record_string_string(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_field0 = sse_decode_String(deserializer);
+    var var_field1 = sse_decode_String(deserializer);
+    return (var_field0, var_field1);
+  }
+
+  @protected
+  SegmentReadResult sse_decode_segment_read_result(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_data = sse_decode_list_prim_u_8_strict(deserializer);
+    var var_metadata = sse_decode_Map_String_String_None(deserializer);
+    return SegmentReadResult(data: var_data, metadata: var_metadata);
+  }
+
+  @protected
+  SegmentResult sse_decode_segment_result(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var var_name = sse_decode_String(deserializer);
+    var var_data = sse_decode_list_prim_u_8_strict(deserializer);
+    var var_error = sse_decode_opt_String(deserializer);
+    return SegmentResult(name: var_name, data: var_data, error: var_error);
   }
 
   @protected
@@ -3047,6 +3328,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_Map_String_String_None(
+    Map<String, String> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_record_string_string(
+      self.entries.map((e) => (e.key, e.value)).toList(),
+      serializer,
+    );
+  }
+
+  @protected
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
@@ -3218,17 +3511,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case CryptoError_SegmentNotFound(field0: final field0):
         sse_encode_i_32(12, serializer);
         sse_encode_String(field0, serializer);
-      case CryptoError_VaultCorrupted(field0: final field0):
+      case CryptoError_DuplicateSegment(field0: final field0):
         sse_encode_i_32(13, serializer);
         sse_encode_String(field0, serializer);
-      case CryptoError_KeyRotationFailed(field0: final field0):
+      case CryptoError_VaultCorrupted(field0: final field0):
         sse_encode_i_32(14, serializer);
         sse_encode_String(field0, serializer);
-      case CryptoError_ExportFailed(field0: final field0):
+      case CryptoError_KeyRotationFailed(field0: final field0):
         sse_encode_i_32(15, serializer);
         sse_encode_String(field0, serializer);
-      case CryptoError_ImportFailed(field0: final field0):
+      case CryptoError_ExportFailed(field0: final field0):
         sse_encode_i_32(16, serializer);
+        sse_encode_String(field0, serializer);
+      case CryptoError_ImportFailed(field0: final field0):
+        sse_encode_i_32(17, serializer);
         sse_encode_String(field0, serializer);
     }
   }
@@ -3285,6 +3581,53 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   }
 
   @protected
+  void sse_encode_list_record_string_string(
+    List<(String, String)> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_record_string_string(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_segment_result(
+    List<SegmentResult> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_segment_result(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_Map_String_String_None(
+    Map<String, String>? self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_Map_String_String_None(self, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    sse_encode_bool(self != null, serializer);
+    if (self != null) {
+      sse_encode_String(self, serializer);
+    }
+  }
+
+  @protected
   void sse_encode_opt_box_autoadd_compression_config(
     CompressionConfig? self,
     SseSerializer serializer,
@@ -3318,6 +3661,34 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     if (self != null) {
       sse_encode_list_prim_u_8_strict(self, serializer);
     }
+  }
+
+  @protected
+  void sse_encode_record_string_string(
+    (String, String) self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.$1, serializer);
+    sse_encode_String(self.$2, serializer);
+  }
+
+  @protected
+  void sse_encode_segment_read_result(
+    SegmentReadResult self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_list_prim_u_8_strict(self.data, serializer);
+    sse_encode_Map_String_String_None(self.metadata, serializer);
+  }
+
+  @protected
+  void sse_encode_segment_result(SegmentResult self, SseSerializer serializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_String(self.name, serializer);
+    sse_encode_list_prim_u_8_strict(self.data, serializer);
+    sse_encode_opt_String(self.error, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -328,6 +328,7 @@ abstract class RustLibApi extends BaseApi {
     required VaultHandle handle,
     required String name,
     required String filePath,
+    Map<String, String>? metadata,
   });
 
   RustArcIncrementStrongCountFnType
@@ -2097,6 +2098,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required VaultHandle handle,
     required String name,
     required String filePath,
+    Map<String, String>? metadata,
   }) {
     final onProgress = RustStreamSink<double>();
     unawaited(
@@ -2110,12 +2112,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             var arg1 = cst_encode_String(name);
             var arg2 = cst_encode_String(filePath);
             var arg3 = cst_encode_StreamSink_f_64_Dco(onProgress);
+            var arg4 = cst_encode_opt_Map_String_String_None(metadata);
             return wire.wire__crate__api__evfs__vault_write_file(
               port_,
               arg0,
               arg1,
               arg2,
               arg3,
+              arg4,
             );
           },
           codec: DcoCodec(
@@ -2123,7 +2127,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             decodeErrorData: dco_decode_crypto_error,
           ),
           constMeta: kCrateApiEvfsVaultWriteFileConstMeta,
-          argValues: [handle, name, filePath, onProgress],
+          argValues: [handle, name, filePath, onProgress, metadata],
           apiImpl: this,
         ),
       ),
@@ -2133,7 +2137,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiEvfsVaultWriteFileConstMeta => const TaskConstMeta(
     debugName: "vault_write_file",
-    argNames: ["handle", "name", "filePath", "onProgress"],
+    argNames: ["handle", "name", "filePath", "onProgress", "metadata"],
   );
 
   RustArcIncrementStrongCountFnType

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -86,6 +86,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
+
+  @protected
   CipherHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     dynamic raw,
@@ -154,6 +157,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
+
+  @protected
+  List<SegmentResult> dco_decode_list_segment_result(dynamic raw);
+
+  @protected
+  Map<String, String>? dco_decode_opt_Map_String_String_None(dynamic raw);
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
   CompressionConfig? dco_decode_opt_box_autoadd_compression_config(dynamic raw);
 
   @protected
@@ -161,6 +176,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List? dco_decode_opt_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  (String, String) dco_decode_record_string_string(dynamic raw);
+
+  @protected
+  SegmentReadResult dco_decode_segment_read_result(dynamic raw);
+
+  @protected
+  SegmentResult dco_decode_segment_result(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -225,6 +249,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   VaultHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  Map<String, String> sse_decode_Map_String_String_None(
     SseDeserializer deserializer,
   );
 
@@ -303,6 +332,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  List<(String, String)> sse_decode_list_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<SegmentResult> sse_decode_list_segment_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  Map<String, String>? sse_decode_opt_Map_String_String_None(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
   CompressionConfig? sse_decode_opt_box_autoadd_compression_config(
     SseDeserializer deserializer,
   );
@@ -312,6 +359,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List? sse_decode_opt_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  (String, String) sse_decode_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SegmentReadResult sse_decode_segment_read_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SegmentResult sse_decode_segment_result(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -342,6 +402,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   ) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     throw UnimplementedError();
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_string_string>
+  cst_encode_Map_String_String_None(Map<String, String> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_list_record_string_string(
+      raw.entries.map((e) => (e.key, e.value)).toList(),
+    );
   }
 
   @protected
@@ -424,6 +493,44 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     final ans = wire.cst_new_list_prim_u_8_strict(raw.length);
     ans.ref.ptr.asTypedList(raw.length).setAll(0, raw);
     return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_string_string>
+  cst_encode_list_record_string_string(List<(String, String)> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_record_string_string(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_record_string_string(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_segment_result> cst_encode_list_segment_result(
+    List<SegmentResult> raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    final ans = wire.cst_new_list_segment_result(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      cst_api_fill_to_wire_segment_result(raw[i], ans.ref.ptr[i]);
+    }
+    return ans;
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_record_string_string>
+  cst_encode_opt_Map_String_String_None(Map<String, String>? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_Map_String_String_None(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_cst_list_prim_u_8_strict> cst_encode_opt_String(
+    String? raw,
+  ) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? ffi.nullptr : cst_encode_String(raw);
   }
 
   @protected
@@ -556,27 +663,33 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.SegmentNotFound.field0 = pre_field0;
       return;
     }
-    if (apiObj is CryptoError_VaultCorrupted) {
+    if (apiObj is CryptoError_DuplicateSegment) {
       var pre_field0 = cst_encode_String(apiObj.field0);
       wireObj.tag = 13;
+      wireObj.kind.DuplicateSegment.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_VaultCorrupted) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 14;
       wireObj.kind.VaultCorrupted.field0 = pre_field0;
       return;
     }
     if (apiObj is CryptoError_KeyRotationFailed) {
       var pre_field0 = cst_encode_String(apiObj.field0);
-      wireObj.tag = 14;
+      wireObj.tag = 15;
       wireObj.kind.KeyRotationFailed.field0 = pre_field0;
       return;
     }
     if (apiObj is CryptoError_ExportFailed) {
       var pre_field0 = cst_encode_String(apiObj.field0);
-      wireObj.tag = 15;
+      wireObj.tag = 16;
       wireObj.kind.ExportFailed.field0 = pre_field0;
       return;
     }
     if (apiObj is CryptoError_ImportFailed) {
       var pre_field0 = cst_encode_String(apiObj.field0);
-      wireObj.tag = 16;
+      wireObj.tag = 17;
       wireObj.kind.ImportFailed.field0 = pre_field0;
       return;
     }
@@ -590,6 +703,34 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     wireObj.segments_moved = cst_encode_u_32(apiObj.segmentsMoved);
     wireObj.bytes_reclaimed = cst_encode_u_64(apiObj.bytesReclaimed);
     wireObj.free_regions_before = cst_encode_u_32(apiObj.freeRegionsBefore);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_record_string_string(
+    (String, String) apiObj,
+    wire_cst_record_string_string wireObj,
+  ) {
+    wireObj.field0 = cst_encode_String(apiObj.$1);
+    wireObj.field1 = cst_encode_String(apiObj.$2);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_segment_read_result(
+    SegmentReadResult apiObj,
+    wire_cst_segment_read_result wireObj,
+  ) {
+    wireObj.data = cst_encode_list_prim_u_8_strict(apiObj.data);
+    wireObj.metadata = cst_encode_Map_String_String_None(apiObj.metadata);
+  }
+
+  @protected
+  void cst_api_fill_to_wire_segment_result(
+    SegmentResult apiObj,
+    wire_cst_segment_result wireObj,
+  ) {
+    wireObj.name = cst_encode_String(apiObj.name);
+    wireObj.data = cst_encode_list_prim_u_8_strict(apiObj.data);
+    wireObj.error = cst_encode_opt_String(apiObj.error);
   }
 
   @protected
@@ -760,6 +901,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_Map_String_String_None(
+    Map<String, String> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
@@ -847,6 +994,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_string(
+    List<(String, String)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_segment_result(
+    List<SegmentResult> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_Map_String_String_None(
+    Map<String, String>? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_box_autoadd_compression_config(
     CompressionConfig? self,
     SseSerializer serializer,
@@ -860,6 +1028,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     Uint8List? self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_record_string_string(
+    (String, String) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_segment_read_result(
+    SegmentReadResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_segment_result(SegmentResult self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
@@ -1912,6 +2095,18 @@ class RustLibWire implements BaseWire {
             )
           >();
 
+  void wire__crate__api__evfs__vault_flush(int port_, int handle) {
+    return _wire__crate__api__evfs__vault_flush(port_, handle);
+  }
+
+  late final _wire__crate__api__evfs__vault_flushPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.UintPtr)>>(
+        'frbgen_m_security_wire__crate__api__evfs__vault_flush',
+      );
+  late final _wire__crate__api__evfs__vault_flush =
+      _wire__crate__api__evfs__vault_flushPtr
+          .asFunction<void Function(int, int)>();
+
   void wire__crate__api__evfs__vault_health(int port_, int handle) {
     return _wire__crate__api__evfs__vault_health(port_, handle);
   }
@@ -2036,6 +2231,30 @@ class RustLibWire implements BaseWire {
             void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
           >();
 
+  void wire__crate__api__evfs__vault_read_parallel(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_String> names,
+  ) {
+    return _wire__crate__api__evfs__vault_read_parallel(port_, handle, names);
+  }
+
+  late final _wire__crate__api__evfs__vault_read_parallelPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_String>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_read_parallel');
+  late final _wire__crate__api__evfs__vault_read_parallel =
+      _wire__crate__api__evfs__vault_read_parallelPtr
+          .asFunction<
+            void Function(int, int, ffi.Pointer<wire_cst_list_String>)
+          >();
+
   void wire__crate__api__evfs__vault_read_stream(
     int port_,
     int handle,
@@ -2075,6 +2294,42 @@ class RustLibWire implements BaseWire {
               int,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               bool,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            )
+          >();
+
+  void wire__crate__api__evfs__vault_rename_segment(
+    int port_,
+    int handle,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> old_name,
+    ffi.Pointer<wire_cst_list_prim_u_8_strict> new_name,
+  ) {
+    return _wire__crate__api__evfs__vault_rename_segment(
+      port_,
+      handle,
+      old_name,
+      new_name,
+    );
+  }
+
+  late final _wire__crate__api__evfs__vault_rename_segmentPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Void Function(
+            ffi.Int64,
+            ffi.UintPtr,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+          )
+        >
+      >('frbgen_m_security_wire__crate__api__evfs__vault_rename_segment');
+  late final _wire__crate__api__evfs__vault_rename_segment =
+      _wire__crate__api__evfs__vault_rename_segmentPtr
+          .asFunction<
+            void Function(
+              int,
+              int,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
             )
@@ -2128,6 +2383,7 @@ class RustLibWire implements BaseWire {
     ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> data,
     ffi.Pointer<wire_cst_compression_config> compression,
+    ffi.Pointer<wire_cst_list_record_string_string> metadata,
   ) {
     return _wire__crate__api__evfs__vault_write(
       port_,
@@ -2135,6 +2391,7 @@ class RustLibWire implements BaseWire {
       name,
       data,
       compression,
+      metadata,
     );
   }
 
@@ -2147,6 +2404,7 @@ class RustLibWire implements BaseWire {
             ffi.Pointer<wire_cst_list_prim_u_8_strict>,
             ffi.Pointer<wire_cst_list_prim_u_8_loose>,
             ffi.Pointer<wire_cst_compression_config>,
+            ffi.Pointer<wire_cst_list_record_string_string>,
           )
         >
       >('frbgen_m_security_wire__crate__api__evfs__vault_write');
@@ -2159,6 +2417,7 @@ class RustLibWire implements BaseWire {
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>,
               ffi.Pointer<wire_cst_compression_config>,
+              ffi.Pointer<wire_cst_list_record_string_string>,
             )
           >();
 
@@ -2371,6 +2630,38 @@ class RustLibWire implements BaseWire {
   late final _cst_new_list_prim_u_8_strict = _cst_new_list_prim_u_8_strictPtr
       .asFunction<ffi.Pointer<wire_cst_list_prim_u_8_strict> Function(int)>();
 
+  ffi.Pointer<wire_cst_list_record_string_string>
+  cst_new_list_record_string_string(int len) {
+    return _cst_new_list_record_string_string(len);
+  }
+
+  late final _cst_new_list_record_string_stringPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_record_string_string> Function(ffi.Int32)
+        >
+      >('frbgen_m_security_cst_new_list_record_string_string');
+  late final _cst_new_list_record_string_string =
+      _cst_new_list_record_string_stringPtr
+          .asFunction<
+            ffi.Pointer<wire_cst_list_record_string_string> Function(int)
+          >();
+
+  ffi.Pointer<wire_cst_list_segment_result> cst_new_list_segment_result(
+    int len,
+  ) {
+    return _cst_new_list_segment_result(len);
+  }
+
+  late final _cst_new_list_segment_resultPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<wire_cst_list_segment_result> Function(ffi.Int32)
+        >
+      >('frbgen_m_security_cst_new_list_segment_result');
+  late final _cst_new_list_segment_result = _cst_new_list_segment_resultPtr
+      .asFunction<ffi.Pointer<wire_cst_list_segment_result> Function(int)>();
+
   int dummy_method_to_enforce_bundling() {
     return _dummy_method_to_enforce_bundling();
   }
@@ -2420,6 +2711,34 @@ final class wire_cst_list_String extends ffi.Struct {
   external int len;
 }
 
+final class wire_cst_record_string_string extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field1;
+}
+
+final class wire_cst_list_record_string_string extends ffi.Struct {
+  external ffi.Pointer<wire_cst_record_string_string> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_cst_segment_result extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> name;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> data;
+
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> error;
+}
+
+final class wire_cst_list_segment_result extends ffi.Struct {
+  external ffi.Pointer<wire_cst_segment_result> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
 final class wire_cst_CryptoError_InvalidKeyLength extends ffi.Struct {
   @ffi.UintPtr()
   external int expected;
@@ -2464,6 +2783,10 @@ final class wire_cst_CryptoError_SegmentNotFound extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 }
 
+final class wire_cst_CryptoError_DuplicateSegment extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
 final class wire_cst_CryptoError_VaultCorrupted extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 }
@@ -2499,6 +2822,8 @@ final class CryptoErrorKind extends ffi.Union {
 
   external wire_cst_CryptoError_SegmentNotFound SegmentNotFound;
 
+  external wire_cst_CryptoError_DuplicateSegment DuplicateSegment;
+
   external wire_cst_CryptoError_VaultCorrupted VaultCorrupted;
 
   external wire_cst_CryptoError_KeyRotationFailed KeyRotationFailed;
@@ -2524,6 +2849,12 @@ final class wire_cst_defrag_result extends ffi.Struct {
 
   @ffi.Uint32()
   external int free_regions_before;
+}
+
+final class wire_cst_segment_read_result extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> data;
+
+  external ffi.Pointer<wire_cst_list_record_string_string> metadata;
 }
 
 final class wire_cst_vault_capacity_info extends ffi.Struct {
@@ -2578,7 +2909,7 @@ const int MIN_LEVEL = 1;
 
 const int MAX_LEVEL = 22;
 
-const int ARCHIVE_VERSION = 1;
+const int ARCHIVE_VERSION = 2;
 
 const int ARCHIVE_HEADER_SIZE = 32;
 
@@ -2586,7 +2917,7 @@ const int WRAPPED_KEY_SIZE = 60;
 
 const int ARCHIVE_TRAILER_SIZE = 36;
 
-const int VAULT_VERSION = 1;
+const int VAULT_VERSION = 2;
 
 const int VAULT_HEADER_SIZE = 32;
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -2427,6 +2427,7 @@ class RustLibWire implements BaseWire {
     ffi.Pointer<wire_cst_list_prim_u_8_strict> name,
     ffi.Pointer<wire_cst_list_prim_u_8_strict> file_path,
     ffi.Pointer<wire_cst_list_prim_u_8_strict> on_progress,
+    ffi.Pointer<wire_cst_list_record_string_string> metadata,
   ) {
     return _wire__crate__api__evfs__vault_write_file(
       port_,
@@ -2434,6 +2435,7 @@ class RustLibWire implements BaseWire {
       name,
       file_path,
       on_progress,
+      metadata,
     );
   }
 
@@ -2446,6 +2448,7 @@ class RustLibWire implements BaseWire {
             ffi.Pointer<wire_cst_list_prim_u_8_strict>,
             ffi.Pointer<wire_cst_list_prim_u_8_strict>,
             ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+            ffi.Pointer<wire_cst_list_record_string_string>,
           )
         >
       >('frbgen_m_security_wire__crate__api__evfs__vault_write_file');
@@ -2458,6 +2461,7 @@ class RustLibWire implements BaseWire {
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              ffi.Pointer<wire_cst_list_record_string_string>,
             )
           >();
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -88,6 +88,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
+
+  @protected
   CipherHandle
   dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     dynamic raw,
@@ -156,6 +159,18 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List dco_decode_list_prim_u_8_strict(dynamic raw);
 
   @protected
+  List<(String, String)> dco_decode_list_record_string_string(dynamic raw);
+
+  @protected
+  List<SegmentResult> dco_decode_list_segment_result(dynamic raw);
+
+  @protected
+  Map<String, String>? dco_decode_opt_Map_String_String_None(dynamic raw);
+
+  @protected
+  String? dco_decode_opt_String(dynamic raw);
+
+  @protected
   CompressionConfig? dco_decode_opt_box_autoadd_compression_config(dynamic raw);
 
   @protected
@@ -163,6 +178,15 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List? dco_decode_opt_list_prim_u_8_strict(dynamic raw);
+
+  @protected
+  (String, String) dco_decode_record_string_string(dynamic raw);
+
+  @protected
+  SegmentReadResult dco_decode_segment_read_result(dynamic raw);
+
+  @protected
+  SegmentResult dco_decode_segment_result(dynamic raw);
 
   @protected
   int dco_decode_u_32(dynamic raw);
@@ -227,6 +251,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   VaultHandle
   sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  Map<String, String> sse_decode_Map_String_String_None(
     SseDeserializer deserializer,
   );
 
@@ -305,6 +334,24 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Uint8List sse_decode_list_prim_u_8_strict(SseDeserializer deserializer);
 
   @protected
+  List<(String, String)> sse_decode_list_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  List<SegmentResult> sse_decode_list_segment_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  Map<String, String>? sse_decode_opt_Map_String_String_None(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  String? sse_decode_opt_String(SseDeserializer deserializer);
+
+  @protected
   CompressionConfig? sse_decode_opt_box_autoadd_compression_config(
     SseDeserializer deserializer,
   );
@@ -314,6 +361,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   Uint8List? sse_decode_opt_list_prim_u_8_strict(SseDeserializer deserializer);
+
+  @protected
+  (String, String) sse_decode_record_string_string(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SegmentReadResult sse_decode_segment_read_result(
+    SseDeserializer deserializer,
+  );
+
+  @protected
+  SegmentResult sse_decode_segment_result(SseDeserializer deserializer);
 
   @protected
   int sse_decode_u_32(SseDeserializer deserializer);
@@ -342,6 +402,14 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   String cst_encode_AnyhowException(AnyhowException raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     throw UnimplementedError();
+  }
+
+  @protected
+  JSAny cst_encode_Map_String_String_None(Map<String, String> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_list_record_string_string(
+      raw.entries.map((e) => (e.key, e.value)).toList(),
+    );
   }
 
   @protected
@@ -449,17 +517,20 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (raw is CryptoError_SegmentNotFound) {
       return [12, cst_encode_String(raw.field0)].jsify()!;
     }
-    if (raw is CryptoError_VaultCorrupted) {
+    if (raw is CryptoError_DuplicateSegment) {
       return [13, cst_encode_String(raw.field0)].jsify()!;
     }
-    if (raw is CryptoError_KeyRotationFailed) {
+    if (raw is CryptoError_VaultCorrupted) {
       return [14, cst_encode_String(raw.field0)].jsify()!;
     }
-    if (raw is CryptoError_ExportFailed) {
+    if (raw is CryptoError_KeyRotationFailed) {
       return [15, cst_encode_String(raw.field0)].jsify()!;
     }
-    if (raw is CryptoError_ImportFailed) {
+    if (raw is CryptoError_ExportFailed) {
       return [16, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_ImportFailed) {
+      return [17, cst_encode_String(raw.field0)].jsify()!;
     }
 
     throw Exception('unreachable');
@@ -494,6 +565,30 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   }
 
   @protected
+  JSAny cst_encode_list_record_string_string(List<(String, String)> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.map(cst_encode_record_string_string).toList().jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_list_segment_result(List<SegmentResult> raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw.map(cst_encode_segment_result).toList().jsify()!;
+  }
+
+  @protected
+  JSAny? cst_encode_opt_Map_String_String_None(Map<String, String>? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_Map_String_String_None(raw);
+  }
+
+  @protected
+  String? cst_encode_opt_String(String? raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return raw == null ? null : cst_encode_String(raw);
+  }
+
+  @protected
   JSAny? cst_encode_opt_box_autoadd_compression_config(CompressionConfig? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? null : cst_encode_box_autoadd_compression_config(raw);
@@ -509,6 +604,31 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   JSAny? cst_encode_opt_list_prim_u_8_strict(Uint8List? raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw == null ? null : cst_encode_list_prim_u_8_strict(raw);
+  }
+
+  @protected
+  JSAny cst_encode_record_string_string((String, String) raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [cst_encode_String(raw.$1), cst_encode_String(raw.$2)].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_segment_read_result(SegmentReadResult raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_list_prim_u_8_strict(raw.data),
+      cst_encode_Map_String_String_None(raw.metadata),
+    ].jsify()!;
+  }
+
+  @protected
+  JSAny cst_encode_segment_result(SegmentResult raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return [
+      cst_encode_String(raw.name),
+      cst_encode_list_prim_u_8_strict(raw.data),
+      cst_encode_opt_String(raw.error),
+    ].jsify()!;
   }
 
   @protected
@@ -691,6 +811,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_Map_String_String_None(
+    Map<String, String> self,
+    SseSerializer serializer,
+  );
+
+  @protected
   void
   sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
     CipherHandle self,
@@ -778,6 +904,27 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
+  void sse_encode_list_record_string_string(
+    List<(String, String)> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_segment_result(
+    List<SegmentResult> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_Map_String_String_None(
+    Map<String, String>? self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_opt_String(String? self, SseSerializer serializer);
+
+  @protected
   void sse_encode_opt_box_autoadd_compression_config(
     CompressionConfig? self,
     SseSerializer serializer,
@@ -791,6 +938,21 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     Uint8List? self,
     SseSerializer serializer,
   );
+
+  @protected
+  void sse_encode_record_string_string(
+    (String, String) self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_segment_read_result(
+    SegmentReadResult self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_segment_result(SegmentResult self, SseSerializer serializer);
 
   @protected
   void sse_encode_u_32(int self, SseSerializer serializer);
@@ -1152,6 +1314,9 @@ class RustLibWire implements BaseWire {
     export_path,
   );
 
+  void wire__crate__api__evfs__vault_flush(NativePortType port_, int handle) =>
+      wasmModule.wire__crate__api__evfs__vault_flush(port_, handle);
+
   void wire__crate__api__evfs__vault_health(NativePortType port_, int handle) =>
       wasmModule.wire__crate__api__evfs__vault_health(port_, handle);
 
@@ -1188,6 +1353,16 @@ class RustLibWire implements BaseWire {
     String name,
   ) => wasmModule.wire__crate__api__evfs__vault_read(port_, handle, name);
 
+  void wire__crate__api__evfs__vault_read_parallel(
+    NativePortType port_,
+    int handle,
+    JSAny names,
+  ) => wasmModule.wire__crate__api__evfs__vault_read_parallel(
+    port_,
+    handle,
+    names,
+  );
+
   void wire__crate__api__evfs__vault_read_stream(
     NativePortType port_,
     int handle,
@@ -1202,6 +1377,18 @@ class RustLibWire implements BaseWire {
     verify_checksum,
     sink,
     on_progress,
+  );
+
+  void wire__crate__api__evfs__vault_rename_segment(
+    NativePortType port_,
+    int handle,
+    String old_name,
+    String new_name,
+  ) => wasmModule.wire__crate__api__evfs__vault_rename_segment(
+    port_,
+    handle,
+    old_name,
+    new_name,
   );
 
   void wire__crate__api__evfs__vault_resize(
@@ -1230,12 +1417,14 @@ class RustLibWire implements BaseWire {
     String name,
     JSAny data,
     JSAny? compression,
+    JSAny? metadata,
   ) => wasmModule.wire__crate__api__evfs__vault_write(
     port_,
     handle,
     name,
     data,
     compression,
+    metadata,
   );
 
   void wire__crate__api__evfs__vault_write_file(
@@ -1536,6 +1725,11 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String export_path,
   );
 
+  external void wire__crate__api__evfs__vault_flush(
+    NativePortType port_,
+    int handle,
+  );
+
   external void wire__crate__api__evfs__vault_health(
     NativePortType port_,
     int handle,
@@ -1568,6 +1762,12 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String name,
   );
 
+  external void wire__crate__api__evfs__vault_read_parallel(
+    NativePortType port_,
+    int handle,
+    JSAny names,
+  );
+
   external void wire__crate__api__evfs__vault_read_stream(
     NativePortType port_,
     int handle,
@@ -1575,6 +1775,13 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     bool verify_checksum,
     String sink,
     String on_progress,
+  );
+
+  external void wire__crate__api__evfs__vault_rename_segment(
+    NativePortType port_,
+    int handle,
+    String old_name,
+    String new_name,
   );
 
   external void wire__crate__api__evfs__vault_resize(
@@ -1595,6 +1802,7 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String name,
     JSAny data,
     JSAny? compression,
+    JSAny? metadata,
   );
 
   external void wire__crate__api__evfs__vault_write_file(

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -1433,12 +1433,14 @@ class RustLibWire implements BaseWire {
     String name,
     String file_path,
     String on_progress,
+    JSAny? metadata,
   ) => wasmModule.wire__crate__api__evfs__vault_write_file(
     port_,
     handle,
     name,
     file_path,
     on_progress,
+    metadata,
   );
 
   void
@@ -1811,6 +1813,7 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String name,
     String file_path,
     String on_progress,
+    JSAny? metadata,
   );
 
   external void

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -667,6 +667,7 @@ pub fn vault_write_file(
     name: String,
     file_path: String,
     on_progress: StreamSink<f64>,
+    metadata: Option<HashMap<String, String>>,
 ) -> Result<(), CryptoError> {
     use crate::core::streaming::CHUNK_SIZE;
 
@@ -700,7 +701,7 @@ pub fn vault_write_file(
         }
     });
 
-    let result = vault_write_stream(handle, name, file_size, data_stream, None);
+    let result = vault_write_stream(handle, name, file_size, data_stream, metadata);
 
     // Surface the real I/O error instead of a misleading "stream underflow"
     if let Some(io_err) = read_error {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1455605677;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 15652661;
 
 // Section: executor
 
@@ -1337,6 +1337,45 @@ fn wire__crate__api__evfs__vault_export_impl(
         },
     )
 }
+fn wire__crate__api__evfs__vault_flush_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vault_flush",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_handle = handle.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
+                    let mut api_handle_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_handle,
+                                0,
+                                true,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref_mut()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let mut api_handle_guard = api_handle_guard.unwrap();
+                    let output_ok = crate::api::evfs::vault_flush(&mut *api_handle_guard)?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
 fn wire__crate__api__evfs__vault_health_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     handle: impl CstDecode<
@@ -1513,7 +1552,51 @@ fn wire__crate__api__evfs__vault_read_impl(
                     }
                     let mut api_handle_guard = api_handle_guard.unwrap();
                     let output_ok = crate::api::evfs::vault_read(&mut *api_handle_guard, api_name)?;
-                    Ok(output_ok.data)
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__evfs__vault_read_parallel_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    names: impl CstDecode<Vec<String>>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vault_read_parallel",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_handle = handle.cst_decode();
+            let api_names = names.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, ()>((move || {
+                    let mut api_handle_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_handle,
+                                0,
+                                false,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let api_handle_guard = api_handle_guard.unwrap();
+                    let output_ok = Result::<_, ()>::Ok(crate::api::evfs::vault_read_parallel(
+                        &*api_handle_guard,
+                        api_names,
+                    ))?;
+                    Ok(output_ok)
                 })())
             }
         },
@@ -1565,6 +1648,53 @@ fn wire__crate__api__evfs__vault_read_stream_impl(
                         api_verify_checksum,
                         api_sink,
                         api_on_progress,
+                    )?;
+                    Ok(output_ok)
+                })())
+            }
+        },
+    )
+}
+fn wire__crate__api__evfs__vault_rename_segment_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    handle: impl CstDecode<
+        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
+    >,
+    old_name: impl CstDecode<String>,
+    new_name: impl CstDecode<String>,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "vault_rename_segment",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let api_handle = handle.cst_decode();
+            let api_old_name = old_name.cst_decode();
+            let api_new_name = new_name.cst_decode();
+            move |context| {
+                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
+                    let mut api_handle_guard = None;
+                    let decode_indices_ =
+                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
+                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
+                                &api_handle,
+                                0,
+                                true,
+                            ),
+                        ]);
+                    for i in decode_indices_ {
+                        match i {
+                            0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref_mut()),
+                            _ => unreachable!(),
+                        }
+                    }
+                    let mut api_handle_guard = api_handle_guard.unwrap();
+                    let output_ok = crate::api::evfs::vault_rename_segment(
+                        &mut *api_handle_guard,
+                        api_old_name,
+                        api_new_name,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1645,6 +1775,7 @@ fn wire__crate__api__evfs__vault_write_impl(
     name: impl CstDecode<String>,
     data: impl CstDecode<Vec<u8>>,
     compression: impl CstDecode<Option<crate::api::compression::CompressionConfig>>,
+    metadata: impl CstDecode<Option<std::collections::HashMap<String, String>>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1657,6 +1788,7 @@ fn wire__crate__api__evfs__vault_write_impl(
             let api_name = name.cst_decode();
             let api_data = data.cst_decode();
             let api_compression = compression.cst_decode();
+            let api_metadata = metadata.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
@@ -1680,7 +1812,7 @@ fn wire__crate__api__evfs__vault_write_impl(
                         api_name,
                         api_data,
                         api_compression,
-                        None,
+                        api_metadata,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1839,6 +1971,14 @@ impl SseDecode for VaultHandle {
             flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>,
         >>::sse_decode(deserializer);
         return flutter_rust_bridge::for_generated::rust_auto_opaque_decode_owned(inner);
+    }
+}
+
+impl SseDecode for std::collections::HashMap<String, String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <Vec<(String, String)>>::sse_decode(deserializer);
+        return inner.into_iter().collect();
     }
 }
 
@@ -2004,17 +2144,21 @@ impl SseDecode for crate::core::error::CryptoError {
             }
             13 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
-                return crate::core::error::CryptoError::VaultCorrupted(var_field0);
+                return crate::core::error::CryptoError::DuplicateSegment(var_field0);
             }
             14 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
-                return crate::core::error::CryptoError::KeyRotationFailed(var_field0);
+                return crate::core::error::CryptoError::VaultCorrupted(var_field0);
             }
             15 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
-                return crate::core::error::CryptoError::ExportFailed(var_field0);
+                return crate::core::error::CryptoError::KeyRotationFailed(var_field0);
             }
             16 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::core::error::CryptoError::ExportFailed(var_field0);
+            }
+            17 => {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crate::core::error::CryptoError::ImportFailed(var_field0);
             }
@@ -2077,6 +2221,56 @@ impl SseDecode for Vec<u8> {
     }
 }
 
+impl SseDecode for Vec<(String, String)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<(String, String)>::sse_decode(deserializer));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<crate::api::evfs::types::SegmentResult> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<crate::api::evfs::types::SegmentResult>::sse_decode(
+                deserializer,
+            ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Option<std::collections::HashMap<String, String>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<std::collections::HashMap<String, String>>::sse_decode(
+                deserializer,
+            ));
+        } else {
+            return None;
+        }
+    }
+}
+
+impl SseDecode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        if (<bool>::sse_decode(deserializer)) {
+            return Some(<String>::sse_decode(deserializer));
+        } else {
+            return None;
+        }
+    }
+}
+
 impl SseDecode for Option<crate::api::compression::CompressionConfig> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
@@ -2109,6 +2303,42 @@ impl SseDecode for Option<Vec<u8>> {
         } else {
             return None;
         }
+    }
+}
+
+impl SseDecode for (String, String) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_field0 = <String>::sse_decode(deserializer);
+        let mut var_field1 = <String>::sse_decode(deserializer);
+        return (var_field0, var_field1);
+    }
+}
+
+impl SseDecode for crate::api::evfs::types::SegmentReadResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_data = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_metadata =
+            <std::collections::HashMap<String, String>>::sse_decode(deserializer);
+        return crate::api::evfs::types::SegmentReadResult {
+            data: var_data,
+            metadata: var_metadata,
+        };
+    }
+}
+
+impl SseDecode for crate::api::evfs::types::SegmentResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut var_name = <String>::sse_decode(deserializer);
+        let mut var_data = <Vec<u8>>::sse_decode(deserializer);
+        let mut var_error = <Option<String>>::sse_decode(deserializer);
+        return crate::api::evfs::types::SegmentResult {
+            name: var_name,
+            data: var_data,
+            error: var_error,
+        };
     }
 }
 
@@ -2366,17 +2596,20 @@ impl flutter_rust_bridge::IntoDart for crate::core::error::CryptoError {
             crate::core::error::CryptoError::SegmentNotFound(field0) => {
                 [12.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
-            crate::core::error::CryptoError::VaultCorrupted(field0) => {
+            crate::core::error::CryptoError::DuplicateSegment(field0) => {
                 [13.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
-            crate::core::error::CryptoError::KeyRotationFailed(field0) => {
+            crate::core::error::CryptoError::VaultCorrupted(field0) => {
                 [14.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
-            crate::core::error::CryptoError::ExportFailed(field0) => {
+            crate::core::error::CryptoError::KeyRotationFailed(field0) => {
                 [15.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
-            crate::core::error::CryptoError::ImportFailed(field0) => {
+            crate::core::error::CryptoError::ExportFailed(field0) => {
                 [16.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::core::error::CryptoError::ImportFailed(field0) => {
+                [17.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             _ => {
                 unimplemented!("");
@@ -2414,6 +2647,49 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::evfs::types::DefragResult>
     for crate::api::evfs::types::DefragResult
 {
     fn into_into_dart(self) -> crate::api::evfs::types::DefragResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::evfs::types::SegmentReadResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.data.into_into_dart().into_dart(),
+            self.metadata.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::evfs::types::SegmentReadResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::evfs::types::SegmentReadResult>
+    for crate::api::evfs::types::SegmentReadResult
+{
+    fn into_into_dart(self) -> crate::api::evfs::types::SegmentReadResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::evfs::types::SegmentResult {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        [
+            self.name.into_into_dart().into_dart(),
+            self.data.into_into_dart().into_dart(),
+            self.error.into_into_dart().into_dart(),
+        ]
+        .into_dart()
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::evfs::types::SegmentResult
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::evfs::types::SegmentResult>
+    for crate::api::evfs::types::SegmentResult
+{
+    fn into_into_dart(self) -> crate::api::evfs::types::SegmentResult {
         self
     }
 }
@@ -2495,6 +2771,13 @@ impl SseEncode for VaultHandle {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>>::sse_encode(flutter_rust_bridge::for_generated::rust_auto_opaque_encode::<_, StdArc<_>>(self), serializer);
+    }
+}
+
+impl SseEncode for std::collections::HashMap<String, String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<(String, String)>>::sse_encode(self.into_iter().collect(), serializer);
     }
 }
 
@@ -2654,20 +2937,24 @@ impl SseEncode for crate::core::error::CryptoError {
                 <i32>::sse_encode(12, serializer);
                 <String>::sse_encode(field0, serializer);
             }
-            crate::core::error::CryptoError::VaultCorrupted(field0) => {
+            crate::core::error::CryptoError::DuplicateSegment(field0) => {
                 <i32>::sse_encode(13, serializer);
                 <String>::sse_encode(field0, serializer);
             }
-            crate::core::error::CryptoError::KeyRotationFailed(field0) => {
+            crate::core::error::CryptoError::VaultCorrupted(field0) => {
                 <i32>::sse_encode(14, serializer);
                 <String>::sse_encode(field0, serializer);
             }
-            crate::core::error::CryptoError::ExportFailed(field0) => {
+            crate::core::error::CryptoError::KeyRotationFailed(field0) => {
                 <i32>::sse_encode(15, serializer);
                 <String>::sse_encode(field0, serializer);
             }
-            crate::core::error::CryptoError::ImportFailed(field0) => {
+            crate::core::error::CryptoError::ExportFailed(field0) => {
                 <i32>::sse_encode(16, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::core::error::CryptoError::ImportFailed(field0) => {
+                <i32>::sse_encode(17, serializer);
                 <String>::sse_encode(field0, serializer);
             }
             _ => {
@@ -2720,6 +3007,46 @@ impl SseEncode for Vec<u8> {
     }
 }
 
+impl SseEncode for Vec<(String, String)> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <(String, String)>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<crate::api::evfs::types::SegmentResult> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <crate::api::evfs::types::SegmentResult>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<std::collections::HashMap<String, String>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <std::collections::HashMap<String, String>>::sse_encode(value, serializer);
+        }
+    }
+}
+
+impl SseEncode for Option<String> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <bool>::sse_encode(self.is_some(), serializer);
+        if let Some(value) = self {
+            <String>::sse_encode(value, serializer);
+        }
+    }
+}
+
 impl SseEncode for Option<crate::api::compression::CompressionConfig> {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
@@ -2747,6 +3074,31 @@ impl SseEncode for Option<Vec<u8>> {
         if let Some(value) = self {
             <Vec<u8>>::sse_encode(value, serializer);
         }
+    }
+}
+
+impl SseEncode for (String, String) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.0, serializer);
+        <String>::sse_encode(self.1, serializer);
+    }
+}
+
+impl SseEncode for crate::api::evfs::types::SegmentReadResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <Vec<u8>>::sse_encode(self.data, serializer);
+        <std::collections::HashMap<String, String>>::sse_encode(self.metadata, serializer);
+    }
+}
+
+impl SseEncode for crate::api::evfs::types::SegmentResult {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <String>::sse_encode(self.name, serializer);
+        <Vec<u8>>::sse_encode(self.data, serializer);
+        <Option<String>>::sse_encode(self.error, serializer);
     }
 }
 
@@ -2875,6 +3227,15 @@ mod io {
             >::cst_decode(
                 self
             ))
+        }
+    }
+    impl CstDecode<std::collections::HashMap<String, String>>
+        for *mut wire_cst_list_record_string_string
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> std::collections::HashMap<String, String> {
+            let vec: Vec<(String, String)> = self.cst_decode();
+            vec.into_iter().collect()
         }
     }
     impl
@@ -3014,18 +3375,22 @@ mod io {
                     crate::core::error::CryptoError::SegmentNotFound(ans.field0.cst_decode())
                 }
                 13 => {
+                    let ans = unsafe { self.kind.DuplicateSegment };
+                    crate::core::error::CryptoError::DuplicateSegment(ans.field0.cst_decode())
+                }
+                14 => {
                     let ans = unsafe { self.kind.VaultCorrupted };
                     crate::core::error::CryptoError::VaultCorrupted(ans.field0.cst_decode())
                 }
-                14 => {
+                15 => {
                     let ans = unsafe { self.kind.KeyRotationFailed };
                     crate::core::error::CryptoError::KeyRotationFailed(ans.field0.cst_decode())
                 }
-                15 => {
+                16 => {
                     let ans = unsafe { self.kind.ExportFailed };
                     crate::core::error::CryptoError::ExportFailed(ans.field0.cst_decode())
                 }
-                16 => {
+                17 => {
                     let ans = unsafe { self.kind.ImportFailed };
                     crate::core::error::CryptoError::ImportFailed(ans.field0.cst_decode())
                 }
@@ -3068,6 +3433,51 @@ mod io {
             unsafe {
                 let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
                 flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            }
+        }
+    }
+    impl CstDecode<Vec<(String, String)>> for *mut wire_cst_list_record_string_string {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<(String, String)> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
+    impl CstDecode<Vec<crate::api::evfs::types::SegmentResult>> for *mut wire_cst_list_segment_result {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::api::evfs::types::SegmentResult> {
+            let vec = unsafe {
+                let wrap = flutter_rust_bridge::for_generated::box_from_leak_ptr(self);
+                flutter_rust_bridge::for_generated::vec_from_leak_ptr(wrap.ptr, wrap.len)
+            };
+            vec.into_iter().map(CstDecode::cst_decode).collect()
+        }
+    }
+    impl CstDecode<(String, String)> for wire_cst_record_string_string {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> (String, String) {
+            (self.field0.cst_decode(), self.field1.cst_decode())
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::SegmentReadResult> for wire_cst_segment_read_result {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::SegmentReadResult {
+            crate::api::evfs::types::SegmentReadResult {
+                data: self.data.cst_decode(),
+                metadata: self.metadata.cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::SegmentResult> for wire_cst_segment_result {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::SegmentResult {
+            crate::api::evfs::types::SegmentResult {
+                name: self.name.cst_decode(),
+                data: self.data.cst_decode(),
+                error: self.error.cst_decode(),
             }
         }
     }
@@ -3135,6 +3545,46 @@ mod io {
         }
     }
     impl Default for wire_cst_defrag_result {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_record_string_string {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                field0: core::ptr::null_mut(),
+                field1: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_record_string_string {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_segment_read_result {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                data: core::ptr::null_mut(),
+                metadata: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_segment_read_result {
+        fn default() -> Self {
+            Self::new_with_null_ptr()
+        }
+    }
+    impl NewWithNullPtr for wire_cst_segment_result {
+        fn new_with_null_ptr() -> Self {
+            Self {
+                name: core::ptr::null_mut(),
+                data: core::ptr::null_mut(),
+                error: core::ptr::null_mut(),
+            }
+        }
+    }
+    impl Default for wire_cst_segment_result {
         fn default() -> Self {
             Self::new_with_null_ptr()
         }
@@ -3557,6 +4007,14 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_flush(
+        port_: i64,
+        handle: usize,
+    ) {
+        wire__crate__api__evfs__vault_flush_impl(port_, handle)
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_health(
         port_: i64,
         handle: usize,
@@ -3612,6 +4070,15 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_read_parallel(
+        port_: i64,
+        handle: usize,
+        names: *mut wire_cst_list_String,
+    ) {
+        wire__crate__api__evfs__vault_read_parallel_impl(port_, handle, names)
+    }
+
+    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_read_stream(
         port_: i64,
         handle: usize,
@@ -3628,6 +4095,16 @@ mod io {
             sink,
             on_progress,
         )
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_rename_segment(
+        port_: i64,
+        handle: usize,
+        old_name: *mut wire_cst_list_prim_u_8_strict,
+        new_name: *mut wire_cst_list_prim_u_8_strict,
+    ) {
+        wire__crate__api__evfs__vault_rename_segment_impl(port_, handle, old_name, new_name)
     }
 
     #[unsafe(no_mangle)]
@@ -3655,8 +4132,9 @@ mod io {
         name: *mut wire_cst_list_prim_u_8_strict,
         data: *mut wire_cst_list_prim_u_8_loose,
         compression: *mut wire_cst_compression_config,
+        metadata: *mut wire_cst_list_record_string_string,
     ) {
-        wire__crate__api__evfs__vault_write_impl(port_, handle, name, data, compression)
+        wire__crate__api__evfs__vault_write_impl(port_, handle, name, data, compression, metadata)
     }
 
     #[unsafe(no_mangle)]
@@ -3771,6 +4249,34 @@ mod io {
         flutter_rust_bridge::for_generated::new_leak_box_ptr(ans)
     }
 
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_list_record_string_string(
+        len: i32,
+    ) -> *mut wire_cst_list_record_string_string {
+        let wrap = wire_cst_list_record_string_string {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_record_string_string>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "C" fn frbgen_m_security_cst_new_list_segment_result(
+        len: i32,
+    ) -> *mut wire_cst_list_segment_result {
+        let wrap = wire_cst_list_segment_result {
+            ptr: flutter_rust_bridge::for_generated::new_leak_vec_ptr(
+                <wire_cst_segment_result>::new_with_null_ptr(),
+                len,
+            ),
+            len,
+        };
+        flutter_rust_bridge::for_generated::new_leak_box_ptr(wrap)
+    }
+
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_compression_config {
@@ -3795,6 +4301,7 @@ mod io {
         CompressionFailed: wire_cst_CryptoError_CompressionFailed,
         VaultFull: wire_cst_CryptoError_VaultFull,
         SegmentNotFound: wire_cst_CryptoError_SegmentNotFound,
+        DuplicateSegment: wire_cst_CryptoError_DuplicateSegment,
         VaultCorrupted: wire_cst_CryptoError_VaultCorrupted,
         KeyRotationFailed: wire_cst_CryptoError_KeyRotationFailed,
         ExportFailed: wire_cst_CryptoError_ExportFailed,
@@ -3850,6 +4357,11 @@ mod io {
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_DuplicateSegment {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
     pub struct wire_cst_CryptoError_VaultCorrupted {
         field0: *mut wire_cst_list_prim_u_8_strict,
     }
@@ -3892,6 +4404,37 @@ mod io {
     pub struct wire_cst_list_prim_u_8_strict {
         ptr: *mut u8,
         len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_record_string_string {
+        ptr: *mut wire_cst_record_string_string,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_list_segment_result {
+        ptr: *mut wire_cst_segment_result,
+        len: i32,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_record_string_string {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+        field1: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_segment_read_result {
+        data: *mut wire_cst_list_prim_u_8_strict,
+        metadata: *mut wire_cst_list_record_string_string,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_segment_result {
+        name: *mut wire_cst_list_prim_u_8_strict,
+        data: *mut wire_cst_list_prim_u_8_strict,
+        error: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
     #[derive(Clone, Copy)]
@@ -4015,10 +4558,11 @@ mod web {
                 },
                 11 => crate::core::error::CryptoError::VaultLocked,
                 12 => crate::core::error::CryptoError::SegmentNotFound(self_.get(1).cst_decode()),
-                13 => crate::core::error::CryptoError::VaultCorrupted(self_.get(1).cst_decode()),
-                14 => crate::core::error::CryptoError::KeyRotationFailed(self_.get(1).cst_decode()),
-                15 => crate::core::error::CryptoError::ExportFailed(self_.get(1).cst_decode()),
-                16 => crate::core::error::CryptoError::ImportFailed(self_.get(1).cst_decode()),
+                13 => crate::core::error::CryptoError::DuplicateSegment(self_.get(1).cst_decode()),
+                14 => crate::core::error::CryptoError::VaultCorrupted(self_.get(1).cst_decode()),
+                15 => crate::core::error::CryptoError::KeyRotationFailed(self_.get(1).cst_decode()),
+                16 => crate::core::error::CryptoError::ExportFailed(self_.get(1).cst_decode()),
+                17 => crate::core::error::CryptoError::ImportFailed(self_.get(1).cst_decode()),
                 _ => unreachable!(),
             }
         }
@@ -4060,10 +4604,96 @@ mod web {
             self.into_vec()
         }
     }
+    impl CstDecode<Vec<(String, String)>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<(String, String)> {
+            self.dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap()
+                .iter()
+                .map(CstDecode::cst_decode)
+                .collect()
+        }
+    }
+    impl CstDecode<Vec<crate::api::evfs::types::SegmentResult>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Vec<crate::api::evfs::types::SegmentResult> {
+            self.dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap()
+                .iter()
+                .map(CstDecode::cst_decode)
+                .collect()
+        }
+    }
+    impl CstDecode<Option<String>> for Option<String> {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> Option<String> {
+            self.map(CstDecode::cst_decode)
+        }
+    }
     impl CstDecode<Option<Vec<u8>>> for Option<Box<[u8]>> {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> Option<Vec<u8>> {
             self.map(CstDecode::cst_decode)
+        }
+    }
+    impl CstDecode<(String, String)> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> (String, String) {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                2,
+                "Expected 2 elements, got {}",
+                self_.length()
+            );
+            (self_.get(0).cst_decode(), self_.get(1).cst_decode())
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::SegmentReadResult>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::SegmentReadResult {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                2,
+                "Expected 2 elements, got {}",
+                self_.length()
+            );
+            crate::api::evfs::types::SegmentReadResult {
+                data: self_.get(0).cst_decode(),
+                metadata: self_.get(1).cst_decode(),
+            }
+        }
+    }
+    impl CstDecode<crate::api::evfs::types::SegmentResult>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::SegmentResult {
+            let self_ = self
+                .dyn_into::<flutter_rust_bridge::for_generated::js_sys::Array>()
+                .unwrap();
+            assert_eq!(
+                self_.length(),
+                3,
+                "Expected 3 elements, got {}",
+                self_.length()
+            );
+            crate::api::evfs::types::SegmentResult {
+                name: self_.get(0).cst_decode(),
+                data: self_.get(1).cst_decode(),
+                error: self_.get(2).cst_decode(),
+            }
         }
     }
     impl CstDecode<crate::api::evfs::types::VaultCapacityInfo>
@@ -4156,6 +4786,15 @@ mod web {
             >::cst_decode(
                 self
             ))
+        }
+    }
+    impl CstDecode<std::collections::HashMap<String, String>>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> std::collections::HashMap<String, String> {
+            let vec: Vec<(String, String)> = self.cst_decode();
+            vec.into_iter().collect()
         }
     }
     impl
@@ -4683,6 +5322,14 @@ mod web {
     }
 
     #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_flush(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_flush_impl(port_, handle)
+    }
+
+    #[wasm_bindgen]
     pub fn wire__crate__api__evfs__vault_health(
         port_: flutter_rust_bridge::for_generated::MessagePort,
         handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
@@ -4738,6 +5385,15 @@ mod web {
     }
 
     #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_read_parallel(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        names: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+    ) {
+        wire__crate__api__evfs__vault_read_parallel_impl(port_, handle, names)
+    }
+
+    #[wasm_bindgen]
     pub fn wire__crate__api__evfs__vault_read_stream(
         port_: flutter_rust_bridge::for_generated::MessagePort,
         handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
@@ -4754,6 +5410,16 @@ mod web {
             sink,
             on_progress,
         )
+    }
+
+    #[wasm_bindgen]
+    pub fn wire__crate__api__evfs__vault_rename_segment(
+        port_: flutter_rust_bridge::for_generated::MessagePort,
+        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        old_name: String,
+        new_name: String,
+    ) {
+        wire__crate__api__evfs__vault_rename_segment_impl(port_, handle, old_name, new_name)
     }
 
     #[wasm_bindgen]
@@ -4781,8 +5447,9 @@ mod web {
         name: String,
         data: Box<[u8]>,
         compression: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        metadata: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) {
-        wire__crate__api__evfs__vault_write_impl(port_, handle, name, data, compression)
+        wire__crate__api__evfs__vault_write_impl(port_, handle, name, data, compression, metadata)
     }
 
     #[wasm_bindgen]

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -1828,6 +1828,7 @@ fn wire__crate__api__evfs__vault_write_file_impl(
     name: impl CstDecode<String>,
     file_path: impl CstDecode<String>,
     on_progress: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
+    metadata: impl CstDecode<Option<std::collections::HashMap<String, String>>>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1840,6 +1841,7 @@ fn wire__crate__api__evfs__vault_write_file_impl(
             let api_name = name.cst_decode();
             let api_file_path = file_path.cst_decode();
             let api_on_progress = on_progress.cst_decode();
+            let api_metadata = metadata.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let mut api_handle_guard = None;
@@ -1863,6 +1865,7 @@ fn wire__crate__api__evfs__vault_write_file_impl(
                         api_name,
                         api_file_path,
                         api_on_progress,
+                        api_metadata,
                     )?;
                     Ok(output_ok)
                 })())
@@ -4144,8 +4147,16 @@ mod io {
         name: *mut wire_cst_list_prim_u_8_strict,
         file_path: *mut wire_cst_list_prim_u_8_strict,
         on_progress: *mut wire_cst_list_prim_u_8_strict,
+        metadata: *mut wire_cst_list_record_string_string,
     ) {
-        wire__crate__api__evfs__vault_write_file_impl(port_, handle, name, file_path, on_progress)
+        wire__crate__api__evfs__vault_write_file_impl(
+            port_,
+            handle,
+            name,
+            file_path,
+            on_progress,
+            metadata,
+        )
     }
 
     #[unsafe(no_mangle)]
@@ -5459,8 +5470,16 @@ mod web {
         name: String,
         file_path: String,
         on_progress: String,
+        metadata: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
     ) {
-        wire__crate__api__evfs__vault_write_file_impl(port_, handle, name, file_path, on_progress)
+        wire__crate__api__evfs__vault_write_file_impl(
+            port_,
+            handle,
+            name,
+            file_path,
+            on_progress,
+            metadata,
+        )
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
## Summary

Add Dart `VaultService` wrappers and integration tests for all EVFS segment enhancement Rust APIs: per-segment metadata, segment rename, explicit flush, and parallel reads.

## Changes

### Dart Wrappers (`lib/src/evfs/vault_service.dart`)
- `write()` accepts optional `Map<String, String>? metadata` parameter
- `writeStream()` accepts optional `Map<String, String>? metadata` — passes through to Rust `vault_write_file`
- `read()` returns `SegmentReadResult { data, metadata }` instead of raw `Uint8List`
- `renameSegment()` — index-only rename, throws `DuplicateSegment` / `SegmentNotFound`
- `flush()` — explicit index flush to disk, no-op when clean
- `readParallel()` — concurrent multi-segment read returning `List<SegmentResult>`
- Doc comments include memory warnings for `readParallel` and metadata limitation notes

### Rust (`rust/src/api/evfs/mod.rs`)
- `vault_write_file` now accepts `metadata: Option<HashMap<String, String>>` and passes it through to `vault_write_stream` (was hardcoded to `None`)

### FRB Types (`lib/src/rust/api/evfs/types.dart`)
- `SegmentReadResult` — decrypted data + metadata map
- `SegmentResult` — per-segment result for parallel reads (name, data, error)
- FRB codegen regenerated for all new/updated Rust functions

### Integration Tests (`integration_test/evfs_enhancements_test.dart`)
- **Metadata** (4 tests): write with metadata roundtrip, write without metadata returns empty map, overwrite replaces metadata, metadata survives close/reopen
- **Rename** (4 tests): rename + read, rename to existing throws `DuplicateSegment`, rename nonexistent throws `SegmentNotFound`, rename preserves metadata
- **Flush** (2 tests): explicit flush after write, flush on clean handle is no-op
- **Parallel Read** (3 tests): 5 segments match sequential reads, missing name returns per-segment error, empty list returns empty result
- **Combined Workflows** (2 tests): write → rename → parallel read → verify metadata; write 10 segments → flush → parallel read all → verify data

### Existing Test Updates
- Updated existing integration tests and key management tests for `SegmentReadResult` return type (`.data` field access)
- Fixed `expect` → `await expectLater` for async error assertions in rename tests

### Test Modules (Rust)
- Refactored monolithic `tests.rs` into 13 focused modules under `tests/`

## Test plan

- [x] Write with metadata → read back → metadata matches
- [x] Write without metadata → read returns empty map
- [x] Overwrite with different metadata → new metadata returned
- [x] Metadata survives close/reopen
- [x] Rename + read → data accessible under new name
- [x] Rename to existing name → throws DuplicateSegment
- [x] Rename nonexistent → throws SegmentNotFound
- [x] Rename preserves metadata
- [x] Explicit flush after write → no error
- [x] Flush on clean handle → no-op
- [x] Parallel read 5 segments → matches sequential reads
- [x] Parallel read with missing name → per-segment error
- [x] Parallel read empty list → empty result
- [x] Combined: write → rename → parallel read → metadata preserved
- [x] Combined: write 10 segments → flush → parallel read all → data verified
- [x] All Rust tests pass (0 regressions)

Closes #124