### PR TITLE
fix(argon2): limit verification work before allocation

### DIFF
--- a/example/integration_test/argon2_test.dart
+++ b/example/integration_test/argon2_test.dart
@@ -1,7 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/hashing/argon2.dart';
+import 'package:m_security/src/rust/core/error.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
+
+// A released mobile-preset hash of 'preset_vector'.
+const String releasedMobileVector =
+    r'$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -82,6 +87,53 @@ void main() {
       );
 
       expect(hash1, isNot(hash2));
+    });
+
+    test('released mobile vector still verifies', () async {
+      await argon2IdVerify(
+        phcHash: releasedMobileVector,
+        password: 'preset_vector',
+      );
+    });
+
+    test('password over the ceiling is a policy violation', () async {
+      await expectLater(
+        argon2IdVerify(
+          phcHash: releasedMobileVector,
+          password: 'a' * (maxArgon2VerifyPasswordBytes + 1),
+        ),
+        throwsA(isA<CryptoError_Argon2PolicyViolation>()),
+      );
+    });
+
+    test('password at the ceiling reaches the verifier', () async {
+      await expectLater(
+        argon2IdVerify(
+          phcHash: releasedMobileVector,
+          password: 'a' * maxArgon2VerifyPasswordBytes,
+        ),
+        throwsA(isA<CryptoError_AuthenticationFailed>()),
+      );
+    });
+
+    test('work factors above the ceiling are a policy violation', () async {
+      const overLimit =
+          r'$argon2id$v=19$m=1048576,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
+
+      await expectLater(
+        argon2IdVerify(phcHash: overLimit, password: 'preset_vector'),
+        throwsA(isA<CryptoError_Argon2PolicyViolation>()),
+      );
+    });
+
+    test('a non-argon2id variant is a policy violation', () async {
+      const argon2i =
+          r'$argon2i$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
+
+      await expectLater(
+        argon2IdVerify(phcHash: argon2i, password: 'preset_vector'),
+        throwsA(isA<CryptoError_Argon2PolicyViolation>()),
+      );
     });
   });
 }

--- a/integration_test/argon2_test.dart
+++ b/integration_test/argon2_test.dart
@@ -1,7 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/hashing/argon2.dart';
+import 'package:m_security/src/rust/core/error.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
+
+// A released mobile-preset hash of 'preset_vector'.
+const String releasedMobileVector =
+    r'$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -82,6 +87,53 @@ void main() {
       );
 
       expect(hash1, isNot(hash2));
+    });
+
+    test('released mobile vector still verifies', () async {
+      await argon2IdVerify(
+        phcHash: releasedMobileVector,
+        password: 'preset_vector',
+      );
+    });
+
+    test('password over the ceiling is a policy violation', () async {
+      await expectLater(
+        argon2IdVerify(
+          phcHash: releasedMobileVector,
+          password: 'a' * (maxArgon2VerifyPasswordBytes + 1),
+        ),
+        throwsA(isA<CryptoError_Argon2PolicyViolation>()),
+      );
+    });
+
+    test('password at the ceiling reaches the verifier', () async {
+      await expectLater(
+        argon2IdVerify(
+          phcHash: releasedMobileVector,
+          password: 'a' * maxArgon2VerifyPasswordBytes,
+        ),
+        throwsA(isA<CryptoError_AuthenticationFailed>()),
+      );
+    });
+
+    test('work factors above the ceiling are a policy violation', () async {
+      const overLimit =
+          r'$argon2id$v=19$m=1048576,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
+
+      await expectLater(
+        argon2IdVerify(phcHash: overLimit, password: 'preset_vector'),
+        throwsA(isA<CryptoError_Argon2PolicyViolation>()),
+      );
+    });
+
+    test('a non-argon2id variant is a policy violation', () async {
+      const argon2i =
+          r'$argon2i$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
+
+      await expectLater(
+        argon2IdVerify(phcHash: argon2i, password: 'preset_vector'),
+        throwsA(isA<CryptoError_Argon2PolicyViolation>()),
+      );
     });
   });
 }

--- a/lib/src/hashing/argon2.dart
+++ b/lib/src/hashing/argon2.dart
@@ -1,9 +1,15 @@
 // Public API wrapper for Argon2id hashing with platform-aware defaults.
 // Uses bool.fromEnvironment for compile-time preset selection.
 
+import 'dart:convert';
+
 import '../rust/api/hashing/argon2.dart' as ffi;
+import '../rust/core/error.dart';
 
 export '../rust/api/hashing/argon2.dart' show Argon2Preset;
+
+/// Largest password [argon2IdVerify] accepts, in UTF-8 bytes.
+const int maxArgon2VerifyPasswordBytes = 1024;
 
 // Compile-time flag: pass -DIS_DESKTOP=true for desktop/server builds
 const bool _isDesktop = bool.fromEnvironment('IS_DESKTOP');
@@ -31,7 +37,22 @@ Future<String> argon2IdHashWithSalt({
 }) => ffi.argon2IdHashWithSalt(password: password, salt: salt, preset: preset);
 
 /// Verify a password against an Argon2id PHC hash string.
+///
+/// Throws [CryptoError.argon2PolicyViolation] if the password is longer than
+/// [maxArgon2VerifyPasswordBytes]. The native side applies the same ceiling,
+/// along with the limits on the hash itself.
 Future<void> argon2IdVerify({
   required String phcHash,
   required String password,
-}) => ffi.argon2IdVerify(phcHash: phcHash, password: password);
+}) async {
+  // UTF-8 never spends fewer bytes than the string has UTF-16 code units, so
+  // the cheap length test runs first and keeps the encoding below it bounded.
+  if (password.length > maxArgon2VerifyPasswordBytes ||
+      utf8.encode(password).length > maxArgon2VerifyPasswordBytes) {
+    throw CryptoError.argon2PolicyViolation(
+      'password is longer than $maxArgon2VerifyPasswordBytes UTF-8 bytes',
+    );
+  }
+
+  return ffi.argon2IdVerify(phcHash: phcHash, password: password);
+}

--- a/lib/src/rust/api/hashing/argon2.dart
+++ b/lib/src/rust/api/hashing/argon2.dart
@@ -7,7 +7,9 @@ import '../../core/error.dart';
 import '../../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `params`
+// These functions are ignored because they are not marked as `pub`: `as_bytes`, `malformed_error`, `new`, `params`, `parse_within_policy`, `policy_error`, `scan_b64_len`, `scan_decimal`, `scan_phc`, `scan_work_factors`, `try_acquire`, `verify_within_policy`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `PasswordGuard`, `VerificationPermit`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `drop`, `drop`
 
 /// Hash a password using Argon2id with the given preset.
 ///
@@ -36,6 +38,14 @@ Future<String> argon2IdHashWithSalt({
 );
 
 /// Verify a password against an Argon2id PHC hash string.
+///
+/// The hash must be Argon2id version 19 within the published verification
+/// limits, and the password must be at most 1024 UTF-8 bytes. A hash outside
+/// those limits returns `Err(CryptoError::Argon2PolicyViolation)`, and one that
+/// is not a well-formed PHC string returns `Err(CryptoError::InvalidParameter)`.
+/// Both come back before any Argon2 memory is reserved. One verification runs
+/// at a time; a caller arriving during another one gets
+/// `Err(CryptoError::Argon2VerificationBusy)` rather than waiting.
 ///
 /// Returns `Ok(())` if the password matches, or
 /// `Err(CryptoError::AuthenticationFailed)` if it does not.

--- a/lib/src/rust/core/error.dart
+++ b/lib/src/rust/core/error.dart
@@ -47,4 +47,8 @@ sealed class CryptoError with _$CryptoError implements FrbException {
       CryptoError_ExportFailed;
   const factory CryptoError.importFailed(String field0) =
       CryptoError_ImportFailed;
+  const factory CryptoError.argon2PolicyViolation(String field0) =
+      CryptoError_Argon2PolicyViolation;
+  const factory CryptoError.argon2VerificationBusy() =
+      CryptoError_Argon2VerificationBusy;
 }

--- a/lib/src/rust/core/error.freezed.dart
+++ b/lib/src/rust/core/error.freezed.dart
@@ -55,7 +55,7 @@ extension CryptoErrorPatterns on CryptoError {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,TResult Function( CryptoError_Argon2PolicyViolation value)?  argon2PolicyViolation,TResult Function( CryptoError_Argon2VerificationBusy value)?  argon2VerificationBusy,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -76,7 +76,9 @@ return duplicateSegment(_that);case CryptoError_VaultCorrupted() when vaultCorru
 return vaultCorrupted(_that);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
-return importFailed(_that);case _:
+return importFailed(_that);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
+return argon2PolicyViolation(_that);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
+return argon2VerificationBusy(_that);case _:
   return orElse();
 
 }
@@ -94,7 +96,7 @@ return importFailed(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_DuplicateSegment value)  duplicateSegment,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_DuplicateSegment value)  duplicateSegment,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,required TResult Function( CryptoError_Argon2PolicyViolation value)  argon2PolicyViolation,required TResult Function( CryptoError_Argon2VerificationBusy value)  argon2VerificationBusy,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
@@ -115,7 +117,9 @@ return duplicateSegment(_that);case CryptoError_VaultCorrupted():
 return vaultCorrupted(_that);case CryptoError_KeyRotationFailed():
 return keyRotationFailed(_that);case CryptoError_ExportFailed():
 return exportFailed(_that);case CryptoError_ImportFailed():
-return importFailed(_that);}
+return importFailed(_that);case CryptoError_Argon2PolicyViolation():
+return argon2PolicyViolation(_that);case CryptoError_Argon2VerificationBusy():
+return argon2VerificationBusy(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -129,7 +133,7 @@ return importFailed(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,TResult? Function( CryptoError_Argon2PolicyViolation value)?  argon2PolicyViolation,TResult? Function( CryptoError_Argon2VerificationBusy value)?  argon2VerificationBusy,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -150,7 +154,9 @@ return duplicateSegment(_that);case CryptoError_VaultCorrupted() when vaultCorru
 return vaultCorrupted(_that);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
-return importFailed(_that);case _:
+return importFailed(_that);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
+return argon2PolicyViolation(_that);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
+return argon2VerificationBusy(_that);case _:
   return null;
 
 }
@@ -167,7 +173,7 @@ return importFailed(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  duplicateSegment,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  duplicateSegment,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,TResult Function( String field0)?  argon2PolicyViolation,TResult Function()?  argon2VerificationBusy,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -187,7 +193,9 @@ return duplicateSegment(_that.field0);case CryptoError_VaultCorrupted() when vau
 return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
-return importFailed(_that.field0);case _:
+return importFailed(_that.field0);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
+return argon2PolicyViolation(_that.field0);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
+return argon2VerificationBusy();case _:
   return orElse();
 
 }
@@ -205,7 +213,7 @@ return importFailed(_that.field0);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  duplicateSegment,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  duplicateSegment,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,required TResult Function( String field0)  argon2PolicyViolation,required TResult Function()  argon2VerificationBusy,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce():
@@ -225,7 +233,9 @@ return duplicateSegment(_that.field0);case CryptoError_VaultCorrupted():
 return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed():
 return keyRotationFailed(_that.field0);case CryptoError_ExportFailed():
 return exportFailed(_that.field0);case CryptoError_ImportFailed():
-return importFailed(_that.field0);}
+return importFailed(_that.field0);case CryptoError_Argon2PolicyViolation():
+return argon2PolicyViolation(_that.field0);case CryptoError_Argon2VerificationBusy():
+return argon2VerificationBusy();}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -239,7 +249,7 @@ return importFailed(_that.field0);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  duplicateSegment,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  duplicateSegment,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,TResult? Function( String field0)?  argon2PolicyViolation,TResult? Function()?  argon2VerificationBusy,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -259,7 +269,9 @@ return duplicateSegment(_that.field0);case CryptoError_VaultCorrupted() when vau
 return vaultCorrupted(_that.field0);case CryptoError_KeyRotationFailed() when keyRotationFailed != null:
 return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when exportFailed != null:
 return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
-return importFailed(_that.field0);case _:
+return importFailed(_that.field0);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
+return argon2PolicyViolation(_that.field0);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
+return argon2VerificationBusy();case _:
   return null;
 
 }
@@ -1322,5 +1334,103 @@ as String,
 
 
 }
+
+/// @nodoc
+
+
+class CryptoError_Argon2PolicyViolation extends CryptoError {
+  const CryptoError_Argon2PolicyViolation(this.field0): super._();
+  
+
+ final  String field0;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CryptoError_Argon2PolicyViolationCopyWith<CryptoError_Argon2PolicyViolation> get copyWith => _$CryptoError_Argon2PolicyViolationCopyWithImpl<CryptoError_Argon2PolicyViolation>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_Argon2PolicyViolation&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'CryptoError.argon2PolicyViolation(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CryptoError_Argon2PolicyViolationCopyWith<$Res> implements $CryptoErrorCopyWith<$Res> {
+  factory $CryptoError_Argon2PolicyViolationCopyWith(CryptoError_Argon2PolicyViolation value, $Res Function(CryptoError_Argon2PolicyViolation) _then) = _$CryptoError_Argon2PolicyViolationCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$CryptoError_Argon2PolicyViolationCopyWithImpl<$Res>
+    implements $CryptoError_Argon2PolicyViolationCopyWith<$Res> {
+  _$CryptoError_Argon2PolicyViolationCopyWithImpl(this._self, this._then);
+
+  final CryptoError_Argon2PolicyViolation _self;
+  final $Res Function(CryptoError_Argon2PolicyViolation) _then;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(CryptoError_Argon2PolicyViolation(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+/// @nodoc
+
+
+class CryptoError_Argon2VerificationBusy extends CryptoError {
+  const CryptoError_Argon2VerificationBusy(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_Argon2VerificationBusy);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CryptoError.argon2VerificationBusy()';
+}
+
+
+}
+
+
+
 
 // dart format on

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -2352,6 +2352,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return CryptoError_ExportFailed(dco_decode_String(raw[1]));
       case 17:
         return CryptoError_ImportFailed(dco_decode_String(raw[1]));
+      case 18:
+        return CryptoError_Argon2PolicyViolation(dco_decode_String(raw[1]));
+      case 19:
+        return CryptoError_Argon2VerificationBusy();
       default:
         throw Exception("unreachable");
     }
@@ -2812,6 +2816,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case 17:
         var var_field0 = sse_decode_String(deserializer);
         return CryptoError_ImportFailed(var_field0);
+      case 18:
+        var var_field0 = sse_decode_String(deserializer);
+        return CryptoError_Argon2PolicyViolation(var_field0);
+      case 19:
+        return CryptoError_Argon2VerificationBusy();
       default:
         throw UnimplementedError('');
     }
@@ -3504,6 +3513,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       case CryptoError_ImportFailed(field0: final field0):
         sse_encode_i_32(17, serializer);
         sse_encode_String(field0, serializer);
+      case CryptoError_Argon2PolicyViolation(field0: final field0):
+        sse_encode_i_32(18, serializer);
+        sse_encode_String(field0, serializer);
+      case CryptoError_Argon2VerificationBusy():
+        sse_encode_i_32(19, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -693,6 +693,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.kind.ImportFailed.field0 = pre_field0;
       return;
     }
+    if (apiObj is CryptoError_Argon2PolicyViolation) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 18;
+      wireObj.kind.Argon2PolicyViolation.field0 = pre_field0;
+      return;
+    }
+    if (apiObj is CryptoError_Argon2VerificationBusy) {
+      wireObj.tag = 19;
+      return;
+    }
   }
 
   @protected
@@ -2795,6 +2805,10 @@ final class wire_cst_CryptoError_ImportFailed extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 }
 
+final class wire_cst_CryptoError_Argon2PolicyViolation extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
 final class CryptoErrorKind extends ffi.Union {
   external wire_cst_CryptoError_InvalidKeyLength InvalidKeyLength;
 
@@ -2823,6 +2837,8 @@ final class CryptoErrorKind extends ffi.Union {
   external wire_cst_CryptoError_ExportFailed ExportFailed;
 
   external wire_cst_CryptoError_ImportFailed ImportFailed;
+
+  external wire_cst_CryptoError_Argon2PolicyViolation Argon2PolicyViolation;
 }
 
 final class wire_cst_crypto_error extends ffi.Struct {
@@ -2894,6 +2910,24 @@ final class wire_cst_vault_health_info extends ffi.Struct {
   @ffi.Bool()
   external bool is_consistent;
 }
+
+const int MAX_VERIFY_PHC_BYTES = 1024;
+
+const int MAX_VERIFY_PASSWORD_BYTES = 1024;
+
+const int MAX_VERIFY_MEMORY_KIB = 262144;
+
+const int MAX_VERIFY_ITERATIONS = 4;
+
+const int MAX_VERIFY_LANES = 8;
+
+const int MIN_VERIFY_SALT_BYTES = 8;
+
+const int MAX_VERIFY_SALT_BYTES = 64;
+
+const int MIN_VERIFY_OUTPUT_BYTES = 16;
+
+const int MAX_VERIFY_OUTPUT_BYTES = 64;
 
 const int DEFAULT_LEVEL = 3;
 

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -532,6 +532,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     if (raw is CryptoError_ImportFailed) {
       return [17, cst_encode_String(raw.field0)].jsify()!;
     }
+    if (raw is CryptoError_Argon2PolicyViolation) {
+      return [18, cst_encode_String(raw.field0)].jsify()!;
+    }
+    if (raw is CryptoError_Argon2VerificationBusy) {
+      return [19].jsify()!;
+    }
 
     throw Exception('unreachable');
   }

--- a/rust/src/api/hashing/argon2.rs
+++ b/rust/src/api/hashing/argon2.rs
@@ -1,12 +1,347 @@
 //! Argon2id password hashing with platform presets and PHC format output.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use argon2::{
     password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Algorithm, Argon2, Params, Version,
 };
 use rand::rngs::OsRng;
+use zeroize::Zeroize;
 
 use crate::core::error::CryptoError;
+
+/// Largest PHC string [`argon2id_verify`] will look at, in bytes.
+pub const MAX_VERIFY_PHC_BYTES: usize = 1024;
+/// Largest password [`argon2id_verify`] will look at, in UTF-8 bytes.
+pub const MAX_VERIFY_PASSWORD_BYTES: usize = 1024;
+/// Largest memory cost accepted from a PHC string, in KiB.
+pub const MAX_VERIFY_MEMORY_KIB: u32 = 262_144;
+/// Largest iteration count accepted from a PHC string.
+pub const MAX_VERIFY_ITERATIONS: u32 = 4;
+/// Largest lane count accepted from a PHC string.
+pub const MAX_VERIFY_LANES: u32 = 8;
+/// Smallest decoded salt accepted from a PHC string, in bytes.
+pub const MIN_VERIFY_SALT_BYTES: usize = 8;
+/// Decoded salt ceiling, in bytes. The PHC parser caps the encoded salt at 64
+/// characters, so 48 decoded bytes is the largest that reaches a verifier.
+pub const MAX_VERIFY_SALT_BYTES: usize = 64;
+/// Smallest decoded hash output accepted from a PHC string, in bytes.
+pub const MIN_VERIFY_OUTPUT_BYTES: usize = 16;
+/// Largest decoded hash output accepted from a PHC string, in bytes.
+pub const MAX_VERIFY_OUTPUT_BYTES: usize = 64;
+
+const SUPPORTED_ALGORITHM: &str = "argon2id";
+const SUPPORTED_VERSION_FIELD: &str = "v=19";
+const SUPPORTED_VERSION: u32 = 0x13;
+
+// Argon2 needs eight KiB blocks per lane, so this is the crate's own floor
+// rather than an added policy bound.
+const KIB_PER_LANE: u64 = 8;
+
+static VERIFICATION_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+fn policy_error(reason: impl Into<String>) -> CryptoError {
+    CryptoError::Argon2PolicyViolation(reason.into())
+}
+
+fn malformed_error(reason: impl Into<String>) -> CryptoError {
+    CryptoError::InvalidParameter(reason.into())
+}
+
+/// Serializes verification so one caller cannot be starved of memory by another.
+///
+/// `Drop` hands the permit back on every return path, including the error ones.
+/// A panic needs no handling: the release profile aborts, and nothing in the
+/// crate catches an unwind to carry on while the permit is still held.
+struct VerificationPermit;
+
+impl VerificationPermit {
+    fn try_acquire() -> Option<Self> {
+        VERIFICATION_IN_FLIGHT
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .ok()
+            .map(|_| Self)
+    }
+}
+
+impl Drop for VerificationPermit {
+    fn drop(&mut self) {
+        VERIFICATION_IN_FLIGHT.store(false, Ordering::Release);
+    }
+}
+
+/// Wipes the Rust-owned copy of a verification password when it goes out of scope.
+///
+/// It borrows rather than owns so a test can keep the allocation alive and read
+/// it back after the wipe instead of inspecting freed memory.
+struct PasswordGuard<'a> {
+    password: &'a mut String,
+}
+
+impl<'a> PasswordGuard<'a> {
+    fn new(password: &'a mut String) -> Self {
+        Self { password }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.password.as_bytes()
+    }
+}
+
+impl Drop for PasswordGuard<'_> {
+    fn drop(&mut self) {
+        self.password.zeroize();
+    }
+}
+
+fn scan_decimal(name: &str, value: &str) -> Result<u32, CryptoError> {
+    if value.is_empty() || !value.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(policy_error(format!(
+            "parameter {name:?} is not a decimal number"
+        )));
+    }
+
+    // A leading zero would give one work factor two spellings, and the PHC
+    // parser rejects it further down, so reject it here where the error is typed.
+    if value.len() > 1 && value.starts_with('0') {
+        return Err(policy_error(format!(
+            "parameter {name:?} has a leading zero"
+        )));
+    }
+
+    value
+        .parse::<u32>()
+        .map_err(|_| policy_error(format!("parameter {name:?} does not fit in 32 bits")))
+}
+
+fn scan_work_factors(field: &str) -> Result<(u32, u32, u32), CryptoError> {
+    // The PHC parser reads a field without '=' as the salt, which would leave
+    // the work factors at library defaults instead of the ones we checked.
+    if !field.contains('=') {
+        return Err(policy_error("PHC string carries no Argon2 parameters"));
+    }
+
+    let (mut m_cost, mut t_cost, mut p_cost) = (None, None, None);
+
+    for pair in field.split(',') {
+        let (name, value) = pair
+            .split_once('=')
+            .ok_or_else(|| policy_error(format!("malformed parameter {pair:?}")))?;
+
+        let slot = match name {
+            "m" => &mut m_cost,
+            "t" => &mut t_cost,
+            "p" => &mut p_cost,
+            other => return Err(policy_error(format!("unsupported parameter {other:?}"))),
+        };
+
+        // The PHC parser keeps duplicates and the verifier takes the last one,
+        // while a reader checking the first would see a different work factor.
+        if slot.is_some() {
+            return Err(policy_error(format!("duplicate parameter {name:?}")));
+        }
+
+        *slot = Some(scan_decimal(name, value)?);
+    }
+
+    let m_cost = m_cost.ok_or_else(|| policy_error("missing parameter \"m\""))?;
+    let t_cost = t_cost.ok_or_else(|| policy_error("missing parameter \"t\""))?;
+    let p_cost = p_cost.ok_or_else(|| policy_error("missing parameter \"p\""))?;
+
+    if !(1..=MAX_VERIFY_LANES).contains(&p_cost) {
+        return Err(policy_error(format!(
+            "lanes {p_cost} outside 1..={MAX_VERIFY_LANES}"
+        )));
+    }
+
+    if !(1..=MAX_VERIFY_ITERATIONS).contains(&t_cost) {
+        return Err(policy_error(format!(
+            "iterations {t_cost} outside 1..={MAX_VERIFY_ITERATIONS}"
+        )));
+    }
+
+    if m_cost > MAX_VERIFY_MEMORY_KIB {
+        return Err(policy_error(format!(
+            "memory {m_cost} KiB above {MAX_VERIFY_MEMORY_KIB} KiB"
+        )));
+    }
+
+    if u64::from(m_cost) < u64::from(p_cost) * KIB_PER_LANE {
+        return Err(policy_error(format!(
+            "memory {m_cost} KiB below the {KIB_PER_LANE} KiB each of {p_cost} lanes needs"
+        )));
+    }
+
+    Ok((m_cost, t_cost, p_cost))
+}
+
+fn scan_b64_len(label: &str, field: &str) -> Result<usize, CryptoError> {
+    if !field
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'/')
+    {
+        return Err(malformed_error(format!(
+            "Invalid PHC string: {label} is not unpadded B64"
+        )));
+    }
+
+    let whole = field.len() / 4 * 3;
+    match field.len() % 4 {
+        0 => Ok(whole),
+        2 => Ok(whole + 1),
+        3 => Ok(whole + 2),
+        // Unpadded B64 never leaves a single trailing character.
+        _ => Err(malformed_error(format!(
+            "Invalid PHC string: {label} has an impossible B64 length"
+        ))),
+    }
+}
+
+/// Reads the work factors and encoded lengths out of a PHC string.
+///
+/// Every value comes back as a checked integer, so nothing here builds a
+/// verifier or reserves an Argon2 block.
+fn scan_phc(phc_hash: &str) -> Result<(u32, u32, u32, usize, usize), CryptoError> {
+    if phc_hash.len() > MAX_VERIFY_PHC_BYTES {
+        return Err(policy_error(format!(
+            "PHC string is {} bytes, above {MAX_VERIFY_PHC_BYTES}",
+            phc_hash.len()
+        )));
+    }
+
+    let mut fields = phc_hash.split('$');
+
+    if fields.next() != Some("") {
+        return Err(malformed_error(
+            "Invalid PHC string: missing leading separator",
+        ));
+    }
+
+    let algorithm = fields
+        .next()
+        .ok_or_else(|| malformed_error("Invalid PHC string: missing algorithm field"))?;
+    if algorithm != SUPPORTED_ALGORITHM {
+        return Err(policy_error(format!(
+            "unsupported algorithm identifier {algorithm:?}"
+        )));
+    }
+
+    // Only the canonical spelling of version 19 is accepted, so no other
+    // encoding of the same number can slip past as a different version.
+    let version = fields
+        .next()
+        .ok_or_else(|| policy_error("missing version field"))?;
+    if version != SUPPORTED_VERSION_FIELD {
+        return Err(policy_error(format!(
+            "unsupported version field {version:?}"
+        )));
+    }
+
+    let work_factors = fields
+        .next()
+        .ok_or_else(|| policy_error("missing parameter field"))?;
+    let (m_cost, t_cost, p_cost) = scan_work_factors(work_factors)?;
+
+    let salt = fields
+        .next()
+        .ok_or_else(|| policy_error("missing salt field"))?;
+    let salt_bytes = scan_b64_len("salt", salt)?;
+    if !(MIN_VERIFY_SALT_BYTES..=MAX_VERIFY_SALT_BYTES).contains(&salt_bytes) {
+        return Err(policy_error(format!(
+            "salt of {salt_bytes} bytes outside {MIN_VERIFY_SALT_BYTES}..={MAX_VERIFY_SALT_BYTES}"
+        )));
+    }
+
+    let output = fields
+        .next()
+        .ok_or_else(|| policy_error("missing hash output field"))?;
+    let output_bytes = scan_b64_len("hash output", output)?;
+    if !(MIN_VERIFY_OUTPUT_BYTES..=MAX_VERIFY_OUTPUT_BYTES).contains(&output_bytes) {
+        return Err(policy_error(format!(
+            "hash output of {output_bytes} bytes outside {MIN_VERIFY_OUTPUT_BYTES}..={MAX_VERIFY_OUTPUT_BYTES}"
+        )));
+    }
+
+    if fields.next().is_some() {
+        return Err(malformed_error("Invalid PHC string: trailing data"));
+    }
+
+    Ok((m_cost, t_cost, p_cost, salt_bytes, output_bytes))
+}
+
+/// Validates a PHC string and returns the parameters the verifier will consume.
+///
+/// The hand-written scan produces the typed policy errors, then the PHC parser
+/// runs and both readings are compared. A verifier is never built from a string
+/// the two disagree about.
+fn parse_within_policy(phc_hash: &str) -> Result<(Params, PasswordHash<'_>), CryptoError> {
+    let (m_cost, t_cost, p_cost, salt_bytes, output_bytes) = scan_phc(phc_hash)?;
+
+    let parsed = PasswordHash::new(phc_hash)
+        .map_err(|e| CryptoError::InvalidParameter(format!("Invalid PHC string: {}", e)))?;
+
+    if parsed.algorithm.as_str() != SUPPORTED_ALGORITHM {
+        return Err(policy_error(format!(
+            "unsupported algorithm identifier {:?}",
+            parsed.algorithm.as_str()
+        )));
+    }
+
+    if parsed.version != Some(SUPPORTED_VERSION) {
+        return Err(policy_error("unsupported Argon2 version"));
+    }
+
+    // `Params::try_from` is what the verifier itself calls, so this is the exact
+    // parameter set the Argon2 run would use.
+    let params = Params::try_from(&parsed)
+        .map_err(|e| policy_error(format!("unsupported Argon2 parameters: {}", e)))?;
+
+    if params.m_cost() != m_cost
+        || params.t_cost() != t_cost
+        || params.p_cost() != p_cost
+        || params.output_len() != Some(output_bytes)
+    {
+        return Err(policy_error(
+            "PHC parameters disagree with the validated policy",
+        ));
+    }
+
+    let salt = parsed
+        .salt
+        .ok_or_else(|| policy_error("missing salt field"))?;
+    let mut decoded_salt = [0u8; MAX_VERIFY_SALT_BYTES];
+    let decoded_len = salt
+        .decode_b64(&mut decoded_salt)
+        .map_err(|e| malformed_error(format!("Invalid PHC salt: {}", e)))?
+        .len();
+
+    if decoded_len != salt_bytes {
+        return Err(policy_error("PHC salt disagrees with the validated policy"));
+    }
+
+    Ok((params, parsed))
+}
+
+fn verify_within_policy(phc_hash: &str, password: &PasswordGuard<'_>) -> Result<(), CryptoError> {
+    let password_bytes = password.as_bytes();
+    if password_bytes.len() > MAX_VERIFY_PASSWORD_BYTES {
+        return Err(policy_error(format!(
+            "password is {} bytes, above {MAX_VERIFY_PASSWORD_BYTES}",
+            password_bytes.len()
+        )));
+    }
+
+    let (params, parsed) = parse_within_policy(phc_hash)?;
+
+    // Taken only once the input is inside policy, so a rejected request never
+    // makes a legitimate caller wait for a permit it will not use.
+    let _permit = VerificationPermit::try_acquire().ok_or(CryptoError::Argon2VerificationBusy)?;
+
+    Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+        .verify_password(password_bytes, &parsed)
+        .map_err(|_| CryptoError::AuthenticationFailed)
+}
 
 /// Platform-appropriate parameter presets for Argon2id.
 pub enum Argon2Preset {
@@ -66,23 +401,177 @@ pub fn argon2id_hash_with_salt(
 
 /// Verify a password against an Argon2id PHC hash string.
 ///
+/// The hash must be Argon2id version 19 within the published verification
+/// limits, and the password must be at most 1024 UTF-8 bytes. A hash outside
+/// those limits returns `Err(CryptoError::Argon2PolicyViolation)`, and one that
+/// is not a well-formed PHC string returns `Err(CryptoError::InvalidParameter)`.
+/// Both come back before any Argon2 memory is reserved. One verification runs
+/// at a time; a caller arriving during another one gets
+/// `Err(CryptoError::Argon2VerificationBusy)` rather than waiting.
+///
 /// Returns `Ok(())` if the password matches, or
 /// `Err(CryptoError::AuthenticationFailed)` if it does not.
 pub fn argon2id_verify(phc_hash: String, password: String) -> Result<(), CryptoError> {
-    let parsed = PasswordHash::new(&phc_hash)
-        .map_err(|e| CryptoError::InvalidParameter(format!("Invalid PHC string: {}", e)))?;
+    let mut password = password;
+    let password = PasswordGuard::new(&mut password);
 
-    // Extract params from the PHC string to reconstruct the hasher
-    let argon2 = Argon2::default();
-
-    argon2
-        .verify_password(password.as_bytes(), &parsed)
-        .map_err(|_| CryptoError::AuthenticationFailed)
+    verify_within_policy(&phc_hash, &password)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, MutexGuard};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
     use super::*;
+    use crate::core::alloc_probe;
+
+    // The permit is process wide, so tests whose outcome depends on holding it
+    // must not overlap with each other.
+    static VERIFY_SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serialized() -> MutexGuard<'static, ()> {
+        VERIFY_SERIAL
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    const B64_ALPHABET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    const CANONICAL_PARAMS: &str = "m=65536,t=3,p=4";
+
+    // Hashes of VECTOR_PASSWORD produced by the released presets, kept here so
+    // the compatibility cases verify shipped output instead of output this run
+    // just made. The desktop vector sits on the memory ceiling.
+    const VECTOR_PASSWORD: &str = "preset_vector";
+    const MOBILE_VECTOR: &str =
+        "$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k";
+    const DESKTOP_VECTOR: &str =
+        "$argon2id$v=19$m=262144,t=4,p=8$c29tZXNhbHQ$vMcxuT3HOzm0fXlb+51TYzxiWAK1mSnVS6PqVB761FI";
+
+    fn b64(bytes: &[u8]) -> String {
+        let mut encoded = String::new();
+
+        for chunk in bytes.chunks(3) {
+            let packed = (u32::from(chunk[0]) << 16)
+                | (u32::from(*chunk.get(1).unwrap_or(&0)) << 8)
+                | u32::from(*chunk.get(2).unwrap_or(&0));
+
+            for position in 0..chunk.len() + 1 {
+                let index = (packed >> (18 - 6 * position)) as usize & 63;
+                encoded.push(char::from(B64_ALPHABET[index]));
+            }
+        }
+
+        encoded
+    }
+
+    fn b64_of_len(decoded_len: usize) -> String {
+        b64(&(0..decoded_len).map(|i| i as u8).collect::<Vec<u8>>())
+    }
+
+    fn phc(params: &str, salt: &str, output: &str) -> String {
+        format!("$argon2id$v=19${params}${salt}${output}")
+    }
+
+    fn canonical_phc() -> String {
+        phc(CANONICAL_PARAMS, &b64_of_len(16), &b64_of_len(32))
+    }
+
+    fn policy_outcome(phc_hash: &str) -> Result<Params, CryptoError> {
+        parse_within_policy(phc_hash).map(|(params, _)| params)
+    }
+
+    // Rejection cases are checked twice: once against the validator, and once
+    // against the exported entry point, so a check inserted between the two
+    // cannot change the public verdict while these still pass. Rejected input
+    // never takes the permit, so neither call needs serializing.
+    fn assert_policy_rejects(case: &str, phc_hash: &str) {
+        match policy_outcome(phc_hash) {
+            Err(CryptoError::Argon2PolicyViolation(_)) => {}
+            other => panic!("{case}: expected a policy violation, got {other:?}"),
+        }
+
+        match argon2id_verify(phc_hash.to_string(), "password".into()) {
+            Err(CryptoError::Argon2PolicyViolation(_)) => {}
+            other => panic!("{case}: exported entry point gave {other:?}"),
+        }
+    }
+
+    fn assert_malformed(case: &str, phc_hash: &str) {
+        match policy_outcome(phc_hash) {
+            Err(CryptoError::InvalidParameter(_)) => {}
+            other => panic!("{case}: expected an invalid parameter error, got {other:?}"),
+        }
+
+        match argon2id_verify(phc_hash.to_string(), "password".into()) {
+            Err(CryptoError::InvalidParameter(_)) => {}
+            other => panic!("{case}: exported entry point gave {other:?}"),
+        }
+    }
+
+    fn assert_accepted(case: &str, phc_hash: &str) {
+        if let Err(e) = policy_outcome(phc_hash) {
+            panic!("{case}: expected acceptance, got {e:?}");
+        }
+    }
+
+    fn rejected_corpus() -> Vec<String> {
+        let salt = b64_of_len(16);
+        let output = b64_of_len(32);
+        let with_params = |params: &str| phc(params, &salt, &output);
+
+        vec![
+            "not_a_phc_string".to_string(),
+            "$".repeat(8),
+            format!("$argon2i$v=19${CANONICAL_PARAMS}${salt}${output}"),
+            format!("$argon2d$v=19${CANONICAL_PARAMS}${salt}${output}"),
+            format!("$argon2id$v=16${CANONICAL_PARAMS}${salt}${output}"),
+            format!("$argon2id$v=20${CANONICAL_PARAMS}${salt}${output}"),
+            format!("$argon2id${CANONICAL_PARAMS}${salt}${output}"),
+            with_params("m=262145,t=3,p=4"),
+            with_params("m=4294967296,t=3,p=4"),
+            with_params("m=99999999999999999999,t=3,p=4"),
+            with_params("m=65536,t=5,p=4"),
+            with_params("m=65536,t=3,p=9"),
+            with_params("m=262144,t=3,p=4294967295"),
+            with_params("m=65536,t=3,p=4,m=262144"),
+            with_params("m=65536,t=3"),
+            with_params("m=65536,t=3,p=4,keyid=Zm9v"),
+            with_params("m=abc,t=3,p=4"),
+            phc(CANONICAL_PARAMS, &b64_of_len(7), &output),
+            phc(CANONICAL_PARAMS, &b64_of_len(65), &output),
+            phc(CANONICAL_PARAMS, &salt, &b64_of_len(15)),
+            phc(CANONICAL_PARAMS, &salt, &b64_of_len(65)),
+            phc(CANONICAL_PARAMS, "", &output),
+            phc(CANONICAL_PARAMS, &salt, ""),
+            format!("{}$AAAA", canonical_phc()),
+            format!(
+                "$argon2id$v=19${CANONICAL_PARAMS}${salt}${}",
+                "A".repeat(MAX_VERIFY_PHC_BYTES)
+            ),
+        ]
+    }
+
+    fn verify_and_observe_wipe(
+        phc_hash: &str,
+        password: &str,
+    ) -> (Result<(), CryptoError>, Vec<u8>) {
+        let mut owned = String::from(password);
+        let len = owned.len();
+
+        let outcome = {
+            let guard = PasswordGuard::new(&mut owned);
+            verify_within_policy(phc_hash, &guard)
+        };
+
+        // The wipe clears the length but keeps the allocation, so this reads
+        // bytes the test still owns rather than freed memory.
+        let observed = unsafe { std::slice::from_raw_parts(owned.as_ptr(), len) }.to_vec();
+        (outcome, observed)
+    }
 
     #[test]
     fn test_hash_produces_phc_string() {
@@ -117,6 +606,7 @@ mod tests {
 
     #[test]
     fn test_verify_correct_password() {
+        let _serial = serialized();
         let hash = argon2id_hash("correct_password".into(), Argon2Preset::Mobile)
             .expect("hashing should succeed");
 
@@ -126,6 +616,7 @@ mod tests {
 
     #[test]
     fn test_verify_wrong_password() {
+        let _serial = serialized();
         let hash = argon2id_hash("correct_password".into(), Argon2Preset::Mobile)
             .expect("hashing should succeed");
 
@@ -170,6 +661,7 @@ mod tests {
 
     #[test]
     fn test_hash_with_salt_verify_roundtrip() {
+        let _serial = serialized();
         let salt = "c29tZXNhbHQ";
 
         let hash = argon2id_hash_with_salt("mypassword".into(), salt.into(), Argon2Preset::Mobile)
@@ -216,10 +708,441 @@ mod tests {
 
     #[test]
     fn test_empty_password_hashes() {
+        let _serial = serialized();
         // Empty password is valid — Argon2id should handle it
         let hash =
             argon2id_hash(String::new(), Argon2Preset::Mobile).expect("empty password should hash");
         assert!(hash.starts_with("$argon2id$"));
         assert!(argon2id_verify(hash, String::new()).is_ok());
+    }
+
+    #[test]
+    fn phc_length_boundary_flips_at_the_ceiling() {
+        let base = canonical_phc();
+
+        for target in [MAX_VERIFY_PHC_BYTES - 1, MAX_VERIFY_PHC_BYTES] {
+            let padded = format!("{base}${}", "A".repeat(target - base.len() - 1));
+            assert_eq!(padded.len(), target);
+            // Inside the ceiling the string is still read, and rejected for the
+            // extra field rather than for its size.
+            assert_malformed(&format!("{target}-byte PHC string"), &padded);
+        }
+
+        let target = MAX_VERIFY_PHC_BYTES + 1;
+        let padded = format!("{base}${}", "A".repeat(target - base.len() - 1));
+        assert_eq!(padded.len(), target);
+
+        match policy_outcome(&padded) {
+            Err(CryptoError::Argon2PolicyViolation(reason)) => {
+                assert!(reason.contains("1025 bytes"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected a length policy violation, got {other:?}"),
+        }
+
+        assert_policy_rejects("1025-byte PHC string", &padded);
+    }
+
+    #[test]
+    fn password_length_boundary_flips_at_the_ceiling() {
+        let _serial = serialized();
+
+        for len in [MAX_VERIFY_PASSWORD_BYTES - 1, MAX_VERIFY_PASSWORD_BYTES] {
+            let password = "a".repeat(len);
+            assert_eq!(password.len(), len);
+
+            match argon2id_verify(MOBILE_VECTOR.into(), password) {
+                Err(CryptoError::AuthenticationFailed) => {}
+                other => {
+                    panic!("{len}-byte password: expected an authentication failure, got {other:?}")
+                }
+            }
+        }
+
+        match argon2id_verify(
+            MOBILE_VECTOR.into(),
+            "a".repeat(MAX_VERIFY_PASSWORD_BYTES + 1),
+        ) {
+            Err(CryptoError::Argon2PolicyViolation(reason)) => {
+                assert!(reason.contains("1025 bytes"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected a length policy violation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn password_ceiling_counts_utf8_bytes_not_characters() {
+        let password = "€".repeat(512);
+
+        assert_eq!(password.chars().count(), 512);
+        assert_eq!(password.len(), 1536);
+
+        match argon2id_verify(MOBILE_VECTOR.into(), password) {
+            Err(CryptoError::Argon2PolicyViolation(reason)) => {
+                assert!(reason.contains("1536 bytes"), "unexpected reason: {reason}");
+            }
+            other => panic!("expected a length policy violation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn salt_length_boundaries() {
+        let output = b64_of_len(32);
+
+        assert_policy_rejects(
+            "7-byte salt",
+            &phc(CANONICAL_PARAMS, &b64_of_len(7), &output),
+        );
+        assert_accepted(
+            "8-byte salt",
+            &phc(CANONICAL_PARAMS, &b64_of_len(8), &output),
+        );
+        assert_accepted(
+            "9-byte salt",
+            &phc(CANONICAL_PARAMS, &b64_of_len(9), &output),
+        );
+        assert_policy_rejects(
+            "65-byte salt",
+            &phc(CANONICAL_PARAMS, &b64_of_len(65), &output),
+        );
+
+        // 63 and 64 decoded bytes sit inside the stated ceiling but need more
+        // than the 64 encoded characters the PHC parser takes, so they are
+        // rejected there instead. Neither reaches a verifier.
+        for len in [63, 64] {
+            assert_malformed(
+                &format!("{len}-byte salt"),
+                &phc(CANONICAL_PARAMS, &b64_of_len(len), &output),
+            );
+        }
+    }
+
+    #[test]
+    fn output_length_boundaries() {
+        let salt = b64_of_len(16);
+
+        assert_policy_rejects(
+            "15-byte output",
+            &phc(CANONICAL_PARAMS, &salt, &b64_of_len(15)),
+        );
+
+        for len in [16, 17, 63, 64] {
+            assert_accepted(
+                &format!("{len}-byte output"),
+                &phc(CANONICAL_PARAMS, &salt, &b64_of_len(len)),
+            );
+        }
+
+        assert_policy_rejects(
+            "65-byte output",
+            &phc(CANONICAL_PARAMS, &salt, &b64_of_len(65)),
+        );
+    }
+
+    #[test]
+    fn empty_and_malformed_salt_and_output_encodings_reject() {
+        let salt = b64_of_len(16);
+        let output = b64_of_len(32);
+
+        assert_policy_rejects("empty salt", &phc(CANONICAL_PARAMS, "", &output));
+        assert_policy_rejects("empty output", &phc(CANONICAL_PARAMS, &salt, ""));
+        assert_malformed(
+            "salt outside the B64 alphabet",
+            &phc(CANONICAL_PARAMS, "not+b64!", &output),
+        );
+        assert_malformed(
+            "output outside the B64 alphabet",
+            &phc(CANONICAL_PARAMS, &salt, "****"),
+        );
+        assert_malformed(
+            "impossible salt length",
+            &phc(CANONICAL_PARAMS, "AAAAA", &output),
+        );
+        assert_malformed(
+            "impossible output length",
+            &phc(CANONICAL_PARAMS, &salt, "AAAAAAAAA"),
+        );
+    }
+
+    #[test]
+    fn only_argon2id_is_accepted() {
+        let tail = format!(
+            "v=19${CANONICAL_PARAMS}${}${}",
+            b64_of_len(16),
+            b64_of_len(32)
+        );
+
+        assert_accepted("argon2id", &format!("$argon2id${tail}"));
+
+        for algorithm in ["argon2i", "argon2d", "argon2", "argon2ID", "scrypt", ""] {
+            assert_policy_rejects(
+                &format!("{algorithm:?} algorithm"),
+                &format!("${algorithm}${tail}"),
+            );
+        }
+    }
+
+    #[test]
+    fn only_version_19_is_accepted() {
+        let salt = b64_of_len(16);
+        let output = b64_of_len(32);
+
+        assert_accepted("v=19", &phc(CANONICAL_PARAMS, &salt, &output));
+
+        for version in ["v=16", "v=20", "v=0", "v=019", "v=abc", "v=", "version=19"] {
+            assert_policy_rejects(
+                &format!("{version:?}"),
+                &format!("$argon2id${version}${CANONICAL_PARAMS}${salt}${output}"),
+            );
+        }
+
+        // With no version field the parameters sit where the version belongs.
+        assert_policy_rejects(
+            "missing version",
+            &format!("$argon2id${CANONICAL_PARAMS}${salt}${output}"),
+        );
+    }
+
+    #[test]
+    fn work_factor_boundaries() {
+        let salt = b64_of_len(16);
+        let output = b64_of_len(32);
+        let with_params = |params: &str| phc(params, &salt, &output);
+
+        assert_accepted("memory 262143 KiB", &with_params("m=262143,t=3,p=4"));
+        assert_accepted("memory 262144 KiB", &with_params("m=262144,t=3,p=4"));
+        assert_policy_rejects("memory 262145 KiB", &with_params("m=262145,t=3,p=4"));
+
+        assert_accepted("3 iterations", &with_params("m=65536,t=3,p=4"));
+        assert_accepted("4 iterations", &with_params("m=65536,t=4,p=4"));
+        assert_policy_rejects("5 iterations", &with_params("m=65536,t=5,p=4"));
+
+        assert_accepted("7 lanes", &with_params("m=65536,t=3,p=7"));
+        assert_accepted("8 lanes", &with_params("m=65536,t=3,p=8"));
+        assert_policy_rejects("9 lanes", &with_params("m=65536,t=3,p=9"));
+
+        assert_policy_rejects("zero iterations", &with_params("m=65536,t=0,p=4"));
+        assert_policy_rejects("zero lanes", &with_params("m=65536,t=3,p=0"));
+        assert_policy_rejects("memory below the lane floor", &with_params("m=8,t=3,p=4"));
+    }
+
+    #[test]
+    fn overflowing_duplicate_missing_and_unknown_parameters_reject() {
+        let salt = b64_of_len(16);
+        let output = b64_of_len(32);
+        let with_params = |params: &str| phc(params, &salt, &output);
+
+        for params in [
+            "m=4294967296,t=3,p=4",
+            "m=99999999999999999999,t=3,p=4",
+            "m=65536,t=4294967296,p=4",
+            "m=65536,t=3,p=99999999999",
+        ] {
+            assert_policy_rejects(&format!("overflow in {params:?}"), &with_params(params));
+        }
+
+        for params in [
+            "m=65536,t=3,p=4,m=262144",
+            "m=8,m=4194304,t=3,p=4",
+            "m=65536,t=3,t=3,p=4",
+        ] {
+            assert_policy_rejects(&format!("duplicate in {params:?}"), &with_params(params));
+        }
+
+        for params in ["t=3,p=4", "m=65536,p=4", "m=65536,t=3", "m=65536"] {
+            assert_policy_rejects(
+                &format!("missing parameter in {params:?}"),
+                &with_params(params),
+            );
+        }
+
+        for params in [
+            "m=65536,t=3,p=4,keyid=Zm9v",
+            "m=65536,t=3,p=4,data=Zm9v",
+            "m=65536,t=3,p=4,x=1",
+        ] {
+            assert_policy_rejects(
+                &format!("unknown parameter in {params:?}"),
+                &with_params(params),
+            );
+        }
+
+        for params in [
+            "m=,t=3,p=4",
+            "m=abc,t=3,p=4",
+            "m=065536,t=3,p=4",
+            "m=-1,t=3,p=4",
+            "m,t=3,p=4",
+            "m=65536,,t=3,p=4",
+        ] {
+            assert_policy_rejects(
+                &format!("malformed parameter in {params:?}"),
+                &with_params(params),
+            );
+        }
+    }
+
+    #[test]
+    fn a_huge_lane_count_is_rejected_before_the_argon2_parameter_check() {
+        // The crate's own check multiplies the lane count by eight before it
+        // range-tests the value, which overflows for this input.
+        let phc_hash = phc(
+            "m=262144,t=3,p=4294967295",
+            &b64_of_len(16),
+            &b64_of_len(32),
+        );
+
+        assert_policy_rejects("u32::MAX lanes", &phc_hash);
+
+        match argon2id_verify(phc_hash, "password".into()) {
+            Err(CryptoError::Argon2PolicyViolation(_)) => {}
+            other => panic!("expected a policy violation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejected_input_never_reserves_argon2_memory() {
+        // Three orders of magnitude below the smallest preset's 64 MiB block.
+        const REJECTION_BUDGET: u64 = 64 * 1024;
+
+        for phc_hash in rejected_corpus() {
+            let (outcome, requested) = alloc_probe::requested_bytes(|| {
+                argon2id_verify(phc_hash.clone(), "password".into())
+            });
+
+            assert!(outcome.is_err(), "{phc_hash:?} was not rejected");
+            assert!(
+                requested < REJECTION_BUDGET,
+                "{phc_hash:?} requested {requested} bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn an_accepted_verification_reserves_the_argon2_block() {
+        let _serial = serialized();
+
+        let (outcome, requested) = alloc_probe::requested_bytes(|| {
+            argon2id_verify(MOBILE_VECTOR.into(), VECTOR_PASSWORD.into())
+        });
+
+        assert!(outcome.is_ok(), "verification failed: {outcome:?}");
+        // The mobile preset reserves 64 MiB, so the probe would see it if any
+        // rejection path ever reached this far.
+        assert!(
+            requested >= 64 * 1024 * 1024,
+            "only {requested} bytes requested"
+        );
+    }
+
+    #[test]
+    fn rejection_returns_without_running_a_verification() {
+        // Argon2 at the ceiling needs hundreds of milliseconds even in release,
+        // so this only shows no verification ran. The tighter budget in the
+        // requirement belongs to a resource-controlled harness, not this suite.
+        const REJECTION_GUARD: Duration = Duration::from_millis(200);
+
+        for phc_hash in rejected_corpus() {
+            let started = Instant::now();
+            let outcome = argon2id_verify(phc_hash.clone(), "password".into());
+            let elapsed = started.elapsed();
+
+            assert!(outcome.is_err(), "{phc_hash:?} was not rejected");
+            assert!(elapsed < REJECTION_GUARD, "{phc_hash:?} took {elapsed:?}");
+        }
+    }
+
+    #[test]
+    fn released_preset_vectors_verify_within_policy() {
+        let _serial = serialized();
+
+        for vector in [MOBILE_VECTOR, DESKTOP_VECTOR] {
+            assert!(
+                argon2id_verify(vector.into(), VECTOR_PASSWORD.into()).is_ok(),
+                "released vector {vector} did not verify"
+            );
+
+            match argon2id_verify(vector.into(), "wrong_password".into()) {
+                Err(CryptoError::AuthenticationFailed) => {}
+                other => panic!("{vector}: expected an authentication failure, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn the_verification_permit_is_exclusive_and_returned_on_drop() {
+        let _serial = serialized();
+
+        let held = VerificationPermit::try_acquire().expect("permit should be free");
+        assert!(VerificationPermit::try_acquire().is_none());
+
+        drop(held);
+        assert!(VerificationPermit::try_acquire().is_some());
+    }
+
+    #[test]
+    fn a_verification_arriving_during_another_one_is_busy() {
+        let _serial = serialized();
+
+        let stop = AtomicBool::new(false);
+        let mut saw_busy = false;
+
+        thread::scope(|scope| {
+            let keeper = scope.spawn(|| {
+                while !stop.load(Ordering::Acquire) {
+                    let _ = argon2id_verify(MOBILE_VECTOR.into(), VECTOR_PASSWORD.into());
+                }
+            });
+
+            let deadline = Instant::now() + Duration::from_secs(30);
+            while Instant::now() < deadline {
+                if matches!(
+                    argon2id_verify(MOBILE_VECTOR.into(), VECTOR_PASSWORD.into()),
+                    Err(CryptoError::Argon2VerificationBusy)
+                ) {
+                    saw_busy = true;
+                    break;
+                }
+            }
+
+            stop.store(true, Ordering::Release);
+            keeper.join().expect("keeper thread panicked");
+        });
+
+        assert!(saw_busy, "no contender ever saw a busy result");
+        assert!(
+            argon2id_verify(MOBILE_VECTOR.into(), VECTOR_PASSWORD.into()).is_ok(),
+            "the permit was not released"
+        );
+    }
+
+    #[test]
+    fn the_verification_password_is_wiped_on_every_outcome() {
+        let _serial = serialized();
+
+        let (success, wiped) = verify_and_observe_wipe(MOBILE_VECTOR, VECTOR_PASSWORD);
+        assert!(success.is_ok(), "verification failed: {success:?}");
+        assert!(wiped.iter().all(|&b| b == 0), "success left {wiped:?}");
+
+        let (mismatch, wiped) = verify_and_observe_wipe(MOBILE_VECTOR, "wrong_password");
+        assert!(matches!(mismatch, Err(CryptoError::AuthenticationFailed)));
+        assert!(wiped.iter().all(|&b| b == 0), "mismatch left {wiped:?}");
+
+        let over_limit = "a".repeat(MAX_VERIFY_PASSWORD_BYTES + 1);
+        let (rejected, wiped) = verify_and_observe_wipe(MOBILE_VECTOR, &over_limit);
+        assert!(matches!(
+            rejected,
+            Err(CryptoError::Argon2PolicyViolation(_))
+        ));
+        assert!(wiped.iter().all(|&b| b == 0), "policy error left bytes");
+
+        let (unparsed, wiped) = verify_and_observe_wipe("not_a_phc_string", VECTOR_PASSWORD);
+        assert!(matches!(unparsed, Err(CryptoError::InvalidParameter(_))));
+        assert!(wiped.iter().all(|&b| b == 0), "parse error left {wiped:?}");
+
+        let held = VerificationPermit::try_acquire().expect("permit should be free");
+        let (busy, wiped) = verify_and_observe_wipe(MOBILE_VECTOR, VECTOR_PASSWORD);
+        drop(held);
+        assert!(matches!(busy, Err(CryptoError::Argon2VerificationBusy)));
+        assert!(wiped.iter().all(|&b| b == 0), "busy return left {wiped:?}");
     }
 }

--- a/rust/src/core/alloc_probe.rs
+++ b/rust/src/core/alloc_probe.rs
@@ -1,0 +1,114 @@
+//! Test-only allocation accounting.
+//!
+//! Counts the bytes a single thread asks the allocator for, so a test can show
+//! that a rejected request never reaches an expensive allocation instead of
+//! only showing that it returned an error.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+thread_local! {
+    static MEASURING: Cell<bool> = const { Cell::new(false) };
+    static REQUESTED: Cell<u64> = const { Cell::new(0) };
+}
+
+#[global_allocator]
+static PROBE: CountingAllocator = CountingAllocator;
+
+pub struct CountingAllocator;
+
+// Both cells are `const`-initialised and hold no destructor, so reading them
+// from inside the allocator cannot allocate or re-enter.
+fn record(size: usize) {
+    let counted = MEASURING.try_with(Cell::get).unwrap_or(false);
+    if counted {
+        let _ = REQUESTED.try_with(|total| total.set(total.get().saturating_add(size as u64)));
+    }
+}
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            record(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            record(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let grown = System.realloc(ptr, layout, new_size);
+        if !grown.is_null() {
+            record(new_size.saturating_sub(layout.size()));
+        }
+        grown
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout)
+    }
+}
+
+struct MeasurementGuard;
+
+impl Drop for MeasurementGuard {
+    fn drop(&mut self) {
+        MEASURING.with(|measuring| measuring.set(false));
+    }
+}
+
+/// Runs `f` and reports how many bytes it requested on the calling thread.
+///
+/// The total is cumulative rather than a live peak, so a freed allocation still
+/// counts and the figure can never understate what `f` reserved.
+pub fn requested_bytes<R>(f: impl FnOnce() -> R) -> (R, u64) {
+    REQUESTED.with(|total| total.set(0));
+    MEASURING.with(|measuring| measuring.set(true));
+    let guard = MeasurementGuard;
+
+    let result = f();
+
+    drop(guard);
+    (result, REQUESTED.with(Cell::get))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counts_a_known_allocation() {
+        let (buffer, requested) = requested_bytes(|| vec![0u8; 4 * 1024 * 1024]);
+
+        assert_eq!(buffer.len(), 4 * 1024 * 1024);
+        assert!(
+            requested >= 4 * 1024 * 1024,
+            "probe missed the allocation, saw {requested} bytes"
+        );
+    }
+
+    #[test]
+    fn reports_almost_nothing_for_work_that_does_not_allocate() {
+        let (sum, requested) = requested_bytes(|| (0u64..1000).sum::<u64>());
+
+        assert_eq!(sum, 499_500);
+        assert!(requested < 4096, "unexpected {requested} bytes requested");
+    }
+
+    #[test]
+    fn stops_counting_after_the_measured_call() {
+        let (_, first) = requested_bytes(|| vec![0u8; 1024 * 1024]);
+        let _outside = vec![0u8; 8 * 1024 * 1024];
+        let (_, second) = requested_bytes(|| ());
+
+        assert!(first >= 1024 * 1024);
+        assert!(second < 4096, "counting leaked, saw {second} bytes");
+    }
+}

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -58,6 +58,12 @@ pub enum CryptoError {
 
     #[error("Import failed: {0}")]
     ImportFailed(String),
+
+    #[error("Argon2 policy violation: {0}")]
+    Argon2PolicyViolation(String),
+
+    #[error("Another Argon2 verification is already in progress")]
+    Argon2VerificationBusy,
 }
 
 impl From<std::io::Error> for CryptoError {

--- a/rust/src/core/mod.rs
+++ b/rust/src/core/mod.rs
@@ -3,6 +3,8 @@
 //! This module contains the foundational types used throughout the crate.
 //! It is not exposed to FRB - only api/ modules are scanned for bindings.
 
+#[cfg(test)]
+pub mod alloc_probe;
 pub mod compression;
 pub mod error;
 pub mod evfs;

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -2145,6 +2145,13 @@ impl SseDecode for crate::core::error::CryptoError {
                 let mut var_field0 = <String>::sse_decode(deserializer);
                 return crate::core::error::CryptoError::ImportFailed(var_field0);
             }
+            18 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::core::error::CryptoError::Argon2PolicyViolation(var_field0);
+            }
+            19 => {
+                return crate::core::error::CryptoError::Argon2VerificationBusy;
+            }
             _ => {
                 unimplemented!("");
             }
@@ -2594,6 +2601,10 @@ impl flutter_rust_bridge::IntoDart for crate::core::error::CryptoError {
             crate::core::error::CryptoError::ImportFailed(field0) => {
                 [17.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
+            crate::core::error::CryptoError::Argon2PolicyViolation(field0) => {
+                [18.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
+            crate::core::error::CryptoError::Argon2VerificationBusy => [19.into_dart()].into_dart(),
             _ => {
                 unimplemented!("");
             }
@@ -2939,6 +2950,13 @@ impl SseEncode for crate::core::error::CryptoError {
             crate::core::error::CryptoError::ImportFailed(field0) => {
                 <i32>::sse_encode(17, serializer);
                 <String>::sse_encode(field0, serializer);
+            }
+            crate::core::error::CryptoError::Argon2PolicyViolation(field0) => {
+                <i32>::sse_encode(18, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
+            crate::core::error::CryptoError::Argon2VerificationBusy => {
+                <i32>::sse_encode(19, serializer);
             }
             _ => {
                 unimplemented!("");
@@ -3377,6 +3395,11 @@ mod io {
                     let ans = unsafe { self.kind.ImportFailed };
                     crate::core::error::CryptoError::ImportFailed(ans.field0.cst_decode())
                 }
+                18 => {
+                    let ans = unsafe { self.kind.Argon2PolicyViolation };
+                    crate::core::error::CryptoError::Argon2PolicyViolation(ans.field0.cst_decode())
+                }
+                19 => crate::core::error::CryptoError::Argon2VerificationBusy,
                 _ => unreachable!(),
             }
         }
@@ -4290,6 +4313,7 @@ mod io {
         KeyRotationFailed: wire_cst_CryptoError_KeyRotationFailed,
         ExportFailed: wire_cst_CryptoError_ExportFailed,
         ImportFailed: wire_cst_CryptoError_ImportFailed,
+        Argon2PolicyViolation: wire_cst_CryptoError_Argon2PolicyViolation,
         nil__: (),
     }
     #[repr(C)]
@@ -4362,6 +4386,11 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_CryptoError_ImportFailed {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_Argon2PolicyViolation {
         field0: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
@@ -4547,6 +4576,10 @@ mod web {
                 15 => crate::core::error::CryptoError::KeyRotationFailed(self_.get(1).cst_decode()),
                 16 => crate::core::error::CryptoError::ExportFailed(self_.get(1).cst_decode()),
                 17 => crate::core::error::CryptoError::ImportFailed(self_.get(1).cst_decode()),
+                18 => crate::core::error::CryptoError::Argon2PolicyViolation(
+                    self_.get(1).cst_decode(),
+                ),
+                19 => crate::core::error::CryptoError::Argon2VerificationBusy,
                 _ => unreachable!(),
             }
         }

--- a/test/argon2_boundary_test.dart
+++ b/test/argon2_boundary_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_security/src/hashing/argon2.dart';
+import 'package:m_security/src/rust/core/error.dart';
+import 'package:m_security/src/rust/frb_generated.io.dart'
+    show MAX_VERIFY_PASSWORD_BYTES;
+
+// A released mobile-preset hash of 'preset_vector'.
+const String _vector =
+    r'$argon2id$v=19$m=65536,t=3,p=4$c29tZXNhbHQ$rUYVKsKrcBrgqxhUdNkDIkzdd3Df9gC3RP6cEdFyM8k';
+
+Future<Object?> _verifyError(String password) async {
+  try {
+    await argon2IdVerify(phcHash: _vector, password: password);
+  } catch (error) {
+    return error;
+  }
+  return null;
+}
+
+void main() {
+  // RustLib is deliberately never initialised. An over-ceiling password has to
+  // be rejected before the call reaches the bridge, so these cases pass without
+  // a native library, and the sizes that are allowed through fail for the
+  // missing library instead.
+  group('argon2IdVerify password ceiling', () {
+    // The Dart ceiling is a separate literal from the native one, so nothing but
+    // this keeps the two boundaries from drifting apart.
+    test('matches the ceiling the native side enforces', () {
+      expect(maxArgon2VerifyPasswordBytes, MAX_VERIFY_PASSWORD_BYTES);
+    });
+
+    test('one byte over the ceiling is a policy violation', () async {
+      final error = await _verifyError('a' * (maxArgon2VerifyPasswordBytes + 1));
+
+      expect(error, isA<CryptoError_Argon2PolicyViolation>());
+      expect(
+        (error as CryptoError_Argon2PolicyViolation).field0,
+        contains('$maxArgon2VerifyPasswordBytes UTF-8 bytes'),
+      );
+    });
+
+    test('the ceiling and one byte under it are passed on', () async {
+      for (final length in [
+        maxArgon2VerifyPasswordBytes - 1,
+        maxArgon2VerifyPasswordBytes,
+      ]) {
+        final error = await _verifyError('a' * length);
+
+        expect(error, isNotNull, reason: '$length bytes reached no bridge');
+        expect(
+          error,
+          isNot(isA<CryptoError_Argon2PolicyViolation>()),
+          reason: '$length bytes was rejected by the Dart check',
+        );
+      }
+    });
+
+    test('the ceiling counts UTF-8 bytes, not characters', () async {
+      // 512 characters, 512 UTF-16 code units, 1536 UTF-8 bytes.
+      final error = await _verifyError('€' * 512);
+
+      expect(error, isA<CryptoError_Argon2PolicyViolation>());
+    });
+
+    test('an empty password is passed on', () async {
+      final error = await _verifyError('');
+
+      expect(error, isNot(isA<CryptoError_Argon2PolicyViolation>()));
+    });
+  });
+}


### PR DESCRIPTION
Verification took the memory, iteration and lane values straight from whatever PHC
string it was handed, so a hostile hash could ask for as much work as it wanted. It
now checks them against fixed bounds first, and only then builds a verifier. PHC
input and passwords cap at 1024 bytes, the password one on the Dart side too so an
oversized one never crosses the bridge. Only one verification runs at a time, so a
second caller gets a busy error instead of another 256 MiB allocation, and the
password is wiped on the way out either way.

Two caveats. The 64 byte salt bound is a ceiling, not a promise: password-hash caps
the encoded salt at 64 characters, so anything past 48 decoded bytes is rejected by
the parser first. And p=4294967295 used to panic outright in debug, because argon2
multiplies lanes by eight before it range checks them.

Green in debug and release, 431 tests against 410, both builds clean under -D
warnings. Bindings regenerate to no diff. The argon2 integration test ran on macOS
against the built app, and an allocation probe shows the rejection paths never
reserve a block.
