### PR TITLE
fix(formats): restrict unsafe legacy formats

### DIFF
--- a/example/integration_test/evfs_enhancements_test.dart
+++ b/example/integration_test/evfs_enhancements_test.dart
@@ -6,6 +6,11 @@ import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/evfs/vault_service.dart';
+import 'package:m_security/src/rust/api/evfs/types.dart';
+
+// Every vault here is the unauthenticated v1/v2 format, which VaultService
+// refuses unless the caller says so.
+const _unsafeLegacy = UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -29,6 +34,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([1, 2, 3, 4, 5]);
@@ -57,6 +63,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([10, 20, 30]);
@@ -81,6 +88,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([1, 2, 3]);
@@ -116,6 +124,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([7, 8, 9]);
@@ -128,7 +137,11 @@ void main() {
       await VaultService.close(handle: handle);
 
       // Reopen and verify
-      handle = await VaultService.open(path: path, key: key);
+      handle = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       final result = await VaultService.read(
         handle: handle,
         name: 'persist.bin',
@@ -158,6 +171,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([1, 2, 3, 4, 5]);
@@ -197,6 +211,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -233,6 +248,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await expectLater(
@@ -258,6 +274,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([42]);
@@ -300,6 +317,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -327,6 +345,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // No writes — flush should be a safe no-op
@@ -354,6 +373,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write 5 segments
@@ -391,6 +411,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -426,6 +447,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final results = await VaultService.readParallel(
@@ -457,6 +479,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList(List.generate(500, (i) => i % 256));
@@ -514,6 +537,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 10 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final segments = <String, Uint8List>{};

--- a/example/integration_test/evfs_policy_test.dart
+++ b/example/integration_test/evfs_policy_test.dart
@@ -1,0 +1,258 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:m_security/m_security.dart';
+import 'package:m_security/src/rust/api/evfs.dart' as bridge;
+import 'package:m_security/src/rust/core/error.dart';
+
+import 'released_surface_consumer.dart' as released;
+
+/// The `.lock`, `.wal` and rotation files a vault path can grow.
+List<String> sidecars(String path) => [
+  path,
+  '$path.lock',
+  '$path.wal',
+  '$path.rotating',
+  '$path.defrag',
+].where((candidate) => File(candidate).existsSync()).toList();
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async => await RustLib.init());
+
+  group('unsafe legacy vault policy', () {
+    late Directory tempDir;
+    late Uint8List key;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('evfs_policy_test');
+      key = await generateAes256GcmKey();
+    });
+    tearDown(() async => await tempDir.delete(recursive: true));
+
+    test('released source denies creation and writes nothing', () async {
+      final path = '${tempDir.path}/denied.vault';
+
+      await expectLater(
+        released.createVault(
+          path: path,
+          key: key,
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+
+      expect(sidecars(path), isEmpty);
+      expect(tempDir.listSync(), isEmpty);
+    });
+
+    test(
+      'released source denies opening and leaves the vault byte-identical',
+      () async {
+        final path = '${tempDir.path}/existing.vault';
+        final handle = await released.createVaultWithOptIn(
+          path: path,
+          key: key,
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        );
+        await released.writeSegment(
+          handle: handle,
+          name: 'note.txt',
+          data: Uint8List.fromList([7, 7, 7]),
+        );
+        await VaultService.close(handle: handle);
+
+        final before = await File(path).readAsBytes();
+        final beforeSidecars = sidecars(path);
+
+        await expectLater(
+          released.openVault(path: path, key: key),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+        );
+
+        expect(await File(path).readAsBytes(), before);
+        expect(sidecars(path), beforeSidecars);
+      },
+    );
+
+    test(
+      'the generated entry denies on its own, not just the wrapper',
+      () async {
+        final path = '${tempDir.path}/raw.vault';
+
+        // Straight at the bridge function, with the wrapper out of the way.
+        await expectLater(
+          bridge.vaultCreate(
+            path: path,
+            key: key,
+            algorithm: 'aes-256-gcm',
+            capacityBytes: BigInt.from(1024 * 1024),
+            unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.deny,
+          ),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+        );
+        expect(sidecars(path), isEmpty);
+
+        await expectLater(
+          bridge.vaultOpen(
+            path: path,
+            key: key,
+            unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.deny,
+          ),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+        );
+        expect(sidecars(path), isEmpty);
+      },
+    );
+
+    test('the generated entry accepts the opt-in', () async {
+      final path = '${tempDir.path}/raw_optin.vault';
+
+      final handle = await bridge.vaultCreate(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: BigInt.from(1024 * 1024),
+        unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+      );
+      await VaultService.close(handle: handle);
+
+      expect(File(path).existsSync(), isTrue);
+
+      final reopened = await bridge.vaultOpen(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+      );
+      await VaultService.close(handle: reopened);
+    });
+
+    test('an opt-in round trip still denies the next default call', () async {
+      final path = '${tempDir.path}/roundtrip.vault';
+      final payload = Uint8List.fromList(List.generate(2048, (i) => i % 256));
+
+      final handle = await released.createVaultWithOptIn(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      await released.writeSegment(
+        handle: handle,
+        name: 'payload.bin',
+        data: payload,
+      );
+      await VaultService.close(handle: handle);
+
+      final reopened = await released.openVaultWithOptIn(path: path, key: key);
+      expect(
+        await released.readSegment(handle: reopened, name: 'payload.bin'),
+        payload,
+      );
+      await VaultService.close(handle: reopened);
+
+      for (var attempt = 0; attempt < 3; attempt++) {
+        await expectLater(
+          released.openVault(path: path, key: key),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+          reason: 'attempt $attempt was authorized by an earlier opt-in',
+        );
+      }
+    });
+
+    test('a live opted-in handle does not authorize a default call', () async {
+      final held = await released.createVaultWithOptIn(
+        path: '${tempDir.path}/held.vault',
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      addTearDown(() => VaultService.close(handle: held));
+
+      await expectLater(
+        released.createVault(
+          path: '${tempDir.path}/second.vault',
+          key: await generateAes256GcmKey(),
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+      expect(File('${tempDir.path}/second.vault').existsSync(), isFalse);
+    });
+
+    test('a rotated vault still needs the opt-in to reopen', () async {
+      final path = '${tempDir.path}/rotated.vault';
+      final newKey = await generateAes256GcmKey();
+
+      var handle = await released.createVaultWithOptIn(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      await released.writeSegment(
+        handle: handle,
+        name: 'a.bin',
+        data: Uint8List.fromList([1, 2, 3]),
+      );
+      handle = await VaultService.rotateKey(handle: handle, newKey: newKey);
+      expect(
+        await released.readSegment(handle: handle, name: 'a.bin'),
+        Uint8List.fromList([1, 2, 3]),
+      );
+      await VaultService.close(handle: handle);
+
+      await expectLater(
+        released.openVault(path: path, key: newKey),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+      final reopened = await released.openVaultWithOptIn(
+        path: path,
+        key: newKey,
+      );
+      await VaultService.close(handle: reopened);
+    });
+
+    test('denial does not depend on the arguments being usable', () async {
+      final path = '${tempDir.path}/bad_args.vault';
+
+      // An empty key and an unknown algorithm are both rejected further in, so
+      // seeing the denial means the check ran before either.
+      await expectLater(
+        released.createVault(
+          path: path,
+          key: Uint8List(0),
+          algorithm: 'not-an-algorithm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+      expect(sidecars(path), isEmpty);
+
+      // Both really are rejected, so the case is not vacuous.
+      await expectLater(
+        released.createVaultWithOptIn(
+          path: path,
+          key: Uint8List(0),
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError>()),
+      );
+      await expectLater(
+        released.createVaultWithOptIn(
+          path: path,
+          key: key,
+          algorithm: 'not-an-algorithm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError>()),
+      );
+    });
+  });
+}

--- a/example/integration_test/evfs_test.dart
+++ b/example/integration_test/evfs_test.dart
@@ -7,6 +7,11 @@ import 'package:m_security/src/rust/api/compression.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/evfs/vault_service.dart';
+import 'package:m_security/src/rust/api/evfs/types.dart';
+
+// Every vault here is the unauthenticated v1/v2 format, which VaultService
+// refuses unless the caller says so.
+const _unsafeLegacy = UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -32,6 +37,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //segment
@@ -42,7 +48,11 @@ void main() {
       await VaultService.close(handle: handle);
 
       //reopen vault
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       //read segment
       final result = await VaultService.read(
@@ -64,6 +74,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024, //5MB
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data1 = Uint8List.fromList(List.generate(1000, (i) => i % 256));
@@ -108,6 +119,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write original
@@ -139,6 +151,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       expect(
@@ -158,6 +171,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //write a segment
@@ -189,6 +203,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024, // 1MB total
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //Try to write 1MB of data (will fail because index takes space too)
@@ -221,12 +236,17 @@ void main() {
         key: keyA,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
       await VaultService.close(handle: handle);
 
       //try to open with keyB
       expect(
-        () async => await VaultService.open(path: path, key: keyB),
+        () async => await VaultService.open(
+          path: path,
+          key: keyB,
+          unsafeLegacyPolicy: _unsafeLegacy,
+        ),
         throwsA(isA<Exception>()),
       );
     });
@@ -240,18 +260,27 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //try to open again without closing first
       expect(
-        () async => await VaultService.open(path: path, key: key),
+        () async => await VaultService.open(
+          path: path,
+          key: key,
+          unsafeLegacyPolicy: _unsafeLegacy,
+        ),
         throwsA(predicate((e) => e.toString().contains('vaultLocked'))),
       );
 
       await VaultService.close(handle: handle);
 
       //now it should work!
-      final handle2 = await VaultService.open(path: path, key: key);
+      final handle2 = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       await VaultService.close(handle: handle2);
     });
 
@@ -264,6 +293,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
       //write 3 segments
       await VaultService.write(
@@ -299,6 +329,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: totalCapacity,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Check initial capacity
@@ -329,6 +360,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
       final data = Uint8List.fromList(List.generate(10000, (i) => i % 256));
       await VaultService.write(
@@ -352,6 +384,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList(List.generate(10000, (i) => i % 256));
@@ -379,6 +412,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Fake JPEG data
@@ -414,6 +448,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024, // 5MB
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Prepare test data (compressible - lots of repeats)
@@ -508,6 +543,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write data
@@ -526,7 +562,11 @@ void main() {
       await file.writeAsBytes(bytes);
 
       // Reopen
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Try to read → should detect tampering via checksum
       expect(
@@ -546,6 +586,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write some data
@@ -560,7 +601,11 @@ void main() {
       await VaultService.close(handle: handle);
 
       // Reopen (WAL recovery runs but finds everything committed)
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Verify data survived
       final result = await VaultService.read(
@@ -579,7 +624,11 @@ void main() {
 
       // Close and reopen again
       await VaultService.close(handle: reopened);
-      final reopened2 = await VaultService.open(path: path, key: key);
+      final reopened2 = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Both segments should exist
       final result1 = await VaultService.read(
@@ -607,6 +656,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write A, B, C
@@ -655,6 +705,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final result = await VaultService.defragment(handle: handle);
@@ -675,6 +726,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 512 * 1024, // 512KB
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Grow to 1MB
@@ -702,6 +754,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024, // 1MB
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write small data
@@ -732,6 +785,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write enough data to occupy space
@@ -761,6 +815,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: cap,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final h = await VaultService.health(handle: handle);
@@ -784,6 +839,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -831,6 +887,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final originalData = Uint8List.fromList([1, 2, 3, 4, 5]);
@@ -868,7 +925,11 @@ void main() {
       // 1. Try to decrypt primary index → fail (corrupted)
       // 2. Fall back to shadow index → succeed
       // 3. Restore primary index from shadow
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Read data - should work because shadow index has it
       final result = await VaultService.read(
@@ -884,7 +945,11 @@ void main() {
       await VaultService.close(handle: reopened);
 
       // Reopen again - primary should be restored now
-      final reopened2 = await VaultService.open(path: path, key: key);
+      final reopened2 = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       final result2 = await VaultService.read(
         handle: reopened2,
         name: 'important.bin',
@@ -909,6 +974,7 @@ void main() {
           algorithm: 'aes-256-gcm',
           capacityBytes:
               16 * 1024 * 1024, // 16 MB — enough for encrypted overhead
+          unsafeLegacyPolicy: _unsafeLegacy,
         );
 
         // Build source data in memory for the round-trip assertion.
@@ -957,6 +1023,7 @@ void main() {
           key: key,
           algorithm: 'aes-256-gcm',
           capacityBytes: 2 * 1024 * 1024,
+          unsafeLegacyPolicy: _unsafeLegacy,
         );
 
         final sourceData = Uint8List.fromList(
@@ -990,6 +1057,7 @@ void main() {
           key: key,
           algorithm: 'aes-256-gcm',
           capacityBytes: 2 * 1024 * 1024,
+          unsafeLegacyPolicy: _unsafeLegacy,
         );
 
         final sourceData = Uint8List.fromList(
@@ -1030,6 +1098,7 @@ void main() {
             key: key,
             algorithm: 'aes-256-gcm',
             capacityBytes: 4 * 1024 * 1024,
+            unsafeLegacyPolicy: _unsafeLegacy,
           );
 
           // Track write progress.
@@ -1086,6 +1155,7 @@ void main() {
           key: key,
           algorithm: 'aes-256-gcm',
           capacityBytes: 2 * 1024 * 1024,
+          unsafeLegacyPolicy: _unsafeLegacy,
         );
 
         // Underflow: stream emits fewer bytes than totalSize claims.
@@ -1128,6 +1198,7 @@ void main() {
           key: key,
           algorithm: 'aes-256-gcm',
           capacityBytes: 55 * 1024 * 1024,
+          unsafeLegacyPolicy: _unsafeLegacy,
         );
 
         // Generate stream lazily — never holds more than one 64 KB chunk in

--- a/example/integration_test/released_surface_consumer.dart
+++ b/example/integration_test/released_surface_consumer.dart
@@ -1,0 +1,159 @@
+/// A consumer written the way the released storage surface documented it, kept
+/// as a compile fixture.
+///
+/// Nothing here passes the unsafe-format policy or catches a disabled-format
+/// result: that is the point. Every call has to keep resolving under the same
+/// name, argument names and types, so `dart analyze` over this directory is what
+/// proves existing source still builds against the patch. The tests that import
+/// it are the ones that pin down what the calls now do at run time.
+library;
+
+import 'dart:typed_data';
+
+import 'package:m_security/m_security.dart';
+
+Future<VaultHandle> createVault({
+  required String path,
+  required Uint8List key,
+  required String algorithm,
+  required int capacityBytes,
+}) {
+  return VaultService.create(
+    path: path,
+    key: key,
+    algorithm: algorithm,
+    capacityBytes: capacityBytes,
+  );
+}
+
+Future<VaultHandle> openVault({required String path, required Uint8List key}) {
+  return VaultService.open(path: path, key: key);
+}
+
+Future<void> writeSegment({
+  required VaultHandle handle,
+  required String name,
+  required Uint8List data,
+}) {
+  return VaultService.write(handle: handle, name: name, data: data);
+}
+
+Future<Uint8List> readSegment({
+  required VaultHandle handle,
+  required String name,
+}) async {
+  return (await VaultService.read(handle: handle, name: name)).data;
+}
+
+Future<void> exportArchive({
+  required VaultHandle handle,
+  required Uint8List wrappingKey,
+  required String exportPath,
+}) {
+  return VaultService.export(
+    handle: handle,
+    wrappingKey: wrappingKey,
+    exportPath: exportPath,
+  );
+}
+
+Future<VaultHandle> importArchive({
+  required String archivePath,
+  required Uint8List wrappingKey,
+  required String destPath,
+  required Uint8List newMasterKey,
+  required String algorithm,
+  required int capacityBytes,
+}) {
+  return VaultService.importVault(
+    archivePath: archivePath,
+    wrappingKey: wrappingKey,
+    destPath: destPath,
+    newMasterKey: newMasterKey,
+    algorithm: algorithm,
+    capacityBytes: capacityBytes,
+  );
+}
+
+Stream<double> encryptStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return StreamingService.encryptFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+  );
+}
+
+Stream<double> decryptStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return StreamingService.decryptFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+  );
+}
+
+Stream<double> compressStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return CompressionService.compressAndEncryptFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+    config: const CompressionConfig(algorithm: CompressionAlgorithm.zstd),
+  );
+}
+
+Stream<double> decompressStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return CompressionService.decryptAndDecompressFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+  );
+}
+
+Future<Uint8List> hashWholeFile({
+  required String filePath,
+  required HasherHandle hasher,
+}) {
+  return StreamingService.hashFile(filePath: filePath, hasher: hasher);
+}
+
+/// The one call that has to be written differently to keep working.
+Future<VaultHandle> createVaultWithOptIn({
+  required String path,
+  required Uint8List key,
+  required String algorithm,
+  required int capacityBytes,
+}) {
+  return VaultService.create(
+    path: path,
+    key: key,
+    algorithm: algorithm,
+    capacityBytes: capacityBytes,
+    unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+  );
+}
+
+Future<VaultHandle> openVaultWithOptIn({
+  required String path,
+  required Uint8List key,
+}) {
+  return VaultService.open(
+    path: path,
+    key: key,
+    unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+  );
+}

--- a/example/integration_test/streaming_test.dart
+++ b/example/integration_test/streaming_test.dart
@@ -1,59 +1,39 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
+import 'package:m_security/src/rust/core/error.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/streaming/streaming_service.dart';
 import 'package:m_security/src/rust/api/hashing.dart';
+
+/// Drain a progress stream, keeping the values and the errors apart.
+Future<({List<double> values, List<Object> errors})> drain(
+  Stream<double> progress,
+) async {
+  final values = <double>[];
+  final errors = <Object>[];
+  final done = Completer<void>();
+
+  progress.listen(
+    values.add,
+    onError: errors.add,
+    onDone: done.complete,
+    cancelOnError: false,
+  );
+  await done.future;
+
+  return (values: values, errors: errors);
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() async => await RustLib.init());
 
   group('Streaming', () {
-    test('encrypt then decrypt file roundtrip', () async {
-      //Create temp file with known content
-      //→ encrypt → decrypt → compare bytes identical
-      final tempDir = await Directory.systemTemp.createTemp('stream_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      final originalData = Uint8List.fromList(
-        List.generate(100000, (i) => i % 256),
-      );
-      await inputFile.writeAsBytes(originalData);
-
-      //generate key and create cipher
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      //Encrypt
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {
-        //wait for completion
-      }
-      //Decrypt
-      await for (final _ in StreamingService.decryptFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {
-        //wait for completion
-      }
-      //verify
-      final result = await decrypted.readAsBytes();
-      expect(result, originalData);
-
-      //cleanup
-      await tempDir.delete(recursive: true);
-    });
-
     test('streaming hash matches one-shot hash', () async {
       final tempDir = await Directory.systemTemp.createTemp('hash_test');
       final file = File('${tempDir.path}/test.bin');
@@ -76,205 +56,94 @@ void main() {
       await tempDir.delete(recursive: true);
     });
 
-    test('progress reports from 0 to 1', () async {
-      final tempDir = await Directory.systemTemp.createTemp('progress_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
+    test(
+      'encryptFile emits one disabled-format error and writes nothing',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('stream_test');
+        final inputFile = File('${tempDir.path}/input.bin');
+        final encrypted = File('${tempDir.path}/encrypted.bin');
 
-      // create 1MB file
-      final data = Uint8List(1024 * 1024);
-      await inputFile.writeAsBytes(data);
+        await inputFile.writeAsBytes(
+          Uint8List.fromList(List.generate(100000, (i) => i % 256)),
+        );
+        final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
 
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
+        final outcome = await drain(
+          StreamingService.encryptFile(
+            inputPath: inputFile.path,
+            outputPath: encrypted.path,
+            cipher: cipher,
+          ),
+        );
 
-      final progressValues = <double>[];
+        expect(outcome.values, isEmpty);
+        expect(outcome.errors, hasLength(1));
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+        expect(encrypted.existsSync(), isFalse);
+        expect(File('${encrypted.path}.tmp').existsSync(), isFalse);
 
-      await for (final progress in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {
-        progressValues.add(progress);
-      }
+        await tempDir.delete(recursive: true);
+      },
+    );
 
-      //verify progress goes from ~0 to 1
-      expect(progressValues.first, lessThan(0.1));
-      expect(progressValues.last, closeTo(1.0, 0.01));
+    test(
+      'decryptFile emits one disabled-format error and writes nothing',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('stream_test');
+        final encrypted = File('${tempDir.path}/encrypted.bin');
+        final decrypted = File('${tempDir.path}/decrypted.bin');
 
-      // verify monotonically increasing
-      for (int i = 1; i < progressValues.length; i++) {
-        expect(progressValues[i], greaterThanOrEqualTo(progressValues[i - 1]));
-      }
+        // Bytes that start like an MSSE stream, so nothing but the refusal keeps
+        // the parser away from them.
+        await encrypted.writeAsBytes(
+          Uint8List.fromList([0x4D, 0x53, 0x53, 0x45, 1, 0, 0, 0]),
+        );
+        final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
 
-      await tempDir.delete(recursive: true);
-    });
-
-    test('wrong key fails decryption', () async {
-      final tempDir = await Directory.systemTemp.createTemp('wrongkey_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      await inputFile.writeAsBytes(Uint8List.fromList([1, 2, 3, 4, 5]));
-
-      final keyA = await generateAes256GcmKey();
-      final cipherA = await createAes256Gcm(key: keyA);
-
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipherA,
-      )) {}
-
-      final keyB = await generateAes256GcmKey();
-      final cipherB = await createAes256Gcm(key: keyB);
-
-      bool errorThrown = false;
-      try {
-        await for (final _ in StreamingService.decryptFile(
-          inputPath: encrypted.path,
-          outputPath: decrypted.path,
-          cipher: cipherB,
-        )) {}
-      } catch (e) {
-        errorThrown = true;
-      }
-      expect(errorThrown, true);
-
-      await tempDir.delete(recursive: true);
-    });
-
-    test('empty file roundtrip', () async {
-      final tempDir = await Directory.systemTemp.createTemp('empty_test');
-      final inputFile = File('${tempDir.path}/empty.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      await inputFile.writeAsBytes(Uint8List(0)); // Empty file
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-
-      await for (final _ in StreamingService.decryptFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final result = await decrypted.readAsBytes();
-      expect(result.length, 0);
-
-      await tempDir.delete(recursive: true);
-    });
-
-    test('small file padding stripped correctly', () async {
-      final tempDir = await Directory.systemTemp.createTemp('padding_test');
-      final inputFile = File('${tempDir.path}/small.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-      
-      final originalData = Uint8List(100); // exactly 100 bytes
-      await inputFile.writeAsBytes(originalData);
-      
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-      
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-      
-      await for (final _ in StreamingService.decryptFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-      
-      final result = await decrypted.readAsBytes();
-      expect(result.length, 100, reason: 'Padding should be stripped, output should be exactly 100 bytes, not 64KB');
-      
-      await tempDir.delete(recursive: true);
-    });
-
-    test('encrypted chunks are uniform size', () async {
-      final tempDir = await Directory.systemTemp.createTemp('uniform_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      
-      // Create file that doesn't fill last chunk 
-      final data = Uint8List(150);
-      await inputFile.writeAsBytes(data);
-      
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-      
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-      
-      final encryptedSize = await encrypted.length();
-      const streamHeaderSize = 16;
-      const encryptedChunkSize = 65564;
-      
-      final dataPortionSize = encryptedSize - streamHeaderSize;
-      
-      expect(
-        dataPortionSize % encryptedChunkSize,
-        0,
-        reason: 'All encrypted chunks should be uniform size. Got file size $encryptedSize',
-      );
-      
-      await tempDir.delete(recursive: true);
-    });
-
-    test('tampered padding detected end-to-end', () async {
-      final tempDir = await Directory.systemTemp.createTemp('tamper_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final tampered = File('${tempDir.path}/tampered.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      final data = Uint8List(100);
-      await inputFile.writeAsBytes(data);
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final encryptedBytes = await encrypted.readAsBytes();
-      final tamperedBytes = Uint8List.fromList(encryptedBytes);
-      tamperedBytes[tamperedBytes.length - 100] ^= 0xFF;
-      await tampered.writeAsBytes(tamperedBytes);
-
-      await expectLater(
-        Future(() async {
-          await for (final _ in StreamingService.decryptFile(
-            inputPath: tampered.path,
+        final outcome = await drain(
+          StreamingService.decryptFile(
+            inputPath: encrypted.path,
             outputPath: decrypted.path,
             cipher: cipher,
-          )) {}
-        }),
-        throwsA(anything),
-        reason: 'Tampered padding should be detected and throw error',
-      );
+          ),
+        );
 
+        expect(outcome.values, isEmpty);
+        expect(outcome.errors, hasLength(1));
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+        expect(decrypted.existsSync(), isFalse);
+
+        await tempDir.delete(recursive: true);
+      },
+    );
+
+    test('the refusal arrives before either path is touched', () async {
+      final tempDir = await Directory.systemTemp.createTemp('stream_test');
+      final missing = '${tempDir.path}/absent.bin';
+      final output = '${tempDir.path}/nested/deeper/out.bin';
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
+
+      // A missing input and an unreachable output would both fail with an I/O
+      // error further in, so a disabled-format error means neither was tried.
+      for (final progress in [
+        StreamingService.encryptFile(
+          inputPath: missing,
+          outputPath: output,
+          cipher: cipher,
+        ),
+        StreamingService.decryptFile(
+          inputPath: missing,
+          outputPath: output,
+          cipher: cipher,
+        ),
+      ]) {
+        final outcome = await drain(progress);
+
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      }
+
+      expect(Directory('${tempDir.path}/nested').existsSync(), isFalse);
       await tempDir.delete(recursive: true);
     });
-
   });
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -639,6 +639,9 @@ class _VaultTabState extends State<_VaultTab> {
         key: _key!,
         algorithm: 'aes-256-gcm',
         capacityBytes: sizeMb * 1024 * 1024,
+        // The demo vault is the unauthenticated v1/v2 format, which the API
+        // refuses unless the caller says so.
+        unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
       );
       _vaultOpen = true;
       _status = 'Vault created (${sizeMb}MB, AES-256-GCM)';
@@ -672,7 +675,11 @@ class _VaultTabState extends State<_VaultTab> {
     if (_vaultPath == null || _key == null) return;
     setState(() => _loading = true);
     try {
-      _handle = await VaultService.open(path: _vaultPath!, key: _key!);
+      _handle = await VaultService.open(
+        path: _vaultPath!,
+        key: _key!,
+        unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+      );
       _vaultOpen = true;
       _status = 'Vault reopened (WAL recovery ran)';
       await _refreshList();
@@ -1045,10 +1052,8 @@ class _VaultTabState extends State<_VaultTab> {
     }
     setState(() => _loading = true);
     try {
-      if (_vaultOpen && _handle != null) {
-        await VaultService.close(handle: _handle!);
-      }
-
+      // The open vault is left alone: import is disabled, so closing it first
+      // would only strand this screen with a handle it can no longer replace.
       final dir = Directory(_vaultPath!).parent;
       final importPath = '${dir.path}/imported.vault';
       final importKey = await msec.generateAes256GcmKey();

--- a/integration_test/compression_test.dart
+++ b/integration_test/compression_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -5,177 +6,162 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/rust/api/compression.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
+import 'package:m_security/src/rust/core/error.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/compression/compression_service.dart';
+
+/// Drain a progress stream, keeping the values and the errors apart.
+Future<({List<double> values, List<Object> errors})> drain(
+  Stream<double> progress,
+) async {
+  final values = <double>[];
+  final errors = <Object>[];
+  final done = Completer<void>();
+
+  progress.listen(
+    values.add,
+    onError: errors.add,
+    onDone: done.complete,
+    cancelOnError: false,
+  );
+  await done.future;
+
+  return (values: values, errors: errors);
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() async => await RustLib.init());
 
   group('Compression', () {
-    test('zstd compress-then-encrypt roundtrip', () async {
+    test('compressAndEncryptFile is disabled for every algorithm', () async {
       final tempDir = await Directory.systemTemp.createTemp('zstd_test');
       addTearDown(() => tempDir.delete(recursive: true));
       final input = File('${tempDir.path}/input.bin');
       final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
 
-      final originalData = Uint8List.fromList(
-        List.generate(100000, (i) => i % 256),
+      await input.writeAsBytes(
+        Uint8List.fromList(List.generate(100000, (i) => i % 256)),
       );
-      await input.writeAsBytes(originalData);
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
 
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
+      for (final algorithm in CompressionAlgorithm.values) {
+        final outcome = await drain(
+          CompressionService.compressAndEncryptFile(
+            inputPath: input.path,
+            outputPath: encrypted.path,
+            cipher: cipher,
+            config: CompressionConfig(algorithm: algorithm),
+          ),
+        );
 
-      await for (final _ in CompressionService.compressAndEncryptFile(
-        inputPath: input.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-        config: const CompressionConfig(algorithm: CompressionAlgorithm.zstd),
-      )) {}
-
-      await for (final _ in CompressionService.decryptAndDecompressFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final result = await decrypted.readAsBytes();
-      expect(result, originalData);
+        expect(outcome.values, isEmpty, reason: '$algorithm reported progress');
+        expect(outcome.errors, hasLength(1));
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+        expect(encrypted.existsSync(), isFalse);
+      }
     });
 
-    test('brotli compress-then-encrypt roundtrip', () async {
-      final tempDir = await Directory.systemTemp.createTemp('brotli_test');
-      addTearDown(() => tempDir.delete(recursive: true));
-      final input = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      final originalData = Uint8List.fromList(
-        List.generate(100000, (i) => i % 256),
-      );
-      await input.writeAsBytes(originalData);
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      await for (final _ in CompressionService.compressAndEncryptFile(
-        inputPath: input.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-        config: const CompressionConfig(algorithm: CompressionAlgorithm.brotli),
-      )) {}
-
-      await for (final _ in CompressionService.decryptAndDecompressFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final result = await decrypted.readAsBytes();
-      expect(result, originalData);
-    });
-
-    test('compression none roundtrips correctly', () async {
-      final tempDir = await Directory.systemTemp.createTemp('none_test');
-      addTearDown(() => tempDir.delete(recursive: true));
-      final input = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      final originalData = Uint8List.fromList(
-        List.generate(50000, (i) => i % 256),
-      );
-      await input.writeAsBytes(originalData);
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      await for (final _ in CompressionService.compressAndEncryptFile(
-        inputPath: input.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-        config: const CompressionConfig(algorithm: CompressionAlgorithm.none),
-      )) {}
-
-      await for (final _ in CompressionService.decryptAndDecompressFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-
-      expect(await decrypted.readAsBytes(), originalData);
-    });
-
-    test('jpg file auto-skips compression', () async {
-      final tempDir = await Directory.systemTemp.createTemp('jpg_test');
-      addTearDown(() => tempDir.delete(recursive: true));
-      // Use .jpg extension to trigger MIME-aware skip
-      final input = File('${tempDir.path}/photo.jpg');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.jpg');
-
-      final originalData = Uint8List.fromList(
-        List.generate(50000, (i) => i % 256),
-      );
-      await input.writeAsBytes(originalData);
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      // Even though we request zstd, .jpg should trigger skip
-      await for (final _ in CompressionService.compressAndEncryptFile(
-        inputPath: input.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-        config: const CompressionConfig(algorithm: CompressionAlgorithm.zstd),
-      )) {}
-
-      await for (final _ in CompressionService.decryptAndDecompressFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final result = await decrypted.readAsBytes();
-      expect(result, originalData);
-    });
-
-    test('custom compression level works', () async {
+    test('compressAndEncryptFile is disabled at a custom level', () async {
       final tempDir = await Directory.systemTemp.createTemp('level_test');
       addTearDown(() => tempDir.delete(recursive: true));
       final input = File('${tempDir.path}/input.bin');
       final encrypted = File('${tempDir.path}/encrypted.bin');
+
+      await input.writeAsBytes(Uint8List(4096));
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
+
+      final outcome = await drain(
+        CompressionService.compressAndEncryptFile(
+          inputPath: input.path,
+          outputPath: encrypted.path,
+          cipher: cipher,
+          config: const CompressionConfig(
+            algorithm: CompressionAlgorithm.zstd,
+            level: 19,
+          ),
+        ),
+      );
+
+      expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      expect(encrypted.existsSync(), isFalse);
+    });
+
+    test('decryptAndDecompressFile is disabled and writes nothing', () async {
+      final tempDir = await Directory.systemTemp.createTemp('decomp_test');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final encrypted = File('${tempDir.path}/encrypted.bin');
       final decrypted = File('${tempDir.path}/decrypted.bin');
 
-      final originalData = Uint8List.fromList(
-        List.generate(100000, (i) => i % 256),
+      // Bytes that start like an MSSE stream, so nothing but the refusal keeps
+      // the parser away from them.
+      await encrypted.writeAsBytes(
+        Uint8List.fromList([0x4D, 0x53, 0x53, 0x45, 1, 0, 0, 1]),
       );
-      await input.writeAsBytes(originalData);
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
 
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      // Zstd with level 19 (high compression)
-      await for (final _ in CompressionService.compressAndEncryptFile(
-        inputPath: input.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-        config: const CompressionConfig(
-          algorithm: CompressionAlgorithm.zstd,
-          level: 19,
+      final outcome = await drain(
+        CompressionService.decryptAndDecompressFile(
+          inputPath: encrypted.path,
+          outputPath: decrypted.path,
+          cipher: cipher,
         ),
-      )) {}
+      );
 
-      await for (final _ in CompressionService.decryptAndDecompressFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
+      expect(outcome.values, isEmpty);
+      expect(outcome.errors, hasLength(1));
+      expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      expect(decrypted.existsSync(), isFalse);
+    });
 
-      final result = await decrypted.readAsBytes();
-      expect(result, originalData);
+    test('the refusal arrives before either path is touched', () async {
+      final tempDir = await Directory.systemTemp.createTemp('untouched_test');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final missing = '${tempDir.path}/absent.bin';
+      final output = '${tempDir.path}/nested/deeper/out.bin';
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
+
+      // A missing input and an unreachable output would both fail with an I/O
+      // error further in, so a disabled-format error means neither was tried.
+      for (final progress in [
+        CompressionService.compressAndEncryptFile(
+          inputPath: missing,
+          outputPath: output,
+          cipher: cipher,
+        ),
+        CompressionService.decryptAndDecompressFile(
+          inputPath: missing,
+          outputPath: output,
+          cipher: cipher,
+        ),
+      ]) {
+        final outcome = await drain(progress);
+
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      }
+
+      expect(Directory('${tempDir.path}/nested').existsSync(), isFalse);
+    });
+
+    test('an already-compressed name is refused the same way', () async {
+      final tempDir = await Directory.systemTemp.createTemp('jpg_test');
+      addTearDown(() => tempDir.delete(recursive: true));
+      final input = File('${tempDir.path}/photo.jpg');
+      final encrypted = File('${tempDir.path}/photo.enc');
+
+      await input.writeAsBytes(Uint8List.fromList([0xFF, 0xD8, 0xFF, 0xE0]));
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
+
+      final outcome = await drain(
+        CompressionService.compressAndEncryptFile(
+          inputPath: input.path,
+          outputPath: encrypted.path,
+          cipher: cipher,
+        ),
+      );
+
+      expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      expect(encrypted.existsSync(), isFalse);
     });
   });
 }

--- a/integration_test/evfs_enhancements_test.dart
+++ b/integration_test/evfs_enhancements_test.dart
@@ -6,6 +6,11 @@ import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/evfs/vault_service.dart';
+import 'package:m_security/src/rust/api/evfs/types.dart';
+
+// Every vault here is the unauthenticated v1/v2 format, which VaultService
+// refuses unless the caller says so.
+const _unsafeLegacy = UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -29,6 +34,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([1, 2, 3, 4, 5]);
@@ -57,6 +63,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([10, 20, 30]);
@@ -81,6 +88,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([1, 2, 3]);
@@ -116,6 +124,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([7, 8, 9]);
@@ -128,7 +137,11 @@ void main() {
       await VaultService.close(handle: handle);
 
       // Reopen and verify
-      handle = await VaultService.open(path: path, key: key);
+      handle = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       final result = await VaultService.read(
         handle: handle,
         name: 'persist.bin',
@@ -158,6 +171,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([1, 2, 3, 4, 5]);
@@ -197,6 +211,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -233,6 +248,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await expectLater(
@@ -258,6 +274,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([42]);
@@ -300,6 +317,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -327,6 +345,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // No writes — flush should be a safe no-op
@@ -354,6 +373,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write 5 segments
@@ -391,6 +411,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -426,6 +447,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final results = await VaultService.readParallel(
@@ -457,6 +479,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList(List.generate(500, (i) => i % 256));
@@ -514,6 +537,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 10 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final segments = <String, Uint8List>{};

--- a/integration_test/evfs_policy_test.dart
+++ b/integration_test/evfs_policy_test.dart
@@ -1,0 +1,258 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:m_security/m_security.dart';
+import 'package:m_security/src/rust/api/evfs.dart' as bridge;
+import 'package:m_security/src/rust/core/error.dart';
+
+import 'released_surface_consumer.dart' as released;
+
+/// The `.lock`, `.wal` and rotation files a vault path can grow.
+List<String> sidecars(String path) => [
+  path,
+  '$path.lock',
+  '$path.wal',
+  '$path.rotating',
+  '$path.defrag',
+].where((candidate) => File(candidate).existsSync()).toList();
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() async => await RustLib.init());
+
+  group('unsafe legacy vault policy', () {
+    late Directory tempDir;
+    late Uint8List key;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('evfs_policy_test');
+      key = await generateAes256GcmKey();
+    });
+    tearDown(() async => await tempDir.delete(recursive: true));
+
+    test('released source denies creation and writes nothing', () async {
+      final path = '${tempDir.path}/denied.vault';
+
+      await expectLater(
+        released.createVault(
+          path: path,
+          key: key,
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+
+      expect(sidecars(path), isEmpty);
+      expect(tempDir.listSync(), isEmpty);
+    });
+
+    test(
+      'released source denies opening and leaves the vault byte-identical',
+      () async {
+        final path = '${tempDir.path}/existing.vault';
+        final handle = await released.createVaultWithOptIn(
+          path: path,
+          key: key,
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        );
+        await released.writeSegment(
+          handle: handle,
+          name: 'note.txt',
+          data: Uint8List.fromList([7, 7, 7]),
+        );
+        await VaultService.close(handle: handle);
+
+        final before = await File(path).readAsBytes();
+        final beforeSidecars = sidecars(path);
+
+        await expectLater(
+          released.openVault(path: path, key: key),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+        );
+
+        expect(await File(path).readAsBytes(), before);
+        expect(sidecars(path), beforeSidecars);
+      },
+    );
+
+    test(
+      'the generated entry denies on its own, not just the wrapper',
+      () async {
+        final path = '${tempDir.path}/raw.vault';
+
+        // Straight at the bridge function, with the wrapper out of the way.
+        await expectLater(
+          bridge.vaultCreate(
+            path: path,
+            key: key,
+            algorithm: 'aes-256-gcm',
+            capacityBytes: BigInt.from(1024 * 1024),
+            unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.deny,
+          ),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+        );
+        expect(sidecars(path), isEmpty);
+
+        await expectLater(
+          bridge.vaultOpen(
+            path: path,
+            key: key,
+            unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.deny,
+          ),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+        );
+        expect(sidecars(path), isEmpty);
+      },
+    );
+
+    test('the generated entry accepts the opt-in', () async {
+      final path = '${tempDir.path}/raw_optin.vault';
+
+      final handle = await bridge.vaultCreate(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: BigInt.from(1024 * 1024),
+        unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+      );
+      await VaultService.close(handle: handle);
+
+      expect(File(path).existsSync(), isTrue);
+
+      final reopened = await bridge.vaultOpen(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+      );
+      await VaultService.close(handle: reopened);
+    });
+
+    test('an opt-in round trip still denies the next default call', () async {
+      final path = '${tempDir.path}/roundtrip.vault';
+      final payload = Uint8List.fromList(List.generate(2048, (i) => i % 256));
+
+      final handle = await released.createVaultWithOptIn(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      await released.writeSegment(
+        handle: handle,
+        name: 'payload.bin',
+        data: payload,
+      );
+      await VaultService.close(handle: handle);
+
+      final reopened = await released.openVaultWithOptIn(path: path, key: key);
+      expect(
+        await released.readSegment(handle: reopened, name: 'payload.bin'),
+        payload,
+      );
+      await VaultService.close(handle: reopened);
+
+      for (var attempt = 0; attempt < 3; attempt++) {
+        await expectLater(
+          released.openVault(path: path, key: key),
+          throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+          reason: 'attempt $attempt was authorized by an earlier opt-in',
+        );
+      }
+    });
+
+    test('a live opted-in handle does not authorize a default call', () async {
+      final held = await released.createVaultWithOptIn(
+        path: '${tempDir.path}/held.vault',
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      addTearDown(() => VaultService.close(handle: held));
+
+      await expectLater(
+        released.createVault(
+          path: '${tempDir.path}/second.vault',
+          key: await generateAes256GcmKey(),
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+      expect(File('${tempDir.path}/second.vault').existsSync(), isFalse);
+    });
+
+    test('a rotated vault still needs the opt-in to reopen', () async {
+      final path = '${tempDir.path}/rotated.vault';
+      final newKey = await generateAes256GcmKey();
+
+      var handle = await released.createVaultWithOptIn(
+        path: path,
+        key: key,
+        algorithm: 'aes-256-gcm',
+        capacityBytes: 1024 * 1024,
+      );
+      await released.writeSegment(
+        handle: handle,
+        name: 'a.bin',
+        data: Uint8List.fromList([1, 2, 3]),
+      );
+      handle = await VaultService.rotateKey(handle: handle, newKey: newKey);
+      expect(
+        await released.readSegment(handle: handle, name: 'a.bin'),
+        Uint8List.fromList([1, 2, 3]),
+      );
+      await VaultService.close(handle: handle);
+
+      await expectLater(
+        released.openVault(path: path, key: newKey),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+      final reopened = await released.openVaultWithOptIn(
+        path: path,
+        key: newKey,
+      );
+      await VaultService.close(handle: reopened);
+    });
+
+    test('denial does not depend on the arguments being usable', () async {
+      final path = '${tempDir.path}/bad_args.vault';
+
+      // An empty key and an unknown algorithm are both rejected further in, so
+      // seeing the denial means the check ran before either.
+      await expectLater(
+        released.createVault(
+          path: path,
+          key: Uint8List(0),
+          algorithm: 'not-an-algorithm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError_UnsafeLegacyFormatDenied>()),
+      );
+      expect(sidecars(path), isEmpty);
+
+      // Both really are rejected, so the case is not vacuous.
+      await expectLater(
+        released.createVaultWithOptIn(
+          path: path,
+          key: Uint8List(0),
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError>()),
+      );
+      await expectLater(
+        released.createVaultWithOptIn(
+          path: path,
+          key: key,
+          algorithm: 'not-an-algorithm',
+          capacityBytes: 1024 * 1024,
+        ),
+        throwsA(isA<CryptoError>()),
+      );
+    });
+  });
+}

--- a/integration_test/evfs_test.dart
+++ b/integration_test/evfs_test.dart
@@ -7,6 +7,11 @@ import 'package:m_security/src/rust/api/compression.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/evfs/vault_service.dart';
+import 'package:m_security/src/rust/api/evfs/types.dart';
+
+// Every vault here is the unauthenticated v1/v2 format, which VaultService
+// refuses unless the caller says so.
+const _unsafeLegacy = UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -32,6 +37,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //segment
@@ -42,7 +48,11 @@ void main() {
       await VaultService.close(handle: handle);
 
       //reopen vault
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       //read segment
       final result = await VaultService.read(
@@ -64,6 +74,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024, //5MB
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data1 = Uint8List.fromList(List.generate(1000, (i) => i % 256));
@@ -108,6 +119,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write original
@@ -139,6 +151,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       expect(
@@ -158,6 +171,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //write a segment
@@ -189,6 +203,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024, // 1MB total
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //Try to write 1MB of data (will fail because index takes space too)
@@ -221,12 +236,17 @@ void main() {
         key: keyA,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
       await VaultService.close(handle: handle);
 
       //try to open with keyB
       expect(
-        () async => await VaultService.open(path: path, key: keyB),
+        () async => await VaultService.open(
+          path: path,
+          key: keyB,
+          unsafeLegacyPolicy: _unsafeLegacy,
+        ),
         throwsA(isA<Exception>()),
       );
     });
@@ -240,18 +260,27 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       //try to open again without closing first
       expect(
-        () async => await VaultService.open(path: path, key: key),
+        () async => await VaultService.open(
+          path: path,
+          key: key,
+          unsafeLegacyPolicy: _unsafeLegacy,
+        ),
         throwsA(predicate((e) => e.toString().contains('vaultLocked'))),
       );
 
       await VaultService.close(handle: handle);
 
       //now it should work!
-      final handle2 = await VaultService.open(path: path, key: key);
+      final handle2 = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       await VaultService.close(handle: handle2);
     });
 
@@ -264,6 +293,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
       //write 3 segments
       await VaultService.write(
@@ -299,6 +329,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: totalCapacity,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Check initial capacity
@@ -329,6 +360,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
       final data = Uint8List.fromList(List.generate(10000, (i) => i % 256));
       await VaultService.write(
@@ -352,6 +384,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList(List.generate(10000, (i) => i % 256));
@@ -379,6 +412,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Fake JPEG data
@@ -414,6 +448,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 5 * 1024 * 1024, // 5MB
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Prepare test data (compressible - lots of repeats)
@@ -508,6 +543,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write data
@@ -526,7 +562,11 @@ void main() {
       await file.writeAsBytes(bytes);
 
       // Reopen
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Try to read → should detect tampering via checksum
       expect(
@@ -546,6 +586,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       // Write some data
@@ -560,7 +601,11 @@ void main() {
       await VaultService.close(handle: handle);
 
       // Reopen (WAL recovery runs but finds everything committed)
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Verify data survived
       final result = await VaultService.read(
@@ -579,7 +624,11 @@ void main() {
 
       // Close and reopen again
       await VaultService.close(handle: reopened);
-      final reopened2 = await VaultService.open(path: path, key: key);
+      final reopened2 = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Both segments should exist
       final result1 = await VaultService.read(
@@ -606,6 +655,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final originalData = Uint8List.fromList([1, 2, 3, 4, 5]);
@@ -638,7 +688,11 @@ void main() {
       await file.writeAsBytes(bytes);
 
       // Try to reopen
-      final reopened = await VaultService.open(path: path, key: key);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
 
       // Read data - should work because shadow index has it
       final result = await VaultService.read(
@@ -654,7 +708,11 @@ void main() {
       await VaultService.close(handle: reopened);
 
       // Reopen again - primary should be restored now
-      final reopened2 = await VaultService.open(path: path, key: key);
+      final reopened2 = await VaultService.open(
+        path: path,
+        key: key,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       final result2 = await VaultService.read(
         handle: reopened2,
         name: 'important.bin',

--- a/integration_test/released_surface_consumer.dart
+++ b/integration_test/released_surface_consumer.dart
@@ -1,0 +1,159 @@
+/// A consumer written the way the released storage surface documented it, kept
+/// as a compile fixture.
+///
+/// Nothing here passes the unsafe-format policy or catches a disabled-format
+/// result: that is the point. Every call has to keep resolving under the same
+/// name, argument names and types, so `dart analyze` over this directory is what
+/// proves existing source still builds against the patch. The tests that import
+/// it are the ones that pin down what the calls now do at run time.
+library;
+
+import 'dart:typed_data';
+
+import 'package:m_security/m_security.dart';
+
+Future<VaultHandle> createVault({
+  required String path,
+  required Uint8List key,
+  required String algorithm,
+  required int capacityBytes,
+}) {
+  return VaultService.create(
+    path: path,
+    key: key,
+    algorithm: algorithm,
+    capacityBytes: capacityBytes,
+  );
+}
+
+Future<VaultHandle> openVault({required String path, required Uint8List key}) {
+  return VaultService.open(path: path, key: key);
+}
+
+Future<void> writeSegment({
+  required VaultHandle handle,
+  required String name,
+  required Uint8List data,
+}) {
+  return VaultService.write(handle: handle, name: name, data: data);
+}
+
+Future<Uint8List> readSegment({
+  required VaultHandle handle,
+  required String name,
+}) async {
+  return (await VaultService.read(handle: handle, name: name)).data;
+}
+
+Future<void> exportArchive({
+  required VaultHandle handle,
+  required Uint8List wrappingKey,
+  required String exportPath,
+}) {
+  return VaultService.export(
+    handle: handle,
+    wrappingKey: wrappingKey,
+    exportPath: exportPath,
+  );
+}
+
+Future<VaultHandle> importArchive({
+  required String archivePath,
+  required Uint8List wrappingKey,
+  required String destPath,
+  required Uint8List newMasterKey,
+  required String algorithm,
+  required int capacityBytes,
+}) {
+  return VaultService.importVault(
+    archivePath: archivePath,
+    wrappingKey: wrappingKey,
+    destPath: destPath,
+    newMasterKey: newMasterKey,
+    algorithm: algorithm,
+    capacityBytes: capacityBytes,
+  );
+}
+
+Stream<double> encryptStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return StreamingService.encryptFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+  );
+}
+
+Stream<double> decryptStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return StreamingService.decryptFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+  );
+}
+
+Stream<double> compressStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return CompressionService.compressAndEncryptFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+    config: const CompressionConfig(algorithm: CompressionAlgorithm.zstd),
+  );
+}
+
+Stream<double> decompressStream({
+  required String inputPath,
+  required String outputPath,
+  required CipherHandle cipher,
+}) {
+  return CompressionService.decryptAndDecompressFile(
+    inputPath: inputPath,
+    outputPath: outputPath,
+    cipher: cipher,
+  );
+}
+
+Future<Uint8List> hashWholeFile({
+  required String filePath,
+  required HasherHandle hasher,
+}) {
+  return StreamingService.hashFile(filePath: filePath, hasher: hasher);
+}
+
+/// The one call that has to be written differently to keep working.
+Future<VaultHandle> createVaultWithOptIn({
+  required String path,
+  required Uint8List key,
+  required String algorithm,
+  required int capacityBytes,
+}) {
+  return VaultService.create(
+    path: path,
+    key: key,
+    algorithm: algorithm,
+    capacityBytes: capacityBytes,
+    unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+  );
+}
+
+Future<VaultHandle> openVaultWithOptIn({
+  required String path,
+  required Uint8List key,
+}) {
+  return VaultService.open(
+    path: path,
+    key: key,
+    unsafeLegacyPolicy: UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2,
+  );
+}

--- a/integration_test/streaming_test.dart
+++ b/integration_test/streaming_test.dart
@@ -1,59 +1,39 @@
+import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
+import 'package:m_security/src/rust/core/error.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/streaming/streaming_service.dart';
 import 'package:m_security/src/rust/api/hashing.dart';
+
+/// Drain a progress stream, keeping the values and the errors apart.
+Future<({List<double> values, List<Object> errors})> drain(
+  Stream<double> progress,
+) async {
+  final values = <double>[];
+  final errors = <Object>[];
+  final done = Completer<void>();
+
+  progress.listen(
+    values.add,
+    onError: errors.add,
+    onDone: done.complete,
+    cancelOnError: false,
+  );
+  await done.future;
+
+  return (values: values, errors: errors);
+}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() async => await RustLib.init());
 
   group('Streaming', () {
-    test('encrypt then decrypt file roundtrip', () async {
-      //Create temp file with known content
-      //→ encrypt → decrypt → compare bytes identical
-      final tempDir = await Directory.systemTemp.createTemp('stream_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      final originalData = Uint8List.fromList(
-        List.generate(100000, (i) => i % 256),
-      );
-      await inputFile.writeAsBytes(originalData);
-
-      //generate key and create cipher
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      //Encrypt
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {
-        //wait for completion
-      }
-      //Decrypt
-      await for (final _ in StreamingService.decryptFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {
-        //wait for completion
-      }
-      //verify
-      final result = await decrypted.readAsBytes();
-      expect(result, originalData);
-
-      //cleanup
-      await tempDir.delete(recursive: true);
-    });
-
     test('streaming hash matches one-shot hash', () async {
       final tempDir = await Directory.systemTemp.createTemp('hash_test');
       final file = File('${tempDir.path}/test.bin');
@@ -76,205 +56,94 @@ void main() {
       await tempDir.delete(recursive: true);
     });
 
-    test('progress reports from 0 to 1', () async {
-      final tempDir = await Directory.systemTemp.createTemp('progress_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
+    test(
+      'encryptFile emits one disabled-format error and writes nothing',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('stream_test');
+        final inputFile = File('${tempDir.path}/input.bin');
+        final encrypted = File('${tempDir.path}/encrypted.bin');
 
-      // create 1MB file
-      final data = Uint8List(1024 * 1024);
-      await inputFile.writeAsBytes(data);
+        await inputFile.writeAsBytes(
+          Uint8List.fromList(List.generate(100000, (i) => i % 256)),
+        );
+        final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
 
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
+        final outcome = await drain(
+          StreamingService.encryptFile(
+            inputPath: inputFile.path,
+            outputPath: encrypted.path,
+            cipher: cipher,
+          ),
+        );
 
-      final progressValues = <double>[];
+        expect(outcome.values, isEmpty);
+        expect(outcome.errors, hasLength(1));
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+        expect(encrypted.existsSync(), isFalse);
+        expect(File('${encrypted.path}.tmp').existsSync(), isFalse);
 
-      await for (final progress in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {
-        progressValues.add(progress);
-      }
+        await tempDir.delete(recursive: true);
+      },
+    );
 
-      //verify progress goes from ~0 to 1
-      expect(progressValues.first, lessThan(0.1));
-      expect(progressValues.last, closeTo(1.0, 0.01));
+    test(
+      'decryptFile emits one disabled-format error and writes nothing',
+      () async {
+        final tempDir = await Directory.systemTemp.createTemp('stream_test');
+        final encrypted = File('${tempDir.path}/encrypted.bin');
+        final decrypted = File('${tempDir.path}/decrypted.bin');
 
-      // verify monotonically increasing
-      for (int i = 1; i < progressValues.length; i++) {
-        expect(progressValues[i], greaterThanOrEqualTo(progressValues[i - 1]));
-      }
+        // Bytes that start like an MSSE stream, so nothing but the refusal keeps
+        // the parser away from them.
+        await encrypted.writeAsBytes(
+          Uint8List.fromList([0x4D, 0x53, 0x53, 0x45, 1, 0, 0, 0]),
+        );
+        final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
 
-      await tempDir.delete(recursive: true);
-    });
-
-    test('wrong key fails decryption', () async {
-      final tempDir = await Directory.systemTemp.createTemp('wrongkey_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      await inputFile.writeAsBytes(Uint8List.fromList([1, 2, 3, 4, 5]));
-
-      final keyA = await generateAes256GcmKey();
-      final cipherA = await createAes256Gcm(key: keyA);
-
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipherA,
-      )) {}
-
-      final keyB = await generateAes256GcmKey();
-      final cipherB = await createAes256Gcm(key: keyB);
-
-      bool errorThrown = false;
-      try {
-        await for (final _ in StreamingService.decryptFile(
-          inputPath: encrypted.path,
-          outputPath: decrypted.path,
-          cipher: cipherB,
-        )) {}
-      } catch (e) {
-        errorThrown = true;
-      }
-      expect(errorThrown, true);
-
-      await tempDir.delete(recursive: true);
-    });
-
-    test('empty file roundtrip', () async {
-      final tempDir = await Directory.systemTemp.createTemp('empty_test');
-      final inputFile = File('${tempDir.path}/empty.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      await inputFile.writeAsBytes(Uint8List(0)); // Empty file
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-
-      await for (final _ in StreamingService.decryptFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final result = await decrypted.readAsBytes();
-      expect(result.length, 0);
-
-      await tempDir.delete(recursive: true);
-    });
-
-    test('small file padding stripped correctly', () async {
-      final tempDir = await Directory.systemTemp.createTemp('padding_test');
-      final inputFile = File('${tempDir.path}/small.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-      
-      final originalData = Uint8List(100); // exactly 100 bytes
-      await inputFile.writeAsBytes(originalData);
-      
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-      
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-      
-      await for (final _ in StreamingService.decryptFile(
-        inputPath: encrypted.path,
-        outputPath: decrypted.path,
-        cipher: cipher,
-      )) {}
-      
-      final result = await decrypted.readAsBytes();
-      expect(result.length, 100, reason: 'Padding should be stripped, output should be exactly 100 bytes, not 64KB');
-      
-      await tempDir.delete(recursive: true);
-    });
-
-    test('encrypted chunks are uniform size', () async {
-      final tempDir = await Directory.systemTemp.createTemp('uniform_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      
-      // Create file that doesn't fill last chunk 
-      final data = Uint8List(150);
-      await inputFile.writeAsBytes(data);
-      
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-      
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-      
-      final encryptedSize = await encrypted.length();
-      const streamHeaderSize = 16;
-      const encryptedChunkSize = 65564;
-      
-      final dataPortionSize = encryptedSize - streamHeaderSize;
-      
-      expect(
-        dataPortionSize % encryptedChunkSize,
-        0,
-        reason: 'All encrypted chunks should be uniform size. Got file size $encryptedSize',
-      );
-      
-      await tempDir.delete(recursive: true);
-    });
-
-    test('tampered padding detected end-to-end', () async {
-      final tempDir = await Directory.systemTemp.createTemp('tamper_test');
-      final inputFile = File('${tempDir.path}/input.bin');
-      final encrypted = File('${tempDir.path}/encrypted.bin');
-      final tampered = File('${tempDir.path}/tampered.bin');
-      final decrypted = File('${tempDir.path}/decrypted.bin');
-
-      final data = Uint8List(100);
-      await inputFile.writeAsBytes(data);
-
-      final key = await generateAes256GcmKey();
-      final cipher = await createAes256Gcm(key: key);
-
-      await for (final _ in StreamingService.encryptFile(
-        inputPath: inputFile.path,
-        outputPath: encrypted.path,
-        cipher: cipher,
-      )) {}
-
-      final encryptedBytes = await encrypted.readAsBytes();
-      final tamperedBytes = Uint8List.fromList(encryptedBytes);
-      tamperedBytes[tamperedBytes.length - 100] ^= 0xFF;
-      await tampered.writeAsBytes(tamperedBytes);
-
-      await expectLater(
-        Future(() async {
-          await for (final _ in StreamingService.decryptFile(
-            inputPath: tampered.path,
+        final outcome = await drain(
+          StreamingService.decryptFile(
+            inputPath: encrypted.path,
             outputPath: decrypted.path,
             cipher: cipher,
-          )) {}
-        }),
-        throwsA(anything),
-        reason: 'Tampered padding should be detected and throw error',
-      );
+          ),
+        );
 
+        expect(outcome.values, isEmpty);
+        expect(outcome.errors, hasLength(1));
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+        expect(decrypted.existsSync(), isFalse);
+
+        await tempDir.delete(recursive: true);
+      },
+    );
+
+    test('the refusal arrives before either path is touched', () async {
+      final tempDir = await Directory.systemTemp.createTemp('stream_test');
+      final missing = '${tempDir.path}/absent.bin';
+      final output = '${tempDir.path}/nested/deeper/out.bin';
+      final cipher = await createAes256Gcm(key: await generateAes256GcmKey());
+
+      // A missing input and an unreachable output would both fail with an I/O
+      // error further in, so a disabled-format error means neither was tried.
+      for (final progress in [
+        StreamingService.encryptFile(
+          inputPath: missing,
+          outputPath: output,
+          cipher: cipher,
+        ),
+        StreamingService.decryptFile(
+          inputPath: missing,
+          outputPath: output,
+          cipher: cipher,
+        ),
+      ]) {
+        final outcome = await drain(progress);
+
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      }
+
+      expect(Directory('${tempDir.path}/nested').existsSync(), isFalse);
       await tempDir.delete(recursive: true);
     });
-
   });
 }

--- a/integration_test/vault_key_management_test.dart
+++ b/integration_test/vault_key_management_test.dart
@@ -6,6 +6,12 @@ import 'package:integration_test/integration_test.dart';
 import 'package:m_security/src/rust/api/encryption.dart';
 import 'package:m_security/src/rust/frb_generated.dart';
 import 'package:m_security/src/evfs/vault_service.dart';
+import 'package:m_security/src/rust/api/evfs/types.dart';
+import 'package:m_security/src/rust/core/error.dart';
+
+// Every vault here is the unauthenticated v1/v2 format, which VaultService
+// refuses unless the caller says so.
+const _unsafeLegacy = UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -30,6 +36,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final dataA = Uint8List.fromList(List.generate(500, (i) => i % 256));
@@ -57,6 +64,7 @@ void main() {
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       await VaultService.write(
@@ -68,14 +76,23 @@ void main() {
       handle = await VaultService.rotateKey(handle: handle, newKey: newKey);
       await VaultService.close(handle: handle);
 
-      // Old key must fail
-      expect(
-        () async => await VaultService.open(path: path, key: key),
+      // Old key must fail. Awaited, because an attempt still in flight holds
+      // the vault lock the next open needs.
+      await expectLater(
+        VaultService.open(
+          path: path,
+          key: key,
+          unsafeLegacyPolicy: _unsafeLegacy,
+        ),
         throwsA(isA<Exception>()),
       );
 
       // New key works
-      final reopened = await VaultService.open(path: path, key: newKey);
+      final reopened = await VaultService.open(
+        path: path,
+        key: newKey,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       expect(
         (await VaultService.read(handle: reopened, name: 'secret.bin')).data,
         Uint8List.fromList([1, 2, 3]),
@@ -83,127 +100,56 @@ void main() {
       await VaultService.close(handle: reopened);
     });
 
-    test('export-import roundtrip: data matches byte-for-byte', () async {
+    test('export is disabled and writes no archive', () async {
       final vaultPath = '${tempDir.path}/source.vault';
       final archivePath = '${tempDir.path}/export.mvex';
-      final importPath = '${tempDir.path}/imported.vault';
       final key = await generateAes256GcmKey();
       final wrappingKey = await generateAes256GcmKey();
-      final importKey = await generateAes256GcmKey();
 
-      var handle = await VaultService.create(
+      final handle = await VaultService.create(
         path: vaultPath,
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
+      final data = Uint8List.fromList(List.generate(800, (i) => i % 256));
+      await VaultService.write(handle: handle, name: 'file1.dat', data: data);
+
+      await expectLater(
+        VaultService.export(
+          handle: handle,
+          wrappingKey: wrappingKey,
+          exportPath: archivePath,
+        ),
+        throwsA(isA<CryptoError_DisabledFormat>()),
       );
 
-      final data1 = Uint8List.fromList(List.generate(800, (i) => i % 256));
-      final data2 = Uint8List.fromList(List.generate(1200, (i) => (i * 3) % 256));
-      await VaultService.write(handle: handle, name: 'file1.dat', data: data1);
-      await VaultService.write(handle: handle, name: 'file2.dat', data: data2);
-
-      // Export
-      await VaultService.export(
-        handle: handle,
-        wrappingKey: wrappingKey,
-        exportPath: archivePath,
-      );
+      expect(File(archivePath).existsSync(), isFalse);
+      // The vault itself is untouched by the refusal.
+      expect((await VaultService.read(handle: handle, name: 'file1.dat')).data, data);
       await VaultService.close(handle: handle);
-
-      expect(File(archivePath).existsSync(), isTrue);
-
-      // Import into new vault
-      final imported = await VaultService.importVault(
-        archivePath: archivePath,
-        wrappingKey: wrappingKey,
-        destPath: importPath,
-        newMasterKey: importKey,
-        algorithm: 'aes-256-gcm',
-        capacityBytes: 2 * 1024 * 1024,
-      );
-
-      expect((await VaultService.read(handle: imported, name: 'file1.dat')).data, data1);
-      expect((await VaultService.read(handle: imported, name: 'file2.dat')).data, data2);
-
-      await VaultService.close(handle: imported);
     });
 
-    test('import with wrong wrapping key throws', () async {
-      final vaultPath = '${tempDir.path}/wk.vault';
-      final archivePath = '${tempDir.path}/wk.mvex';
-      final key = await generateAes256GcmKey();
-      final wrappingKey = await generateAes256GcmKey();
-      final wrongKey = await generateAes256GcmKey();
+    test('import is disabled and writes no destination vault', () async {
+      final archivePath = '${tempDir.path}/absent.mvex';
+      final importPath = '${tempDir.path}/imported.vault';
 
-      var handle = await VaultService.create(
-        path: vaultPath,
-        key: key,
-        algorithm: 'aes-256-gcm',
-        capacityBytes: 1024 * 1024,
-      );
-      await VaultService.write(
-        handle: handle,
-        name: 'x.bin',
-        data: Uint8List.fromList([42]),
-      );
-      await VaultService.export(
-        handle: handle,
-        wrappingKey: wrappingKey,
-        exportPath: archivePath,
-      );
-      await VaultService.close(handle: handle);
-
-      expect(
-        () async => await VaultService.importVault(
+      await expectLater(
+        VaultService.importVault(
           archivePath: archivePath,
-          wrappingKey: wrongKey,
-          destPath: '${tempDir.path}/bad.vault',
+          wrappingKey: await generateAes256GcmKey(),
+          destPath: importPath,
           newMasterKey: await generateAes256GcmKey(),
           algorithm: 'aes-256-gcm',
-          capacityBytes: 1024 * 1024,
+          capacityBytes: 2 * 1024 * 1024,
         ),
-        throwsA(isA<Exception>()),
-      );
-    });
-
-    test('large segment (1MB+) survives export-import', () async {
-      final vaultPath = '${tempDir.path}/big.vault';
-      final archivePath = '${tempDir.path}/big.mvex';
-      final importPath = '${tempDir.path}/big_imported.vault';
-      final key = await generateAes256GcmKey();
-      final wrappingKey = await generateAes256GcmKey();
-
-      var handle = await VaultService.create(
-        path: vaultPath,
-        key: key,
-        algorithm: 'aes-256-gcm',
-        capacityBytes: 5 * 1024 * 1024,
+        throwsA(isA<CryptoError_DisabledFormat>()),
       );
 
-      final bigData = Uint8List.fromList(
-        List.generate(1024 * 1024 + 37, (i) => (i * 13) % 256),
-      );
-      await VaultService.write(handle: handle, name: 'big.bin', data: bigData);
-
-      await VaultService.export(
-        handle: handle,
-        wrappingKey: wrappingKey,
-        exportPath: archivePath,
-      );
-      await VaultService.close(handle: handle);
-
-      final imported = await VaultService.importVault(
-        archivePath: archivePath,
-        wrappingKey: wrappingKey,
-        destPath: importPath,
-        newMasterKey: await generateAes256GcmKey(),
-        algorithm: 'aes-256-gcm',
-        capacityBytes: 5 * 1024 * 1024,
-      );
-
-      expect((await VaultService.read(handle: imported, name: 'big.bin')).data, bigData);
-      await VaultService.close(handle: imported);
+      expect(File(importPath).existsSync(), isFalse);
+      expect(File('$importPath.lock').existsSync(), isFalse);
+      expect(File('$importPath.wal').existsSync(), isFalse);
     });
 
     test('multiple sequential rotations', () async {
@@ -217,6 +163,7 @@ void main() {
         key: key1,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList([10, 20, 30, 40, 50]);
@@ -232,56 +179,50 @@ void main() {
       await VaultService.close(handle: handle);
 
       // Only key3 works
-      final reopened = await VaultService.open(path: path, key: key3);
+      final reopened = await VaultService.open(
+        path: path,
+        key: key3,
+        unsafeLegacyPolicy: _unsafeLegacy,
+      );
       expect((await VaultService.read(handle: reopened, name: 'data.bin')).data, data);
       await VaultService.close(handle: reopened);
     });
 
-    test('rotate then export-import the rotated vault', () async {
+    test('a rotated vault stays readable after export is refused', () async {
       final vaultPath = '${tempDir.path}/rot_exp.vault';
       final archivePath = '${tempDir.path}/rot_exp.mvex';
-      final importPath = '${tempDir.path}/rot_exp_imported.vault';
       final key = await generateAes256GcmKey();
       final rotatedKey = await generateAes256GcmKey();
       final wrappingKey = await generateAes256GcmKey();
-      final importKey = await generateAes256GcmKey();
 
       var handle = await VaultService.create(
         path: vaultPath,
         key: key,
         algorithm: 'aes-256-gcm',
         capacityBytes: 2 * 1024 * 1024,
+        unsafeLegacyPolicy: _unsafeLegacy,
       );
 
       final data = Uint8List.fromList(List.generate(256, (i) => i));
       await VaultService.write(handle: handle, name: 'payload.bin', data: data);
 
-      // Rotate first
       handle = await VaultService.rotateKey(handle: handle, newKey: rotatedKey);
 
-      // Then export
-      await VaultService.export(
-        handle: handle,
-        wrappingKey: wrappingKey,
-        exportPath: archivePath,
-      );
-      await VaultService.close(handle: handle);
-
-      // Import
-      final imported = await VaultService.importVault(
-        archivePath: archivePath,
-        wrappingKey: wrappingKey,
-        destPath: importPath,
-        newMasterKey: importKey,
-        algorithm: 'aes-256-gcm',
-        capacityBytes: 2 * 1024 * 1024,
+      await expectLater(
+        VaultService.export(
+          handle: handle,
+          wrappingKey: wrappingKey,
+          exportPath: archivePath,
+        ),
+        throwsA(isA<CryptoError_DisabledFormat>()),
       );
 
+      expect(File(archivePath).existsSync(), isFalse);
       expect(
-        (await VaultService.read(handle: imported, name: 'payload.bin')).data,
+        (await VaultService.read(handle: handle, name: 'payload.bin')).data,
         data,
       );
-      await VaultService.close(handle: imported);
+      await VaultService.close(handle: handle);
     });
   });
 }

--- a/lib/m_security.dart
+++ b/lib/m_security.dart
@@ -25,7 +25,12 @@ export 'src/rust/api/hashing.dart'
 export 'src/rust/api/compression.dart'
     show CompressionConfig, CompressionAlgorithm;
 export 'src/rust/api/evfs/types.dart'
-    show VaultHandle, DefragResult, VaultCapacityInfo, VaultHealthInfo;
+    show
+        VaultHandle,
+        DefragResult,
+        VaultCapacityInfo,
+        VaultHealthInfo,
+        UnsafeLegacyEvfsPolicy;
 export 'src/streaming/streaming_service.dart';
 export 'src/compression/compression_service.dart';
 export 'src/evfs/vault_service.dart';

--- a/lib/src/compression/compression_service.dart
+++ b/lib/src/compression/compression_service.dart
@@ -1,19 +1,22 @@
-import 'dart:async';
-
 import 'package:m_security/src/rust/api/compression.dart';
 import 'package:m_security/src/rust/api/encryption.dart' as rust_encryption;
-import 'package:m_security/src/rust/api/streaming.dart' as rust_streaming;
+import 'package:m_security/src/rust/core/error.dart';
 
-/// Compressed streaming file operations (compress+encrypt, decrypt+decompress).
+/// Compressed streaming file operations.
 ///
-/// Uses stream-compress-then-chunk: input is compressed as a stream, then
-/// the compressed bytes are chunked and encrypted. Decompression algorithm
-/// is stored in the file header — decrypt needs no config.
+/// Both are disabled in this release. They wrote and read the same encrypted
+/// stream format as the plain streaming methods, whose header is unauthenticated
+/// and whose chunks are bound to nothing but their index and finality, so a
+/// chunk from another stream encrypted under the same handle splices in. The
+/// native entry points are gone and the methods below fail before touching
+/// either path.
 class CompressionService {
   CompressionService._();
 
-  /// Compress then encrypt a file.
-  /// Returns a Stream of progress (0.0 to 1.0).
+  /// Disabled. Kept so existing code still compiles.
+  ///
+  /// Emits one disabled-format error before reading [inputPath] or creating
+  /// [outputPath].
   static Stream<double> compressAndEncryptFile({
     required String inputPath,
     required String outputPath,
@@ -22,53 +25,22 @@ class CompressionService {
       algorithm: CompressionAlgorithm.zstd,
     ),
   }) {
-    return _guardedStream(
-      () => rust_streaming.streamCompressEncryptFile(
-        cipher: cipher,
-        compression: config,
-        inputPath: inputPath,
-        outputPath: outputPath,
-      ),
+    return Stream<double>.error(
+      const CryptoError.disabledFormat('compressed encrypted stream write'),
     );
   }
 
-  /// Decrypt then decompress a file.
-  /// Algorithm is read from the encrypted file header — no config needed.
+  /// Disabled. Kept so existing code still compiles.
+  ///
+  /// Emits one disabled-format error before reading [inputPath] or creating
+  /// [outputPath].
   static Stream<double> decryptAndDecompressFile({
     required String inputPath,
     required String outputPath,
     required rust_encryption.CipherHandle cipher,
   }) {
-    return _guardedStream(
-      () => rust_streaming.streamDecryptDecompressFile(
-        cipher: cipher,
-        inputPath: inputPath,
-        outputPath: outputPath,
-      ),
+    return Stream<double>.error(
+      const CryptoError.disabledFormat('compressed encrypted stream read'),
     );
-  }
-
-  static Stream<double> _guardedStream(Stream<double> Function() factory) {
-    final controller = StreamController<double>();
-    runZonedGuarded(
-      () {
-        factory().listen(
-          controller.add,
-          onError: controller.addError,
-          onDone: () {
-            Future(() {
-              if (!controller.isClosed) controller.close();
-            });
-          },
-        );
-      },
-      (error, stack) {
-        if (!controller.isClosed) {
-          controller.addError(error, stack);
-          controller.close();
-        }
-      },
-    );
-    return controller.stream;
   }
 }

--- a/lib/src/evfs/vault_service.dart
+++ b/lib/src/evfs/vault_service.dart
@@ -7,37 +7,58 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge.dart'
 import 'package:m_security/src/rust/api/evfs.dart' as rust_evfs;
 import 'package:m_security/src/rust/api/evfs/types.dart' as rust_types;
 import 'package:m_security/src/rust/api/compression.dart';
+import 'package:m_security/src/rust/core/error.dart';
 
 /// Encrypted Virtual File System — named segment storage in a .vault container.
 ///
 /// Compression is optional on write (pass [CompressionConfig]) and
 /// automatic on read (algorithm stored per-segment in the vault index).
+///
+/// The stored format derives its keys without a per-vault salt, repeats
+/// encryption nonces across vaults and copies, leaves its structural metadata
+/// unauthenticated and is not crash-atomic. [create] and [open] therefore
+/// refuse before they touch the path unless the caller passes
+/// [rust_types.UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2]. Opting in does
+/// not make an existing vault safe.
 class VaultService {
   VaultService._();
 
   /// Create a new vault file.
   ///
   /// [algorithm] must be "aes-256-gcm" or "chacha20-poly1305".
+  ///
+  /// Denied unless [unsafeLegacyPolicy] opts in.
   static Future<rust_types.VaultHandle> create({
     required String path,
     required Uint8List key,
     required String algorithm,
     required int capacityBytes,
+    rust_types.UnsafeLegacyEvfsPolicy unsafeLegacyPolicy =
+        rust_types.UnsafeLegacyEvfsPolicy.deny,
   }) {
     return rust_evfs.vaultCreate(
       path: path,
       key: key,
       algorithm: algorithm,
       capacityBytes: BigInt.from(capacityBytes),
+      unsafeLegacyPolicy: unsafeLegacyPolicy,
     );
   }
 
   /// Open an existing vault (runs WAL recovery if needed).
+  ///
+  /// Denied unless [unsafeLegacyPolicy] opts in.
   static Future<rust_types.VaultHandle> open({
     required String path,
     required Uint8List key,
+    rust_types.UnsafeLegacyEvfsPolicy unsafeLegacyPolicy =
+        rust_types.UnsafeLegacyEvfsPolicy.deny,
   }) {
-    return rust_evfs.vaultOpen(path: path, key: key);
+    return rust_evfs.vaultOpen(
+      path: path,
+      key: key,
+      unsafeLegacyPolicy: unsafeLegacyPolicy,
+    );
   }
 
   /// Write (or overwrite) a named segment.
@@ -287,25 +308,26 @@ class VaultService {
     return rust_evfs.vaultRotateKey(handle: handle, newKey: newKey);
   }
 
-  /// Export the vault to a portable encrypted archive (.mvex).
+  /// Disabled. Kept so existing code still compiles.
   ///
-  /// The archive is encrypted with a random ephemeral key wrapped by
-  /// [wrappingKey]. Share the wrapping key out-of-band for import.
+  /// The .mvex archive stores segment names, user metadata and content
+  /// checksums in the clear and its trailer is unkeyed and recomputable, so the
+  /// native entry point is gone and this fails before reading the vault or
+  /// creating [exportPath].
   static Future<void> export({
     required rust_types.VaultHandle handle,
     required Uint8List wrappingKey,
     required String exportPath,
   }) {
-    return rust_evfs.vaultExport(
-      handle: handle,
-      wrappingKey: wrappingKey,
-      exportPath: exportPath,
+    return Future<void>.error(
+      const CryptoError.disabledFormat('.mvex archive export'),
     );
   }
 
-  /// Import a vault from an encrypted archive (.mvex).
+  /// Disabled. Kept so existing code still compiles.
   ///
-  /// Creates a new vault at [destPath] re-encrypted under [newMasterKey].
+  /// See [export] for why the archive format is unreachable. This fails before
+  /// reading [archivePath] or creating anything at [destPath].
   static Future<rust_types.VaultHandle> importVault({
     required String archivePath,
     required Uint8List wrappingKey,
@@ -314,13 +336,8 @@ class VaultService {
     required String algorithm,
     required int capacityBytes,
   }) {
-    return rust_evfs.vaultImport(
-      archivePath: archivePath,
-      wrappingKey: wrappingKey,
-      destPath: destPath,
-      newMasterKey: newMasterKey,
-      algorithm: algorithm,
-      capacityBytes: BigInt.from(capacityBytes),
+    return Future<rust_types.VaultHandle>.error(
+      const CryptoError.disabledFormat('.mvex archive import'),
     );
   }
 

--- a/lib/src/rust/api/encryption.dart
+++ b/lib/src/rust/api/encryption.dart
@@ -7,7 +7,7 @@ import '../core/error.dart';
 import '../frb_generated.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `algorithm_id`, `decrypt_raw`, `encrypt_raw`, `new`
+// These functions are ignored because they are not marked as `pub`: `new`
 
 /// Create an AES-256-GCM cipher handle from a 32-byte key.
 Future<CipherHandle> createAes256Gcm({required List<int> key}) =>

--- a/lib/src/rust/api/evfs.dart
+++ b/lib/src/rust/api/evfs.dart
@@ -9,27 +9,46 @@ import 'compression.dart';
 import 'evfs/types.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `chunk_abs_offset`, `read_segment_from_mmap_inner`, `read_segment_from_mmap`, `read_segment_with_file_inner`, `read_segment_with_file`, `vault_export_write`, `vault_resize_grow_impl`, `vault_resize_shrink_impl`, `write_encrypted_chunk`
+// These functions are ignored because they are not marked as `pub`: `as_bytes`, `chunk_abs_offset`, `create_legacy_vault`, `new`, `open_legacy_vault`, `read_segment_from_mmap_inner`, `read_segment_from_mmap`, `read_segment_with_file_inner`, `read_segment_with_file`, `vault_create_guarded`, `vault_open_guarded`, `vault_resize_grow_impl`, `vault_resize_shrink_impl`, `vault_rotate_key_guarded`, `write_encrypted_chunk`
+// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `KeyGuard`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `drop`
 // These functions have error during generation (see debug logs or enable `stop_on_error: true` for more details): `vault_write_stream`
 
 /// Create a new vault file at `path` with the given capacity.
 ///
 /// The algorithm string must be "aes-256-gcm" or "chacha20-poly1305".
+///
+/// The vault format this writes is the unauthenticated v1/v2 one, so the call
+/// is refused before `path` is touched unless `unsafe_legacy_policy` is
+/// `AllowUnauthenticatedV1V2`.
 Future<VaultHandle> vaultCreate({
   required String path,
   required List<int> key,
   required String algorithm,
   required BigInt capacityBytes,
+  required UnsafeLegacyEvfsPolicy unsafeLegacyPolicy,
 }) => RustLib.instance.api.crateApiEvfsVaultCreate(
   path: path,
   key: key,
   algorithm: algorithm,
   capacityBytes: capacityBytes,
+  unsafeLegacyPolicy: unsafeLegacyPolicy,
 );
 
 /// Open an existing vault, running WAL recovery if needed.
-Future<VaultHandle> vaultOpen({required String path, required List<int> key}) =>
-    RustLib.instance.api.crateApiEvfsVaultOpen(path: path, key: key);
+///
+/// The stored format is the unauthenticated v1/v2 one, so the call is refused
+/// before `path` is touched unless `unsafe_legacy_policy` is
+/// `AllowUnauthenticatedV1V2`.
+Future<VaultHandle> vaultOpen({
+  required String path,
+  required List<int> key,
+  required UnsafeLegacyEvfsPolicy unsafeLegacyPolicy,
+}) => RustLib.instance.api.crateApiEvfsVaultOpen(
+  path: path,
+  key: key,
+  unsafeLegacyPolicy: unsafeLegacyPolicy,
+);
 
 /// Write (or overwrite) a named segment.
 ///
@@ -174,43 +193,6 @@ Future<VaultHandle> vaultRotateKey({
   newKey: newKey,
 );
 
-/// Export all vault segments into a self-contained `.mvex` encrypted archive.
-///
-/// Each segment is decrypted from the vault, then re-encrypted under an
-/// ephemeral export key with a random per-segment nonce. The export key is
-/// AEAD-wrapped with the caller's `wrapping_key`.
-///
-/// The vault is not modified by this operation.
-Future<void> vaultExport({
-  required VaultHandle handle,
-  required List<int> wrappingKey,
-  required String exportPath,
-}) => RustLib.instance.api.crateApiEvfsVaultExport(
-  handle: handle,
-  wrappingKey: wrappingKey,
-  exportPath: exportPath,
-);
-
 /// Close the vault — flush dirty index, checkpoint WAL, release lock, zeroize keys on drop.
 Future<void> vaultClose({required VaultHandle handle}) =>
     RustLib.instance.api.crateApiEvfsVaultClose(handle: handle);
-
-/// Unwraps export key, creates new vault at dest_path, writes all segments under new_master_key.
-///
-/// Archives with version < 2 do not carry per-segment metadata; imported
-/// segments from those archives will have empty metadata.
-Future<VaultHandle> vaultImport({
-  required String archivePath,
-  required List<int> wrappingKey,
-  required String destPath,
-  required List<int> newMasterKey,
-  required String algorithm,
-  required BigInt capacityBytes,
-}) => RustLib.instance.api.crateApiEvfsVaultImport(
-  archivePath: archivePath,
-  wrappingKey: wrappingKey,
-  destPath: destPath,
-  newMasterKey: newMasterKey,
-  algorithm: algorithm,
-  capacityBytes: capacityBytes,
-);

--- a/lib/src/rust/api/evfs/types.dart
+++ b/lib/src/rust/api/evfs/types.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
 // These functions are ignored because they are not marked as `pub`: `new`, `refresh_mmap`, `slice`
 // These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `VaultMmap`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `clone`, `drop`, `eq`, `eq`, `fmt`, `fmt`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `drop`, `eq`, `eq`, `eq`, `fmt`, `fmt`, `fmt`
 
 // Rust type: RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>
 abstract class VaultHandle implements RustOpaqueInterface {
@@ -90,6 +90,24 @@ class SegmentResult {
           name == other.name &&
           data == other.data &&
           error == other.error;
+}
+
+/// What a caller wants done about the unauthenticated v1/v2 vault format.
+///
+/// Vaults written by this and every earlier release derive their keys without a
+/// per-vault salt, repeat encryption nonces across vaults and copied files, do
+/// not authenticate their structural metadata and are not crash-atomic. Every
+/// entry point that takes a vault path therefore refuses by default, and a
+/// caller has to name the risk to reach one.
+///
+/// Opting in does not make an existing vault safe and does not change its bytes.
+enum UnsafeLegacyEvfsPolicy {
+  /// Refuse before the path is opened, created, locked or recovered. Every
+  /// wrapper defaults to this, and it is what a zeroed wire value decodes to.
+  deny,
+
+  /// Work against the unauthenticated v1/v2 format anyway.
+  allowUnauthenticatedV1V2,
 }
 
 /// Capacity info returned to callers.

--- a/lib/src/rust/api/streaming.dart
+++ b/lib/src/rust/api/streaming.dart
@@ -5,56 +5,10 @@
 
 import '../core/error.dart';
 import '../frb_generated.dart';
-import 'compression.dart';
-import 'encryption.dart';
 import 'hashing.dart';
 import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 
-// These functions are ignored because they are not marked as `pub`: `algorithm_from_id`, `defuse`, `new`, `open_input`, `parse_encrypted_output`, `read_full`, `reassemble_into`
-// These types are ignored because they are neither used by any `pub` functions nor (for structs and enums) marked `#[frb(unignore)]`: `TempFileGuard`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `drop`
-
-Stream<double> streamEncryptFile({
-  required CipherHandle cipher,
-  required String inputPath,
-  required String outputPath,
-}) => RustLib.instance.api.crateApiStreamingStreamEncryptFile(
-  cipher: cipher,
-  inputPath: inputPath,
-  outputPath: outputPath,
-);
-
-Stream<double> streamDecryptFile({
-  required CipherHandle cipher,
-  required String inputPath,
-  required String outputPath,
-}) => RustLib.instance.api.crateApiStreamingStreamDecryptFile(
-  cipher: cipher,
-  inputPath: inputPath,
-  outputPath: outputPath,
-);
-
-Stream<double> streamCompressEncryptFile({
-  required CipherHandle cipher,
-  required CompressionConfig compression,
-  required String inputPath,
-  required String outputPath,
-}) => RustLib.instance.api.crateApiStreamingStreamCompressEncryptFile(
-  cipher: cipher,
-  compression: compression,
-  inputPath: inputPath,
-  outputPath: outputPath,
-);
-
-Stream<double> streamDecryptDecompressFile({
-  required CipherHandle cipher,
-  required String inputPath,
-  required String outputPath,
-}) => RustLib.instance.api.crateApiStreamingStreamDecryptDecompressFile(
-  cipher: cipher,
-  inputPath: inputPath,
-  outputPath: outputPath,
-);
+// These functions are ignored because they are not marked as `pub`: `read_full`
 
 Stream<double> streamHashFile({
   required HasherHandle hasher,

--- a/lib/src/rust/core/error.dart
+++ b/lib/src/rust/core/error.dart
@@ -51,4 +51,8 @@ sealed class CryptoError with _$CryptoError implements FrbException {
       CryptoError_Argon2PolicyViolation;
   const factory CryptoError.argon2VerificationBusy() =
       CryptoError_Argon2VerificationBusy;
+  const factory CryptoError.unsafeLegacyFormatDenied() =
+      CryptoError_UnsafeLegacyFormatDenied;
+  const factory CryptoError.disabledFormat(String field0) =
+      CryptoError_DisabledFormat;
 }

--- a/lib/src/rust/core/error.freezed.dart
+++ b/lib/src/rust/core/error.freezed.dart
@@ -55,7 +55,7 @@ extension CryptoErrorPatterns on CryptoError {
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,TResult Function( CryptoError_Argon2PolicyViolation value)?  argon2PolicyViolation,TResult Function( CryptoError_Argon2VerificationBusy value)?  argon2VerificationBusy,required TResult orElse(),}){
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult Function( CryptoError_HashingFailed value)?  hashingFailed,TResult Function( CryptoError_KdfFailed value)?  kdfFailed,TResult Function( CryptoError_IoError value)?  ioError,TResult Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult Function( CryptoError_VaultFull value)?  vaultFull,TResult Function( CryptoError_VaultLocked value)?  vaultLocked,TResult Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult Function( CryptoError_ExportFailed value)?  exportFailed,TResult Function( CryptoError_ImportFailed value)?  importFailed,TResult Function( CryptoError_Argon2PolicyViolation value)?  argon2PolicyViolation,TResult Function( CryptoError_Argon2VerificationBusy value)?  argon2VerificationBusy,TResult Function( CryptoError_UnsafeLegacyFormatDenied value)?  unsafeLegacyFormatDenied,TResult Function( CryptoError_DisabledFormat value)?  disabledFormat,required TResult orElse(),}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -78,7 +78,9 @@ return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFaile
 return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
 return importFailed(_that);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
 return argon2PolicyViolation(_that);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
-return argon2VerificationBusy(_that);case _:
+return argon2VerificationBusy(_that);case CryptoError_UnsafeLegacyFormatDenied() when unsafeLegacyFormatDenied != null:
+return unsafeLegacyFormatDenied(_that);case CryptoError_DisabledFormat() when disabledFormat != null:
+return disabledFormat(_that);case _:
   return orElse();
 
 }
@@ -96,7 +98,7 @@ return argon2VerificationBusy(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_DuplicateSegment value)  duplicateSegment,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,required TResult Function( CryptoError_Argon2PolicyViolation value)  argon2PolicyViolation,required TResult Function( CryptoError_Argon2VerificationBusy value)  argon2VerificationBusy,}){
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( CryptoError_InvalidKeyLength value)  invalidKeyLength,required TResult Function( CryptoError_InvalidNonce value)  invalidNonce,required TResult Function( CryptoError_EncryptionFailed value)  encryptionFailed,required TResult Function( CryptoError_DecryptionFailed value)  decryptionFailed,required TResult Function( CryptoError_HashingFailed value)  hashingFailed,required TResult Function( CryptoError_KdfFailed value)  kdfFailed,required TResult Function( CryptoError_IoError value)  ioError,required TResult Function( CryptoError_InvalidParameter value)  invalidParameter,required TResult Function( CryptoError_CompressionFailed value)  compressionFailed,required TResult Function( CryptoError_AuthenticationFailed value)  authenticationFailed,required TResult Function( CryptoError_VaultFull value)  vaultFull,required TResult Function( CryptoError_VaultLocked value)  vaultLocked,required TResult Function( CryptoError_SegmentNotFound value)  segmentNotFound,required TResult Function( CryptoError_DuplicateSegment value)  duplicateSegment,required TResult Function( CryptoError_VaultCorrupted value)  vaultCorrupted,required TResult Function( CryptoError_KeyRotationFailed value)  keyRotationFailed,required TResult Function( CryptoError_ExportFailed value)  exportFailed,required TResult Function( CryptoError_ImportFailed value)  importFailed,required TResult Function( CryptoError_Argon2PolicyViolation value)  argon2PolicyViolation,required TResult Function( CryptoError_Argon2VerificationBusy value)  argon2VerificationBusy,required TResult Function( CryptoError_UnsafeLegacyFormatDenied value)  unsafeLegacyFormatDenied,required TResult Function( CryptoError_DisabledFormat value)  disabledFormat,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
@@ -119,7 +121,9 @@ return keyRotationFailed(_that);case CryptoError_ExportFailed():
 return exportFailed(_that);case CryptoError_ImportFailed():
 return importFailed(_that);case CryptoError_Argon2PolicyViolation():
 return argon2PolicyViolation(_that);case CryptoError_Argon2VerificationBusy():
-return argon2VerificationBusy(_that);}
+return argon2VerificationBusy(_that);case CryptoError_UnsafeLegacyFormatDenied():
+return unsafeLegacyFormatDenied(_that);case CryptoError_DisabledFormat():
+return disabledFormat(_that);}
 }
 /// A variant of `map` that fallback to returning `null`.
 ///
@@ -133,7 +137,7 @@ return argon2VerificationBusy(_that);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,TResult? Function( CryptoError_Argon2PolicyViolation value)?  argon2PolicyViolation,TResult? Function( CryptoError_Argon2VerificationBusy value)?  argon2VerificationBusy,}){
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( CryptoError_InvalidKeyLength value)?  invalidKeyLength,TResult? Function( CryptoError_InvalidNonce value)?  invalidNonce,TResult? Function( CryptoError_EncryptionFailed value)?  encryptionFailed,TResult? Function( CryptoError_DecryptionFailed value)?  decryptionFailed,TResult? Function( CryptoError_HashingFailed value)?  hashingFailed,TResult? Function( CryptoError_KdfFailed value)?  kdfFailed,TResult? Function( CryptoError_IoError value)?  ioError,TResult? Function( CryptoError_InvalidParameter value)?  invalidParameter,TResult? Function( CryptoError_CompressionFailed value)?  compressionFailed,TResult? Function( CryptoError_AuthenticationFailed value)?  authenticationFailed,TResult? Function( CryptoError_VaultFull value)?  vaultFull,TResult? Function( CryptoError_VaultLocked value)?  vaultLocked,TResult? Function( CryptoError_SegmentNotFound value)?  segmentNotFound,TResult? Function( CryptoError_DuplicateSegment value)?  duplicateSegment,TResult? Function( CryptoError_VaultCorrupted value)?  vaultCorrupted,TResult? Function( CryptoError_KeyRotationFailed value)?  keyRotationFailed,TResult? Function( CryptoError_ExportFailed value)?  exportFailed,TResult? Function( CryptoError_ImportFailed value)?  importFailed,TResult? Function( CryptoError_Argon2PolicyViolation value)?  argon2PolicyViolation,TResult? Function( CryptoError_Argon2VerificationBusy value)?  argon2VerificationBusy,TResult? Function( CryptoError_UnsafeLegacyFormatDenied value)?  unsafeLegacyFormatDenied,TResult? Function( CryptoError_DisabledFormat value)?  disabledFormat,}){
 final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
@@ -156,7 +160,9 @@ return keyRotationFailed(_that);case CryptoError_ExportFailed() when exportFaile
 return exportFailed(_that);case CryptoError_ImportFailed() when importFailed != null:
 return importFailed(_that);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
 return argon2PolicyViolation(_that);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
-return argon2VerificationBusy(_that);case _:
+return argon2VerificationBusy(_that);case CryptoError_UnsafeLegacyFormatDenied() when unsafeLegacyFormatDenied != null:
+return unsafeLegacyFormatDenied(_that);case CryptoError_DisabledFormat() when disabledFormat != null:
+return disabledFormat(_that);case _:
   return null;
 
 }
@@ -173,7 +179,7 @@ return argon2VerificationBusy(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  duplicateSegment,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,TResult Function( String field0)?  argon2PolicyViolation,TResult Function()?  argon2VerificationBusy,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult Function()?  invalidNonce,TResult Function( String field0)?  encryptionFailed,TResult Function()?  decryptionFailed,TResult Function( String field0)?  hashingFailed,TResult Function( String field0)?  kdfFailed,TResult Function( String field0)?  ioError,TResult Function( String field0)?  invalidParameter,TResult Function( String field0)?  compressionFailed,TResult Function()?  authenticationFailed,TResult Function( BigInt needed,  BigInt available)?  vaultFull,TResult Function()?  vaultLocked,TResult Function( String field0)?  segmentNotFound,TResult Function( String field0)?  duplicateSegment,TResult Function( String field0)?  vaultCorrupted,TResult Function( String field0)?  keyRotationFailed,TResult Function( String field0)?  exportFailed,TResult Function( String field0)?  importFailed,TResult Function( String field0)?  argon2PolicyViolation,TResult Function()?  argon2VerificationBusy,TResult Function()?  unsafeLegacyFormatDenied,TResult Function( String field0)?  disabledFormat,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -195,7 +201,9 @@ return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when expo
 return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
 return importFailed(_that.field0);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
 return argon2PolicyViolation(_that.field0);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
-return argon2VerificationBusy();case _:
+return argon2VerificationBusy();case CryptoError_UnsafeLegacyFormatDenied() when unsafeLegacyFormatDenied != null:
+return unsafeLegacyFormatDenied();case CryptoError_DisabledFormat() when disabledFormat != null:
+return disabledFormat(_that.field0);case _:
   return orElse();
 
 }
@@ -213,7 +221,7 @@ return argon2VerificationBusy();case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  duplicateSegment,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,required TResult Function( String field0)  argon2PolicyViolation,required TResult Function()  argon2VerificationBusy,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( BigInt expected,  BigInt actual)  invalidKeyLength,required TResult Function()  invalidNonce,required TResult Function( String field0)  encryptionFailed,required TResult Function()  decryptionFailed,required TResult Function( String field0)  hashingFailed,required TResult Function( String field0)  kdfFailed,required TResult Function( String field0)  ioError,required TResult Function( String field0)  invalidParameter,required TResult Function( String field0)  compressionFailed,required TResult Function()  authenticationFailed,required TResult Function( BigInt needed,  BigInt available)  vaultFull,required TResult Function()  vaultLocked,required TResult Function( String field0)  segmentNotFound,required TResult Function( String field0)  duplicateSegment,required TResult Function( String field0)  vaultCorrupted,required TResult Function( String field0)  keyRotationFailed,required TResult Function( String field0)  exportFailed,required TResult Function( String field0)  importFailed,required TResult Function( String field0)  argon2PolicyViolation,required TResult Function()  argon2VerificationBusy,required TResult Function()  unsafeLegacyFormatDenied,required TResult Function( String field0)  disabledFormat,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength():
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce():
@@ -235,7 +243,9 @@ return keyRotationFailed(_that.field0);case CryptoError_ExportFailed():
 return exportFailed(_that.field0);case CryptoError_ImportFailed():
 return importFailed(_that.field0);case CryptoError_Argon2PolicyViolation():
 return argon2PolicyViolation(_that.field0);case CryptoError_Argon2VerificationBusy():
-return argon2VerificationBusy();}
+return argon2VerificationBusy();case CryptoError_UnsafeLegacyFormatDenied():
+return unsafeLegacyFormatDenied();case CryptoError_DisabledFormat():
+return disabledFormat(_that.field0);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -249,7 +259,7 @@ return argon2VerificationBusy();}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  duplicateSegment,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,TResult? Function( String field0)?  argon2PolicyViolation,TResult? Function()?  argon2VerificationBusy,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( BigInt expected,  BigInt actual)?  invalidKeyLength,TResult? Function()?  invalidNonce,TResult? Function( String field0)?  encryptionFailed,TResult? Function()?  decryptionFailed,TResult? Function( String field0)?  hashingFailed,TResult? Function( String field0)?  kdfFailed,TResult? Function( String field0)?  ioError,TResult? Function( String field0)?  invalidParameter,TResult? Function( String field0)?  compressionFailed,TResult? Function()?  authenticationFailed,TResult? Function( BigInt needed,  BigInt available)?  vaultFull,TResult? Function()?  vaultLocked,TResult? Function( String field0)?  segmentNotFound,TResult? Function( String field0)?  duplicateSegment,TResult? Function( String field0)?  vaultCorrupted,TResult? Function( String field0)?  keyRotationFailed,TResult? Function( String field0)?  exportFailed,TResult? Function( String field0)?  importFailed,TResult? Function( String field0)?  argon2PolicyViolation,TResult? Function()?  argon2VerificationBusy,TResult? Function()?  unsafeLegacyFormatDenied,TResult? Function( String field0)?  disabledFormat,}) {final _that = this;
 switch (_that) {
 case CryptoError_InvalidKeyLength() when invalidKeyLength != null:
 return invalidKeyLength(_that.expected,_that.actual);case CryptoError_InvalidNonce() when invalidNonce != null:
@@ -271,7 +281,9 @@ return keyRotationFailed(_that.field0);case CryptoError_ExportFailed() when expo
 return exportFailed(_that.field0);case CryptoError_ImportFailed() when importFailed != null:
 return importFailed(_that.field0);case CryptoError_Argon2PolicyViolation() when argon2PolicyViolation != null:
 return argon2PolicyViolation(_that.field0);case CryptoError_Argon2VerificationBusy() when argon2VerificationBusy != null:
-return argon2VerificationBusy();case _:
+return argon2VerificationBusy();case CryptoError_UnsafeLegacyFormatDenied() when unsafeLegacyFormatDenied != null:
+return unsafeLegacyFormatDenied();case CryptoError_DisabledFormat() when disabledFormat != null:
+return disabledFormat(_that.field0);case _:
   return null;
 
 }
@@ -1432,5 +1444,103 @@ String toString() {
 
 
 
+
+/// @nodoc
+
+
+class CryptoError_UnsafeLegacyFormatDenied extends CryptoError {
+  const CryptoError_UnsafeLegacyFormatDenied(): super._();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_UnsafeLegacyFormatDenied);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'CryptoError.unsafeLegacyFormatDenied()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class CryptoError_DisabledFormat extends CryptoError {
+  const CryptoError_DisabledFormat(this.field0): super._();
+  
+
+ final  String field0;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$CryptoError_DisabledFormatCopyWith<CryptoError_DisabledFormat> get copyWith => _$CryptoError_DisabledFormatCopyWithImpl<CryptoError_DisabledFormat>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CryptoError_DisabledFormat&&(identical(other.field0, field0) || other.field0 == field0));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,field0);
+
+@override
+String toString() {
+  return 'CryptoError.disabledFormat(field0: $field0)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $CryptoError_DisabledFormatCopyWith<$Res> implements $CryptoErrorCopyWith<$Res> {
+  factory $CryptoError_DisabledFormatCopyWith(CryptoError_DisabledFormat value, $Res Function(CryptoError_DisabledFormat) _then) = _$CryptoError_DisabledFormatCopyWithImpl;
+@useResult
+$Res call({
+ String field0
+});
+
+
+
+
+}
+/// @nodoc
+class _$CryptoError_DisabledFormatCopyWithImpl<$Res>
+    implements $CryptoError_DisabledFormatCopyWith<$Res> {
+  _$CryptoError_DisabledFormatCopyWithImpl(this._self, this._then);
+
+  final CryptoError_DisabledFormat _self;
+  final $Res Function(CryptoError_DisabledFormat) _then;
+
+/// Create a copy of CryptoError
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? field0 = null,}) {
+  return _then(CryptoError_DisabledFormat(
+null == field0 ? _self.field0 : field0 // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
 
 // dart format on

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -74,7 +74,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1392838074;
+  int get rustContentHash => -1545310340;
 
   static const kDefaultExternalLibraryLoaderConfig =
       ExternalLibraryLoaderConfig(
@@ -200,31 +200,6 @@ abstract class RustLibApi extends BaseApi {
     required String filePath,
   });
 
-  Stream<double> crateApiStreamingStreamCompressEncryptFile({
-    required CipherHandle cipher,
-    required CompressionConfig compression,
-    required String inputPath,
-    required String outputPath,
-  });
-
-  Stream<double> crateApiStreamingStreamDecryptDecompressFile({
-    required CipherHandle cipher,
-    required String inputPath,
-    required String outputPath,
-  });
-
-  Stream<double> crateApiStreamingStreamDecryptFile({
-    required CipherHandle cipher,
-    required String inputPath,
-    required String outputPath,
-  });
-
-  Stream<double> crateApiStreamingStreamEncryptFile({
-    required CipherHandle cipher,
-    required String inputPath,
-    required String outputPath,
-  });
-
   Stream<double> crateApiStreamingStreamHashFile({
     required HasherHandle hasher,
     required String filePath,
@@ -241,6 +216,7 @@ abstract class RustLibApi extends BaseApi {
     required List<int> key,
     required String algorithm,
     required BigInt capacityBytes,
+    required UnsafeLegacyEvfsPolicy unsafeLegacyPolicy,
   });
 
   Future<DefragResult> crateApiEvfsVaultDefragment({
@@ -252,25 +228,10 @@ abstract class RustLibApi extends BaseApi {
     required String name,
   });
 
-  Future<void> crateApiEvfsVaultExport({
-    required VaultHandle handle,
-    required List<int> wrappingKey,
-    required String exportPath,
-  });
-
   Future<void> crateApiEvfsVaultFlush({required VaultHandle handle});
 
   Future<VaultHealthInfo> crateApiEvfsVaultHealth({
     required VaultHandle handle,
-  });
-
-  Future<VaultHandle> crateApiEvfsVaultImport({
-    required String archivePath,
-    required List<int> wrappingKey,
-    required String destPath,
-    required List<int> newMasterKey,
-    required String algorithm,
-    required BigInt capacityBytes,
   });
 
   Future<List<String>> crateApiEvfsVaultList({required VaultHandle handle});
@@ -278,6 +239,7 @@ abstract class RustLibApi extends BaseApi {
   Future<VaultHandle> crateApiEvfsVaultOpen({
     required String path,
     required List<int> key,
+    required UnsafeLegacyEvfsPolicy unsafeLegacyPolicy,
   });
 
   Future<SegmentReadResult> crateApiEvfsVaultRead({
@@ -1223,197 +1185,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       );
 
   @override
-  Stream<double> crateApiStreamingStreamCompressEncryptFile({
-    required CipherHandle cipher,
-    required CompressionConfig compression,
-    required String inputPath,
-    required String outputPath,
-  }) {
-    final progressSink = RustStreamSink<double>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            var arg0 =
-                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-                  cipher,
-                );
-            var arg1 = cst_encode_box_autoadd_compression_config(compression);
-            var arg2 = cst_encode_String(inputPath);
-            var arg3 = cst_encode_String(outputPath);
-            var arg4 = cst_encode_StreamSink_f_64_Dco(progressSink);
-            return wire
-                .wire__crate__api__streaming__stream_compress_encrypt_file(
-                  port_,
-                  arg0,
-                  arg1,
-                  arg2,
-                  arg3,
-                  arg4,
-                );
-          },
-          codec: DcoCodec(
-            decodeSuccessData: dco_decode_unit,
-            decodeErrorData: dco_decode_crypto_error,
-          ),
-          constMeta: kCrateApiStreamingStreamCompressEncryptFileConstMeta,
-          argValues: [cipher, compression, inputPath, outputPath, progressSink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return progressSink.stream;
-  }
-
-  TaskConstMeta get kCrateApiStreamingStreamCompressEncryptFileConstMeta =>
-      const TaskConstMeta(
-        debugName: "stream_compress_encrypt_file",
-        argNames: [
-          "cipher",
-          "compression",
-          "inputPath",
-          "outputPath",
-          "progressSink",
-        ],
-      );
-
-  @override
-  Stream<double> crateApiStreamingStreamDecryptDecompressFile({
-    required CipherHandle cipher,
-    required String inputPath,
-    required String outputPath,
-  }) {
-    final progressSink = RustStreamSink<double>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            var arg0 =
-                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-                  cipher,
-                );
-            var arg1 = cst_encode_String(inputPath);
-            var arg2 = cst_encode_String(outputPath);
-            var arg3 = cst_encode_StreamSink_f_64_Dco(progressSink);
-            return wire
-                .wire__crate__api__streaming__stream_decrypt_decompress_file(
-                  port_,
-                  arg0,
-                  arg1,
-                  arg2,
-                  arg3,
-                );
-          },
-          codec: DcoCodec(
-            decodeSuccessData: dco_decode_unit,
-            decodeErrorData: dco_decode_crypto_error,
-          ),
-          constMeta: kCrateApiStreamingStreamDecryptDecompressFileConstMeta,
-          argValues: [cipher, inputPath, outputPath, progressSink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return progressSink.stream;
-  }
-
-  TaskConstMeta get kCrateApiStreamingStreamDecryptDecompressFileConstMeta =>
-      const TaskConstMeta(
-        debugName: "stream_decrypt_decompress_file",
-        argNames: ["cipher", "inputPath", "outputPath", "progressSink"],
-      );
-
-  @override
-  Stream<double> crateApiStreamingStreamDecryptFile({
-    required CipherHandle cipher,
-    required String inputPath,
-    required String outputPath,
-  }) {
-    final progressSink = RustStreamSink<double>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            var arg0 =
-                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-                  cipher,
-                );
-            var arg1 = cst_encode_String(inputPath);
-            var arg2 = cst_encode_String(outputPath);
-            var arg3 = cst_encode_StreamSink_f_64_Dco(progressSink);
-            return wire.wire__crate__api__streaming__stream_decrypt_file(
-              port_,
-              arg0,
-              arg1,
-              arg2,
-              arg3,
-            );
-          },
-          codec: DcoCodec(
-            decodeSuccessData: dco_decode_unit,
-            decodeErrorData: dco_decode_crypto_error,
-          ),
-          constMeta: kCrateApiStreamingStreamDecryptFileConstMeta,
-          argValues: [cipher, inputPath, outputPath, progressSink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return progressSink.stream;
-  }
-
-  TaskConstMeta get kCrateApiStreamingStreamDecryptFileConstMeta =>
-      const TaskConstMeta(
-        debugName: "stream_decrypt_file",
-        argNames: ["cipher", "inputPath", "outputPath", "progressSink"],
-      );
-
-  @override
-  Stream<double> crateApiStreamingStreamEncryptFile({
-    required CipherHandle cipher,
-    required String inputPath,
-    required String outputPath,
-  }) {
-    final progressSink = RustStreamSink<double>();
-    unawaited(
-      handler.executeNormal(
-        NormalTask(
-          callFfi: (port_) {
-            var arg0 =
-                cst_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerCipherHandle(
-                  cipher,
-                );
-            var arg1 = cst_encode_String(inputPath);
-            var arg2 = cst_encode_String(outputPath);
-            var arg3 = cst_encode_StreamSink_f_64_Dco(progressSink);
-            return wire.wire__crate__api__streaming__stream_encrypt_file(
-              port_,
-              arg0,
-              arg1,
-              arg2,
-              arg3,
-            );
-          },
-          codec: DcoCodec(
-            decodeSuccessData: dco_decode_unit,
-            decodeErrorData: dco_decode_crypto_error,
-          ),
-          constMeta: kCrateApiStreamingStreamEncryptFileConstMeta,
-          argValues: [cipher, inputPath, outputPath, progressSink],
-          apiImpl: this,
-        ),
-      ),
-    );
-    return progressSink.stream;
-  }
-
-  TaskConstMeta get kCrateApiStreamingStreamEncryptFileConstMeta =>
-      const TaskConstMeta(
-        debugName: "stream_encrypt_file",
-        argNames: ["cipher", "inputPath", "outputPath", "progressSink"],
-      );
-
-  @override
   Stream<double> crateApiStreamingStreamHashFile({
     required HasherHandle hasher,
     required String filePath,
@@ -1513,6 +1284,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     required List<int> key,
     required String algorithm,
     required BigInt capacityBytes,
+    required UnsafeLegacyEvfsPolicy unsafeLegacyPolicy,
   }) {
     return handler.executeNormal(
       NormalTask(
@@ -1521,12 +1293,14 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           var arg1 = cst_encode_list_prim_u_8_loose(key);
           var arg2 = cst_encode_String(algorithm);
           var arg3 = cst_encode_u_64(capacityBytes);
+          var arg4 = cst_encode_unsafe_legacy_evfs_policy(unsafeLegacyPolicy);
           return wire.wire__crate__api__evfs__vault_create(
             port_,
             arg0,
             arg1,
             arg2,
             arg3,
+            arg4,
           );
         },
         codec: DcoCodec(
@@ -1535,7 +1309,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultCreateConstMeta,
-        argValues: [path, key, algorithm, capacityBytes],
+        argValues: [path, key, algorithm, capacityBytes, unsafeLegacyPolicy],
         apiImpl: this,
       ),
     );
@@ -1543,7 +1317,13 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
 
   TaskConstMeta get kCrateApiEvfsVaultCreateConstMeta => const TaskConstMeta(
     debugName: "vault_create",
-    argNames: ["path", "key", "algorithm", "capacityBytes"],
+    argNames: [
+      "path",
+      "key",
+      "algorithm",
+      "capacityBytes",
+      "unsafeLegacyPolicy",
+    ],
   );
 
   @override
@@ -1605,44 +1385,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
-  Future<void> crateApiEvfsVaultExport({
-    required VaultHandle handle,
-    required List<int> wrappingKey,
-    required String exportPath,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          var arg0 =
-              cst_encode_Auto_RefMut_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle(
-                handle,
-              );
-          var arg1 = cst_encode_list_prim_u_8_loose(wrappingKey);
-          var arg2 = cst_encode_String(exportPath);
-          return wire.wire__crate__api__evfs__vault_export(
-            port_,
-            arg0,
-            arg1,
-            arg2,
-          );
-        },
-        codec: DcoCodec(
-          decodeSuccessData: dco_decode_unit,
-          decodeErrorData: dco_decode_crypto_error,
-        ),
-        constMeta: kCrateApiEvfsVaultExportConstMeta,
-        argValues: [handle, wrappingKey, exportPath],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiEvfsVaultExportConstMeta => const TaskConstMeta(
-    debugName: "vault_export",
-    argNames: ["handle", "wrappingKey", "exportPath"],
-  );
-
-  @override
   Future<void> crateApiEvfsVaultFlush({required VaultHandle handle}) {
     return handler.executeNormal(
       NormalTask(
@@ -1695,65 +1437,6 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       const TaskConstMeta(debugName: "vault_health", argNames: ["handle"]);
 
   @override
-  Future<VaultHandle> crateApiEvfsVaultImport({
-    required String archivePath,
-    required List<int> wrappingKey,
-    required String destPath,
-    required List<int> newMasterKey,
-    required String algorithm,
-    required BigInt capacityBytes,
-  }) {
-    return handler.executeNormal(
-      NormalTask(
-        callFfi: (port_) {
-          var arg0 = cst_encode_String(archivePath);
-          var arg1 = cst_encode_list_prim_u_8_loose(wrappingKey);
-          var arg2 = cst_encode_String(destPath);
-          var arg3 = cst_encode_list_prim_u_8_loose(newMasterKey);
-          var arg4 = cst_encode_String(algorithm);
-          var arg5 = cst_encode_u_64(capacityBytes);
-          return wire.wire__crate__api__evfs__vault_import(
-            port_,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-          );
-        },
-        codec: DcoCodec(
-          decodeSuccessData:
-              dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerVaultHandle,
-          decodeErrorData: dco_decode_crypto_error,
-        ),
-        constMeta: kCrateApiEvfsVaultImportConstMeta,
-        argValues: [
-          archivePath,
-          wrappingKey,
-          destPath,
-          newMasterKey,
-          algorithm,
-          capacityBytes,
-        ],
-        apiImpl: this,
-      ),
-    );
-  }
-
-  TaskConstMeta get kCrateApiEvfsVaultImportConstMeta => const TaskConstMeta(
-    debugName: "vault_import",
-    argNames: [
-      "archivePath",
-      "wrappingKey",
-      "destPath",
-      "newMasterKey",
-      "algorithm",
-      "capacityBytes",
-    ],
-  );
-
-  @override
   Future<List<String>> crateApiEvfsVaultList({required VaultHandle handle}) {
     return handler.executeNormal(
       NormalTask(
@@ -1782,13 +1465,20 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   Future<VaultHandle> crateApiEvfsVaultOpen({
     required String path,
     required List<int> key,
+    required UnsafeLegacyEvfsPolicy unsafeLegacyPolicy,
   }) {
     return handler.executeNormal(
       NormalTask(
         callFfi: (port_) {
           var arg0 = cst_encode_String(path);
           var arg1 = cst_encode_list_prim_u_8_loose(key);
-          return wire.wire__crate__api__evfs__vault_open(port_, arg0, arg1);
+          var arg2 = cst_encode_unsafe_legacy_evfs_policy(unsafeLegacyPolicy);
+          return wire.wire__crate__api__evfs__vault_open(
+            port_,
+            arg0,
+            arg1,
+            arg2,
+          );
         },
         codec: DcoCodec(
           decodeSuccessData:
@@ -1796,14 +1486,16 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           decodeErrorData: dco_decode_crypto_error,
         ),
         constMeta: kCrateApiEvfsVaultOpenConstMeta,
-        argValues: [path, key],
+        argValues: [path, key, unsafeLegacyPolicy],
         apiImpl: this,
       ),
     );
   }
 
-  TaskConstMeta get kCrateApiEvfsVaultOpenConstMeta =>
-      const TaskConstMeta(debugName: "vault_open", argNames: ["path", "key"]);
+  TaskConstMeta get kCrateApiEvfsVaultOpenConstMeta => const TaskConstMeta(
+    debugName: "vault_open",
+    argNames: ["path", "key", "unsafeLegacyPolicy"],
+  );
 
   @override
   Future<SegmentReadResult> crateApiEvfsVaultRead({
@@ -2356,6 +2048,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return CryptoError_Argon2PolicyViolation(dco_decode_String(raw[1]));
       case 19:
         return CryptoError_Argon2VerificationBusy();
+      case 20:
+        return CryptoError_UnsafeLegacyFormatDenied();
+      case 21:
+        return CryptoError_DisabledFormat(dco_decode_String(raw[1]));
       default:
         throw Exception("unreachable");
     }
@@ -2505,6 +2201,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void dco_decode_unit(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return;
+  }
+
+  @protected
+  UnsafeLegacyEvfsPolicy dco_decode_unsafe_legacy_evfs_policy(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return UnsafeLegacyEvfsPolicy.values[raw as int];
   }
 
   @protected
@@ -2821,6 +2523,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         return CryptoError_Argon2PolicyViolation(var_field0);
       case 19:
         return CryptoError_Argon2VerificationBusy();
+      case 20:
+        return CryptoError_UnsafeLegacyFormatDenied();
+      case 21:
+        var var_field0 = sse_decode_String(deserializer);
+        return CryptoError_DisabledFormat(var_field0);
       default:
         throw UnimplementedError('');
     }
@@ -3014,6 +2721,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_decode_unit(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  UnsafeLegacyEvfsPolicy sse_decode_unsafe_legacy_evfs_policy(
+    SseDeserializer deserializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    var inner = sse_decode_i_32(deserializer);
+    return UnsafeLegacyEvfsPolicy.values[inner];
   }
 
   @protected
@@ -3212,6 +2928,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void cst_encode_unit(void raw) {
     // Codec=Cst (C-struct based), see doc to use other codecs
     return raw;
+  }
+
+  @protected
+  int cst_encode_unsafe_legacy_evfs_policy(UnsafeLegacyEvfsPolicy raw) {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    return cst_encode_i_32(raw.index);
   }
 
   @protected
@@ -3518,6 +3240,11 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         sse_encode_String(field0, serializer);
       case CryptoError_Argon2VerificationBusy():
         sse_encode_i_32(19, serializer);
+      case CryptoError_UnsafeLegacyFormatDenied():
+        sse_encode_i_32(20, serializer);
+      case CryptoError_DisabledFormat(field0: final field0):
+        sse_encode_i_32(21, serializer);
+        sse_encode_String(field0, serializer);
     }
   }
 
@@ -3704,6 +3431,15 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   @protected
   void sse_encode_unit(void self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
+  }
+
+  @protected
+  void sse_encode_unsafe_legacy_evfs_policy(
+    UnsafeLegacyEvfsPolicy self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.index, serializer);
   }
 
   @protected

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -199,6 +199,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void dco_decode_unit(dynamic raw);
 
   @protected
+  UnsafeLegacyEvfsPolicy dco_decode_unsafe_legacy_evfs_policy(dynamic raw);
+
+  @protected
   BigInt dco_decode_usize(dynamic raw);
 
   @protected
@@ -384,6 +387,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_decode_unit(SseDeserializer deserializer);
+
+  @protected
+  UnsafeLegacyEvfsPolicy sse_decode_unsafe_legacy_evfs_policy(
+    SseDeserializer deserializer,
+  );
 
   @protected
   BigInt sse_decode_usize(SseDeserializer deserializer);
@@ -703,6 +711,16 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
       wireObj.tag = 19;
       return;
     }
+    if (apiObj is CryptoError_UnsafeLegacyFormatDenied) {
+      wireObj.tag = 20;
+      return;
+    }
+    if (apiObj is CryptoError_DisabledFormat) {
+      var pre_field0 = cst_encode_String(apiObj.field0);
+      wireObj.tag = 21;
+      wireObj.kind.DisabledFormat.field0 = pre_field0;
+      return;
+    }
   }
 
   @protected
@@ -854,6 +872,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void cst_encode_unit(void raw);
+
+  @protected
+  int cst_encode_unsafe_legacy_evfs_policy(UnsafeLegacyEvfsPolicy raw);
 
   @protected
   void sse_encode_AnyhowException(
@@ -1065,6 +1086,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_unsafe_legacy_evfs_policy(
+    UnsafeLegacyEvfsPolicy self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_usize(BigInt self, SseSerializer serializer);
@@ -1753,174 +1780,6 @@ class RustLibWire implements BaseWire {
             void Function(int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
           >();
 
-  void wire__crate__api__streaming__stream_compress_encrypt_file(
-    int port_,
-    int cipher,
-    ffi.Pointer<wire_cst_compression_config> compression,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
-  ) {
-    return _wire__crate__api__streaming__stream_compress_encrypt_file(
-      port_,
-      cipher,
-      compression,
-      input_path,
-      output_path,
-      progress_sink,
-    );
-  }
-
-  late final _wire__crate__api__streaming__stream_compress_encrypt_filePtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.UintPtr,
-            ffi.Pointer<wire_cst_compression_config>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-          )
-        >
-      >(
-        'frbgen_m_security_wire__crate__api__streaming__stream_compress_encrypt_file',
-      );
-  late final _wire__crate__api__streaming__stream_compress_encrypt_file =
-      _wire__crate__api__streaming__stream_compress_encrypt_filePtr
-          .asFunction<
-            void Function(
-              int,
-              int,
-              ffi.Pointer<wire_cst_compression_config>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            )
-          >();
-
-  void wire__crate__api__streaming__stream_decrypt_decompress_file(
-    int port_,
-    int cipher,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
-  ) {
-    return _wire__crate__api__streaming__stream_decrypt_decompress_file(
-      port_,
-      cipher,
-      input_path,
-      output_path,
-      progress_sink,
-    );
-  }
-
-  late final _wire__crate__api__streaming__stream_decrypt_decompress_filePtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.UintPtr,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-          )
-        >
-      >(
-        'frbgen_m_security_wire__crate__api__streaming__stream_decrypt_decompress_file',
-      );
-  late final _wire__crate__api__streaming__stream_decrypt_decompress_file =
-      _wire__crate__api__streaming__stream_decrypt_decompress_filePtr
-          .asFunction<
-            void Function(
-              int,
-              int,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            )
-          >();
-
-  void wire__crate__api__streaming__stream_decrypt_file(
-    int port_,
-    int cipher,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
-  ) {
-    return _wire__crate__api__streaming__stream_decrypt_file(
-      port_,
-      cipher,
-      input_path,
-      output_path,
-      progress_sink,
-    );
-  }
-
-  late final _wire__crate__api__streaming__stream_decrypt_filePtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.UintPtr,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-          )
-        >
-      >('frbgen_m_security_wire__crate__api__streaming__stream_decrypt_file');
-  late final _wire__crate__api__streaming__stream_decrypt_file =
-      _wire__crate__api__streaming__stream_decrypt_filePtr
-          .asFunction<
-            void Function(
-              int,
-              int,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            )
-          >();
-
-  void wire__crate__api__streaming__stream_encrypt_file(
-    int port_,
-    int cipher,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> input_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> output_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> progress_sink,
-  ) {
-    return _wire__crate__api__streaming__stream_encrypt_file(
-      port_,
-      cipher,
-      input_path,
-      output_path,
-      progress_sink,
-    );
-  }
-
-  late final _wire__crate__api__streaming__stream_encrypt_filePtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.UintPtr,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-          )
-        >
-      >('frbgen_m_security_wire__crate__api__streaming__stream_encrypt_file');
-  late final _wire__crate__api__streaming__stream_encrypt_file =
-      _wire__crate__api__streaming__stream_encrypt_filePtr
-          .asFunction<
-            void Function(
-              int,
-              int,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            )
-          >();
-
   void wire__crate__api__streaming__stream_hash_file(
     int port_,
     int hasher,
@@ -1987,6 +1846,7 @@ class RustLibWire implements BaseWire {
     ffi.Pointer<wire_cst_list_prim_u_8_loose> key,
     ffi.Pointer<wire_cst_list_prim_u_8_strict> algorithm,
     int capacity_bytes,
+    int unsafe_legacy_policy,
   ) {
     return _wire__crate__api__evfs__vault_create(
       port_,
@@ -1994,6 +1854,7 @@ class RustLibWire implements BaseWire {
       key,
       algorithm,
       capacity_bytes,
+      unsafe_legacy_policy,
     );
   }
 
@@ -2006,6 +1867,7 @@ class RustLibWire implements BaseWire {
             ffi.Pointer<wire_cst_list_prim_u_8_loose>,
             ffi.Pointer<wire_cst_list_prim_u_8_strict>,
             ffi.Uint64,
+            ffi.Int32,
           )
         >
       >('frbgen_m_security_wire__crate__api__evfs__vault_create');
@@ -2017,6 +1879,7 @@ class RustLibWire implements BaseWire {
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
+              int,
               int,
             )
           >();
@@ -2057,42 +1920,6 @@ class RustLibWire implements BaseWire {
             void Function(int, int, ffi.Pointer<wire_cst_list_prim_u_8_strict>)
           >();
 
-  void wire__crate__api__evfs__vault_export(
-    int port_,
-    int handle,
-    ffi.Pointer<wire_cst_list_prim_u_8_loose> wrapping_key,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> export_path,
-  ) {
-    return _wire__crate__api__evfs__vault_export(
-      port_,
-      handle,
-      wrapping_key,
-      export_path,
-    );
-  }
-
-  late final _wire__crate__api__evfs__vault_exportPtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.UintPtr,
-            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-          )
-        >
-      >('frbgen_m_security_wire__crate__api__evfs__vault_export');
-  late final _wire__crate__api__evfs__vault_export =
-      _wire__crate__api__evfs__vault_exportPtr
-          .asFunction<
-            void Function(
-              int,
-              int,
-              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            )
-          >();
-
   void wire__crate__api__evfs__vault_flush(int port_, int handle) {
     return _wire__crate__api__evfs__vault_flush(port_, handle);
   }
@@ -2117,54 +1944,6 @@ class RustLibWire implements BaseWire {
       _wire__crate__api__evfs__vault_healthPtr
           .asFunction<void Function(int, int)>();
 
-  void wire__crate__api__evfs__vault_import(
-    int port_,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> archive_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_loose> wrapping_key,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> dest_path,
-    ffi.Pointer<wire_cst_list_prim_u_8_loose> new_master_key,
-    ffi.Pointer<wire_cst_list_prim_u_8_strict> algorithm,
-    int capacity_bytes,
-  ) {
-    return _wire__crate__api__evfs__vault_import(
-      port_,
-      archive_path,
-      wrapping_key,
-      dest_path,
-      new_master_key,
-      algorithm,
-      capacity_bytes,
-    );
-  }
-
-  late final _wire__crate__api__evfs__vault_importPtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Void Function(
-            ffi.Int64,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-            ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-            ffi.Uint64,
-          )
-        >
-      >('frbgen_m_security_wire__crate__api__evfs__vault_import');
-  late final _wire__crate__api__evfs__vault_import =
-      _wire__crate__api__evfs__vault_importPtr
-          .asFunction<
-            void Function(
-              int,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              ffi.Pointer<wire_cst_list_prim_u_8_loose>,
-              ffi.Pointer<wire_cst_list_prim_u_8_strict>,
-              int,
-            )
-          >();
-
   void wire__crate__api__evfs__vault_list(int port_, int handle) {
     return _wire__crate__api__evfs__vault_list(port_, handle);
   }
@@ -2181,8 +1960,14 @@ class RustLibWire implements BaseWire {
     int port_,
     ffi.Pointer<wire_cst_list_prim_u_8_strict> path,
     ffi.Pointer<wire_cst_list_prim_u_8_loose> key,
+    int unsafe_legacy_policy,
   ) {
-    return _wire__crate__api__evfs__vault_open(port_, path, key);
+    return _wire__crate__api__evfs__vault_open(
+      port_,
+      path,
+      key,
+      unsafe_legacy_policy,
+    );
   }
 
   late final _wire__crate__api__evfs__vault_openPtr =
@@ -2192,6 +1977,7 @@ class RustLibWire implements BaseWire {
             ffi.Int64,
             ffi.Pointer<wire_cst_list_prim_u_8_strict>,
             ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+            ffi.Int32,
           )
         >
       >('frbgen_m_security_wire__crate__api__evfs__vault_open');
@@ -2202,6 +1988,7 @@ class RustLibWire implements BaseWire {
               int,
               ffi.Pointer<wire_cst_list_prim_u_8_strict>,
               ffi.Pointer<wire_cst_list_prim_u_8_loose>,
+              int,
             )
           >();
 
@@ -2809,6 +2596,10 @@ final class wire_cst_CryptoError_Argon2PolicyViolation extends ffi.Struct {
   external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
 }
 
+final class wire_cst_CryptoError_DisabledFormat extends ffi.Struct {
+  external ffi.Pointer<wire_cst_list_prim_u_8_strict> field0;
+}
+
 final class CryptoErrorKind extends ffi.Union {
   external wire_cst_CryptoError_InvalidKeyLength InvalidKeyLength;
 
@@ -2839,6 +2630,8 @@ final class CryptoErrorKind extends ffi.Union {
   external wire_cst_CryptoError_ImportFailed ImportFailed;
 
   external wire_cst_CryptoError_Argon2PolicyViolation Argon2PolicyViolation;
+
+  external wire_cst_CryptoError_DisabledFormat DisabledFormat;
 }
 
 final class wire_cst_crypto_error extends ffi.Struct {

--- a/lib/src/rust/frb_generated.web.dart
+++ b/lib/src/rust/frb_generated.web.dart
@@ -201,6 +201,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void dco_decode_unit(dynamic raw);
 
   @protected
+  UnsafeLegacyEvfsPolicy dco_decode_unsafe_legacy_evfs_policy(dynamic raw);
+
+  @protected
   BigInt dco_decode_usize(dynamic raw);
 
   @protected
@@ -388,6 +391,11 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_decode_unit(SseDeserializer deserializer);
 
   @protected
+  UnsafeLegacyEvfsPolicy sse_decode_unsafe_legacy_evfs_policy(
+    SseDeserializer deserializer,
+  );
+
+  @protected
   BigInt sse_decode_usize(SseDeserializer deserializer);
 
   @protected
@@ -537,6 +545,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     }
     if (raw is CryptoError_Argon2VerificationBusy) {
       return [19].jsify()!;
+    }
+    if (raw is CryptoError_UnsafeLegacyFormatDenied) {
+      return [20].jsify()!;
+    }
+    if (raw is CryptoError_DisabledFormat) {
+      return [21, cst_encode_String(raw.field0)].jsify()!;
     }
 
     throw Exception('unreachable');
@@ -762,6 +776,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void cst_encode_unit(void raw);
 
   @protected
+  int cst_encode_unsafe_legacy_evfs_policy(UnsafeLegacyEvfsPolicy raw);
+
+  @protected
   void sse_encode_AnyhowException(
     AnyhowException self,
     SseSerializer serializer,
@@ -971,6 +988,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
 
   @protected
   void sse_encode_unit(void self, SseSerializer serializer);
+
+  @protected
+  void sse_encode_unsafe_legacy_evfs_policy(
+    UnsafeLegacyEvfsPolicy self,
+    SseSerializer serializer,
+  );
 
   @protected
   void sse_encode_usize(BigInt self, SseSerializer serializer);
@@ -1201,64 +1224,6 @@ class RustLibWire implements BaseWire {
     file_path,
   );
 
-  void wire__crate__api__streaming__stream_compress_encrypt_file(
-    NativePortType port_,
-    int cipher,
-    JSAny compression,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  ) => wasmModule.wire__crate__api__streaming__stream_compress_encrypt_file(
-    port_,
-    cipher,
-    compression,
-    input_path,
-    output_path,
-    progress_sink,
-  );
-
-  void wire__crate__api__streaming__stream_decrypt_decompress_file(
-    NativePortType port_,
-    int cipher,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  ) => wasmModule.wire__crate__api__streaming__stream_decrypt_decompress_file(
-    port_,
-    cipher,
-    input_path,
-    output_path,
-    progress_sink,
-  );
-
-  void wire__crate__api__streaming__stream_decrypt_file(
-    NativePortType port_,
-    int cipher,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  ) => wasmModule.wire__crate__api__streaming__stream_decrypt_file(
-    port_,
-    cipher,
-    input_path,
-    output_path,
-    progress_sink,
-  );
-
-  void wire__crate__api__streaming__stream_encrypt_file(
-    NativePortType port_,
-    int cipher,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  ) => wasmModule.wire__crate__api__streaming__stream_encrypt_file(
-    port_,
-    cipher,
-    input_path,
-    output_path,
-    progress_sink,
-  );
-
   void wire__crate__api__streaming__stream_hash_file(
     NativePortType port_,
     int hasher,
@@ -1285,12 +1250,14 @@ class RustLibWire implements BaseWire {
     JSAny key,
     String algorithm,
     JSAny capacity_bytes,
+    int unsafe_legacy_policy,
   ) => wasmModule.wire__crate__api__evfs__vault_create(
     port_,
     path,
     key,
     algorithm,
     capacity_bytes,
+    unsafe_legacy_policy,
   );
 
   void wire__crate__api__evfs__vault_defragment(
@@ -1304,41 +1271,11 @@ class RustLibWire implements BaseWire {
     String name,
   ) => wasmModule.wire__crate__api__evfs__vault_delete(port_, handle, name);
 
-  void wire__crate__api__evfs__vault_export(
-    NativePortType port_,
-    int handle,
-    JSAny wrapping_key,
-    String export_path,
-  ) => wasmModule.wire__crate__api__evfs__vault_export(
-    port_,
-    handle,
-    wrapping_key,
-    export_path,
-  );
-
   void wire__crate__api__evfs__vault_flush(NativePortType port_, int handle) =>
       wasmModule.wire__crate__api__evfs__vault_flush(port_, handle);
 
   void wire__crate__api__evfs__vault_health(NativePortType port_, int handle) =>
       wasmModule.wire__crate__api__evfs__vault_health(port_, handle);
-
-  void wire__crate__api__evfs__vault_import(
-    NativePortType port_,
-    String archive_path,
-    JSAny wrapping_key,
-    String dest_path,
-    JSAny new_master_key,
-    String algorithm,
-    JSAny capacity_bytes,
-  ) => wasmModule.wire__crate__api__evfs__vault_import(
-    port_,
-    archive_path,
-    wrapping_key,
-    dest_path,
-    new_master_key,
-    algorithm,
-    capacity_bytes,
-  );
 
   void wire__crate__api__evfs__vault_list(NativePortType port_, int handle) =>
       wasmModule.wire__crate__api__evfs__vault_list(port_, handle);
@@ -1347,7 +1284,13 @@ class RustLibWire implements BaseWire {
     NativePortType port_,
     String path,
     JSAny key,
-  ) => wasmModule.wire__crate__api__evfs__vault_open(port_, path, key);
+    int unsafe_legacy_policy,
+  ) => wasmModule.wire__crate__api__evfs__vault_open(
+    port_,
+    path,
+    key,
+    unsafe_legacy_policy,
+  );
 
   void wire__crate__api__evfs__vault_read(
     NativePortType port_,
@@ -1649,39 +1592,6 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String file_path,
   );
 
-  external void wire__crate__api__streaming__stream_compress_encrypt_file(
-    NativePortType port_,
-    int cipher,
-    JSAny compression,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  );
-
-  external void wire__crate__api__streaming__stream_decrypt_decompress_file(
-    NativePortType port_,
-    int cipher,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  );
-
-  external void wire__crate__api__streaming__stream_decrypt_file(
-    NativePortType port_,
-    int cipher,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  );
-
-  external void wire__crate__api__streaming__stream_encrypt_file(
-    NativePortType port_,
-    int cipher,
-    String input_path,
-    String output_path,
-    String progress_sink,
-  );
-
   external void wire__crate__api__streaming__stream_hash_file(
     NativePortType port_,
     int hasher,
@@ -1705,6 +1615,7 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     JSAny key,
     String algorithm,
     JSAny capacity_bytes,
+    int unsafe_legacy_policy,
   );
 
   external void wire__crate__api__evfs__vault_defragment(
@@ -1718,13 +1629,6 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     String name,
   );
 
-  external void wire__crate__api__evfs__vault_export(
-    NativePortType port_,
-    int handle,
-    JSAny wrapping_key,
-    String export_path,
-  );
-
   external void wire__crate__api__evfs__vault_flush(
     NativePortType port_,
     int handle,
@@ -1733,16 +1637,6 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
   external void wire__crate__api__evfs__vault_health(
     NativePortType port_,
     int handle,
-  );
-
-  external void wire__crate__api__evfs__vault_import(
-    NativePortType port_,
-    String archive_path,
-    JSAny wrapping_key,
-    String dest_path,
-    JSAny new_master_key,
-    String algorithm,
-    JSAny capacity_bytes,
   );
 
   external void wire__crate__api__evfs__vault_list(
@@ -1754,6 +1648,7 @@ extension type RustLibWasmModule._(JSObject _) implements JSObject {
     NativePortType port_,
     String path,
     JSAny key,
+    int unsafe_legacy_policy,
   );
 
   external void wire__crate__api__evfs__vault_read(

--- a/lib/src/streaming/streaming_service.dart
+++ b/lib/src/streaming/streaming_service.dart
@@ -3,43 +3,46 @@ import 'dart:typed_data';
 import 'package:m_security/src/rust/api/streaming.dart' as rust_streaming;
 import 'package:m_security/src/rust/api/encryption.dart' as rust_encryption;
 import 'package:m_security/src/rust/api/hashing.dart' as rust_hashing;
+import 'package:m_security/src/rust/core/error.dart';
 
-/// Streaming file operations (encrypt, decrypt, hash).
+/// Streaming file operations.
 ///
 /// Processes large files in 64KB chunks to maintain constant RAM usage
 /// regardless of file size.
+///
+/// Only hashing is available in this release. The encrypted stream format
+/// leaves its header unauthenticated and binds a chunk to nothing but its index
+/// and finality, so a chunk from another stream encrypted under the same handle
+/// splices in. Its native entry points are gone and the methods below fail
+/// before touching either path.
 class StreamingService {
   StreamingService._();
 
-  /// Encrypt a file, writing the result to outputPath.
-  /// Returns a Stream of progress (0.0 to 1.0).
+  /// Disabled. Kept so existing code still compiles.
+  ///
+  /// Emits one disabled-format error before reading [inputPath] or creating
+  /// [outputPath].
   static Stream<double> encryptFile({
     required String inputPath,
     required String outputPath,
     required rust_encryption.CipherHandle cipher,
   }) {
-    return _guardedStream(
-      () => rust_streaming.streamEncryptFile(
-        cipher: cipher,
-        inputPath: inputPath,
-        outputPath: outputPath,
-      ),
+    return Stream<double>.error(
+      const CryptoError.disabledFormat('encrypted stream write'),
     );
   }
 
-  /// Decrypt a streaming-encrypted file.
-  /// Returns a Stream of progress (0.0 to 1.0).
+  /// Disabled. Kept so existing code still compiles.
+  ///
+  /// Emits one disabled-format error before reading [inputPath] or creating
+  /// [outputPath].
   static Stream<double> decryptFile({
     required String inputPath,
     required String outputPath,
     required rust_encryption.CipherHandle cipher,
   }) {
-    return _guardedStream(
-      () => rust_streaming.streamDecryptFile(
-        cipher: cipher,
-        inputPath: inputPath,
-        outputPath: outputPath,
-      ),
+    return Stream<double>.error(
+      const CryptoError.disabledFormat('encrypted stream read'),
     );
   }
 

--- a/rust/src/api/encryption/mod.rs
+++ b/rust/src/api/encryption/mod.rs
@@ -20,7 +20,12 @@ impl CipherHandle {
     fn new(cipher: Box<dyn Encryption>) -> Self {
         Self { inner: cipher }
     }
+}
 
+// The chunked encrypted-stream pipeline was the only caller of these, and this
+// release compiles that pipeline for its regression tests only.
+#[cfg(test)]
+impl CipherHandle {
     /// Direct encrypt for internal use (streaming). Not FRB-visible.
     pub(crate) fn encrypt_raw(&self, plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
         self.inner.encrypt(plaintext, aad)

--- a/rust/src/api/evfs/mod.rs
+++ b/rust/src/api/evfs/mod.rs
@@ -26,6 +26,30 @@ use zeroize::{Zeroize, Zeroizing};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 
+/// Wipes the Rust-owned copy of a vault key when it goes out of scope.
+///
+/// It borrows rather than owns so a test can keep the allocation alive and read
+/// it back after the wipe instead of inspecting freed memory.
+struct KeyGuard<'a> {
+    key: &'a mut Vec<u8>,
+}
+
+impl<'a> KeyGuard<'a> {
+    fn new(key: &'a mut Vec<u8>) -> Self {
+        Self { key }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.key
+    }
+}
+
+impl Drop for KeyGuard<'_> {
+    fn drop(&mut self) {
+        self.key.zeroize();
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -33,17 +57,62 @@ use std::io::{Read, Seek, SeekFrom, Write};
 /// Create a new vault file at `path` with the given capacity.
 ///
 /// The algorithm string must be "aes-256-gcm" or "chacha20-poly1305".
+///
+/// The vault format this writes is the unauthenticated v1/v2 one, so the call
+/// is refused before `path` is touched unless `unsafe_legacy_policy` is
+/// `AllowUnauthenticatedV1V2`.
 #[cfg(feature = "compression")]
 pub fn vault_create(
     path: String,
     mut key: Vec<u8>,
     algorithm: String,
     capacity_bytes: u64,
+    unsafe_legacy_policy: UnsafeLegacyEvfsPolicy,
+) -> Result<VaultHandle, CryptoError> {
+    vault_create_guarded(
+        path,
+        &mut key,
+        algorithm,
+        capacity_bytes,
+        unsafe_legacy_policy,
+    )
+}
+
+/// Guards the caller's key, then makes the one policy decision for creation.
+///
+/// Takes the key by reference so a test owns the allocation and can read it back
+/// after the guard has wiped it. Derivation happens here so the guard drops
+/// before any of the work below, which keeps the caller's plaintext key out of
+/// memory for the whole preallocation.
+#[cfg(feature = "compression")]
+fn vault_create_guarded(
+    path: String,
+    key: &mut Vec<u8>,
+    algorithm: String,
+    capacity_bytes: u64,
+    unsafe_legacy_policy: UnsafeLegacyEvfsPolicy,
+) -> Result<VaultHandle, CryptoError> {
+    let (grant, keys) = {
+        let key = KeyGuard::new(key);
+        let grant = unsafe_legacy_policy.authorize()?;
+        (grant, segment::derive_vault_keys(key.as_bytes())?)
+    };
+
+    create_legacy_vault(path, keys, algorithm, capacity_bytes, grant)
+}
+
+/// Writes a v2 vault. Unreachable without a grant, so the signature is what
+/// keeps a default call out.
+#[cfg(feature = "compression")]
+fn create_legacy_vault(
+    path: String,
+    keys: segment::VaultKeys,
+    algorithm: String,
+    capacity_bytes: u64,
+    grant: LegacyFormatGrant,
 ) -> Result<VaultHandle, CryptoError> {
     let algo = parse_algorithm(&algorithm)?;
     let lock = VaultLock::acquire(&path)?;
-    let keys = segment::derive_vault_keys(&key)?;
-    key.zeroize();
     let index_pad_size = format::compute_index_size(capacity_bytes);
     let total_size = format::total_vault_size(capacity_bytes, index_pad_size)?;
 
@@ -89,12 +158,52 @@ pub fn vault_create(
         wal,
         lock,
         index_dirty: false,
+        grant,
     })
 }
 
 /// Open an existing vault, running WAL recovery if needed.
+///
+/// The stored format is the unauthenticated v1/v2 one, so the call is refused
+/// before `path` is touched unless `unsafe_legacy_policy` is
+/// `AllowUnauthenticatedV1V2`.
 #[cfg(feature = "compression")]
-pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoError> {
+pub fn vault_open(
+    path: String,
+    mut key: Vec<u8>,
+    unsafe_legacy_policy: UnsafeLegacyEvfsPolicy,
+) -> Result<VaultHandle, CryptoError> {
+    vault_open_guarded(path, &mut key, unsafe_legacy_policy)
+}
+
+/// Guards the caller's key, then makes the one policy decision for opening.
+///
+/// Takes the key by reference so a test owns the allocation and can read it back
+/// after the guard has wiped it. Derivation happens here so the guard drops
+/// before the recovery and index work below.
+#[cfg(feature = "compression")]
+fn vault_open_guarded(
+    path: String,
+    key: &mut Vec<u8>,
+    unsafe_legacy_policy: UnsafeLegacyEvfsPolicy,
+) -> Result<VaultHandle, CryptoError> {
+    let (grant, keys) = {
+        let key = KeyGuard::new(key);
+        let grant = unsafe_legacy_policy.authorize()?;
+        (grant, segment::derive_vault_keys(key.as_bytes())?)
+    };
+
+    open_legacy_vault(path, keys, grant)
+}
+
+/// Opens a v1/v2 vault, recovering the WAL if needed. Unreachable without a
+/// grant, so the signature is what keeps a default call out.
+#[cfg(feature = "compression")]
+fn open_legacy_vault(
+    path: String,
+    keys: segment::VaultKeys,
+    grant: LegacyFormatGrant,
+) -> Result<VaultHandle, CryptoError> {
     let lock = VaultLock::acquire(&path)?;
 
     // If a previous key rotation was interrupted after pre-allocation but before
@@ -122,10 +231,6 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
     let index_pad_size = header.index_size as usize;
     let enc_idx_size = format::encrypted_index_size(index_pad_size);
     let data_off = format::data_region_offset(index_pad_size);
-
-    // Derive keys
-    let keys = segment::derive_vault_keys(&key)?;
-    key.zeroize();
 
     // Compute capacity from file size
     let file_size = file.seek(SeekFrom::End(0))?;
@@ -255,6 +360,7 @@ pub fn vault_open(path: String, mut key: Vec<u8>) -> Result<VaultHandle, CryptoE
         wal,
         lock,
         index_dirty: false,
+        grant,
     })
 }
 
@@ -1446,9 +1552,25 @@ pub fn vault_defragment(handle: &mut VaultHandle) -> Result<DefragResult, Crypto
 
 /// Consumes old handle (keys invalidated after rename). Returns new handle with new keys.
 pub fn vault_rotate_key(
-    mut handle: VaultHandle,
+    handle: VaultHandle,
     mut new_key: Vec<u8>,
 ) -> Result<VaultHandle, CryptoError> {
+    vault_rotate_key_guarded(handle, &mut new_key)
+}
+
+/// Takes the key by reference so a test owns the allocation and can read it back
+/// after the guard has wiped it.
+fn vault_rotate_key_guarded(
+    mut handle: VaultHandle,
+    new_key: &mut Vec<u8>,
+) -> Result<VaultHandle, CryptoError> {
+    // Derived first and under the guard, so the caller's key is gone before the
+    // lock, the cleanup and the copy below, and on every early return.
+    let new_keys = {
+        let new_key = KeyGuard::new(new_key);
+        segment::derive_vault_keys(new_key.as_bytes())?
+    };
+
     // We acquire a lock on both the current vault and the new vault that we do the transition with.
     let temp_path = format!("{}.rotating", handle.path);
 
@@ -1460,19 +1582,7 @@ pub fn vault_rotate_key(
     }
 
     let temp_lock = VaultLock::acquire(&temp_path)?;
-
-    // Generate the new key
     let capacity = handle.index.capacity;
-    let new_keys = match segment::derive_vault_keys(&new_key) {
-        Ok(k) => {
-            new_key.zeroize();
-            k
-        }
-        Err(e) => {
-            new_key.zeroize();
-            return Err(e);
-        }
-    };
     // Re-calc the same constants.
     let index_pad_size = format::compute_index_size(capacity);
     let total_size = format::total_vault_size(capacity, index_pad_size)?;
@@ -1707,6 +1817,9 @@ pub fn vault_rotate_key(
         wal: new_wal,
         lock: new_lock,
         index_dirty: false,
+        // The rotated file is the same vault in the same format, so it stays
+        // covered by the opt-in that opened it rather than granting its own.
+        grant: handle.grant,
     })
 }
 
@@ -1717,8 +1830,13 @@ pub fn vault_rotate_key(
 /// AEAD-wrapped with the caller's `wrapping_key`.
 ///
 /// The vault is not modified by this operation.
-#[cfg(feature = "compression")]
-pub fn vault_export(
+///
+/// The archive structure it writes is plaintext and its trailer is unkeyed, so
+/// this release ships no way to reach it. It is compiled for the regression and
+/// fixture tests only, and the Dart method that used to call it now returns a
+/// disabled-format result instead.
+#[cfg(all(test, feature = "compression"))]
+fn vault_export(
     handle: &mut VaultHandle,
     wrapping_key: Vec<u8>,
     export_path: String,
@@ -1774,7 +1892,7 @@ pub fn vault_export(
 
 /// Write the archive contents. Separated from `vault_export` so the caller
 /// can delete the partial file if this returns an error.
-#[cfg(feature = "compression")]
+#[cfg(all(test, feature = "compression"))]
 fn vault_export_write(
     handle: &mut VaultHandle,
     export_key: &[u8],
@@ -1935,14 +2053,21 @@ pub fn vault_close(mut handle: VaultHandle) -> Result<(), CryptoError> {
 ///
 /// Archives with version < 2 do not carry per-segment metadata; imported
 /// segments from those archives will have empty metadata.
-#[cfg(feature = "compression")]
-pub fn vault_import(
+///
+/// The archive it parses has no authenticated structure, so this release ships
+/// no way to reach it. It is compiled for the regression and fixture tests only,
+/// and the Dart method that used to call it now returns a disabled-format
+/// result instead. The grant it takes is the destination vault's: import writes
+/// the same unauthenticated v1/v2 format that `vault_create` writes.
+#[cfg(all(test, feature = "compression"))]
+fn vault_import(
     archive_path: String,
     wrapping_key: Vec<u8>,
     dest_path: String,
-    new_master_key: Vec<u8>,
+    mut new_master_key: Vec<u8>,
     algorithm: String,
     capacity_bytes: u64,
+    grant: LegacyFormatGrant,
 ) -> Result<VaultHandle, CryptoError> {
     use crate::core::evfs::archive::{
         ArchiveHeader, ArchiveTrailer, SegmentRecord, ARCHIVE_HEADER_SIZE, ARCHIVE_TRAILER_SIZE,
@@ -1951,6 +2076,7 @@ pub fn vault_import(
 
     // Ensure automatic zeroization on drop
     let wrapping_key = Zeroizing::new(wrapping_key);
+    let new_master_key = KeyGuard::new(&mut new_master_key);
 
     let mut archive = File::open(&archive_path)
         .map_err(|e| CryptoError::IoError(format!("cannot open archive '{archive_path}': {e}")))?;
@@ -1992,8 +2118,14 @@ pub fn vault_import(
     );
 
     // Create new destination vault
-    let mut dest_vault =
-        vault_create(dest_path.clone(), new_master_key, algorithm, capacity_bytes)?;
+    let dest_keys = segment::derive_vault_keys(new_master_key.as_bytes())?;
+    let mut dest_vault = create_legacy_vault(
+        dest_path.clone(),
+        dest_keys,
+        algorithm,
+        capacity_bytes,
+        grant,
+    )?;
 
     // Process all segments inside a closure to handle atomic crash recovery cleanup
     let mut process_records = || -> Result<(), CryptoError> {

--- a/rust/src/api/evfs/tests/crud.rs
+++ b/rust/src/api/evfs/tests/crud.rs
@@ -8,7 +8,7 @@ fn test_create_and_open() {
     let path = vault_path(&dir);
 
     {
-        let handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         let names = vault_list(&handle);
         assert!(names.is_empty());
@@ -16,7 +16,7 @@ fn test_create_and_open() {
     }
 
     {
-        let handle = vault_open(path, test_key()).expect("open");
+        let handle = optin_open(path, test_key()).expect("open");
         let names = vault_list(&handle);
         assert!(names.is_empty());
         vault_close(handle).expect("close");
@@ -29,12 +29,12 @@ fn test_open_wrong_key_fails() {
     let path = vault_path(&dir);
 
     {
-        let handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         vault_close(handle).expect("close");
     }
 
-    let result = vault_open(path, wrong_key());
+    let result = optin_open(path, wrong_key());
     assert!(result.is_err());
 }
 
@@ -45,7 +45,7 @@ fn test_open_runs_wal_recovery() {
 
     // Create vault with segment A
     {
-        let mut handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let mut handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         vault_write(&mut handle, "a.txt".into(), b"data-A".to_vec(), None, None).expect("write A");
         vault_close(handle).expect("close");
@@ -64,7 +64,7 @@ fn test_open_runs_wal_recovery() {
 
     // Add segment B normally (both index and data on disk)
     {
-        let mut handle = vault_open(path.clone(), test_key()).expect("open");
+        let mut handle = optin_open(path.clone(), test_key()).expect("open");
         vault_write(&mut handle, "b.txt".into(), b"data-B".to_vec(), None, None).expect("write B");
         vault_close(handle).expect("close");
     }
@@ -78,7 +78,7 @@ fn test_open_runs_wal_recovery() {
     }
 
     // Reopen — WAL recovery should roll back to A-only index
-    let mut handle = vault_open(path, test_key()).expect("open after recovery");
+    let mut handle = optin_open(path, test_key()).expect("open after recovery");
     let data = vault_read(&mut handle, "a.txt".into()).expect("read A").data;
     assert_eq!(data, b"data-A");
 

--- a/rust/src/api/evfs/tests/defragment.rs
+++ b/rust/src/api/evfs/tests/defragment.rs
@@ -164,7 +164,7 @@ fn test_defragment_crash_recovery() {
 
     // Create vault with A, B, C. Delete B to create a gap.
     {
-        let mut handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let mut handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         vault_write(&mut handle, "a.txt".into(), vec![0xAA; 100], None, None).expect("A");
         vault_write(&mut handle, "b.txt".into(), vec![0xBB; 100], None, None).expect("B");
@@ -193,7 +193,7 @@ fn test_defragment_crash_recovery() {
     }
 
     // Reopen — WAL recovery should restore pre-defrag index
-    let mut handle = vault_open(path, test_key()).expect("open after crash");
+    let mut handle = optin_open(path, test_key()).expect("open after crash");
 
     // C should still be at its original (pre-defrag) offset, readable
     assert_eq!(
@@ -236,7 +236,7 @@ fn test_defragment_crash_overlapping_move_recovers() {
     // so B's move from offset(A.size) to 0 overlaps.
     {
         let mut handle =
-            vault_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+            optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
         vault_write(&mut handle, "a.txt".into(), vec![0xAA; 100], None, None).expect("A");
         vault_write(&mut handle, "b.txt".into(), vec![0xBB; 10_000], None, None).expect("B");
         vault_delete(&mut handle, "a.txt".into()).expect("del A");
@@ -245,7 +245,7 @@ fn test_defragment_crash_overlapping_move_recovers() {
 
     // Save pre-defrag index and get B's offset/size
     let (pre_defrag_index, b_old_offset, b_size) = {
-        let handle = vault_open(path.clone(), test_key()).expect("open");
+        let handle = optin_open(path.clone(), test_key()).expect("open");
         let mut f = File::open(&path).expect("open file");
         let idx = read_encrypted_index(
             &mut f,
@@ -303,7 +303,7 @@ fn test_defragment_crash_overlapping_move_recovers() {
     }
 
     // Reopen — defrag backup + WAL recovery should restore to consistent state
-    let mut handle = vault_open(path, test_key()).expect("open after crash");
+    let mut handle = optin_open(path, test_key()).expect("open after crash");
 
     // B should be readable at old position (overlap zone restored)
     let b_data = vault_read(&mut handle, "b.txt".into()).expect("read B").data;

--- a/rust/src/api/evfs/tests/delete.rs
+++ b/rust/src/api/evfs/tests/delete.rs
@@ -129,9 +129,9 @@ fn test_concurrent_open_fails() {
     let path = vault_path(&dir);
 
     let _handle =
-        vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
 
-    let result = vault_open(path, test_key());
+    let result = optin_open(path, test_key());
     assert!(matches!(result, Err(CryptoError::VaultLocked)));
 }
 
@@ -143,7 +143,7 @@ fn test_write_close_open_read() {
     let path = vault_path(&dir);
 
     {
-        let mut handle = vault_create(
+        let mut handle = optin_create(
             path.clone(),
             test_key(),
             "chacha20-poly1305".into(),
@@ -162,7 +162,7 @@ fn test_write_close_open_read() {
     }
 
     {
-        let mut handle = vault_open(path, test_key()).expect("open");
+        let mut handle = optin_open(path, test_key()).expect("open");
         let data = vault_read(&mut handle, "persist.txt".into()).expect("read").data;
         assert_eq!(data, b"survives close");
         vault_close(handle).expect("close");
@@ -177,7 +177,7 @@ fn test_corrupted_primary_falls_back_to_shadow() {
     let path = vault_path(&dir);
 
     {
-        let mut handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let mut handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         vault_write(&mut handle, "doc.txt".into(), b"shadow test".to_vec(), None, None).expect("write");
         vault_close(handle).expect("close");
@@ -191,7 +191,7 @@ fn test_corrupted_primary_falls_back_to_shadow() {
     }
 
     // Open should succeed via shadow
-    let mut handle = vault_open(path, test_key()).expect("open via shadow");
+    let mut handle = optin_open(path, test_key()).expect("open via shadow");
     let data = vault_read(&mut handle, "doc.txt".into()).expect("read").data;
     assert_eq!(data, b"shadow test");
 

--- a/rust/src/api/evfs/tests/export_import.rs
+++ b/rust/src/api/evfs/tests/export_import.rs
@@ -410,7 +410,7 @@ fn test_import_full_roundtrip() {
     vault_close(handle).expect("close");
 
     let dest_path = import_dest_path(&dir);
-    let mut imported = vault_import(
+    let mut imported = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -444,7 +444,7 @@ fn test_import_wrong_wrapping_key_fails() {
 
     let dest_path = import_dest_path(&dir);
     let wrong_wk = vec![0xEE; 32];
-    let result = vault_import(
+    let result = optin_import(
         epath,
         wrong_wk,
         dest_path,
@@ -471,7 +471,7 @@ fn test_import_truncated_archive() {
     std::fs::write(&epath, archive).expect("write");
 
     let dest_path = import_dest_path(&dir);
-    let result = vault_import(
+    let result = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -503,7 +503,7 @@ fn test_import_tampered_segment_data() {
     std::fs::write(&epath, archive).expect("write");
 
     let dest_path = import_dest_path(&dir);
-    let result = vault_import(
+    let result = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -531,7 +531,7 @@ fn test_import_tampered_trailer_checksum() {
     std::fs::write(&epath, archive).expect("write");
 
     let dest_path = import_dest_path(&dir);
-    let result = vault_import(
+    let result = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -553,7 +553,7 @@ fn test_import_insufficient_capacity() {
     vault_close(handle).expect("close");
 
     let dest_path = import_dest_path(&dir);
-    let result = vault_import(
+    let result = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -586,7 +586,7 @@ fn test_import_streaming_segment() {
     vault_close(handle).expect("close");
 
     let dest_path = import_dest_path(&dir);
-    let mut imported = vault_import(
+    let mut imported = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -626,7 +626,7 @@ fn test_import_compressed_segment() {
     vault_close(handle).expect("close");
 
     let dest_path = import_dest_path(&dir);
-    let mut imported = vault_import(
+    let mut imported = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -648,7 +648,7 @@ fn test_import_compressed_segment() {
 #[test]
 fn test_import_chacha20() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let mut handle = vault_create(
+    let mut handle = optin_create(
         vault_path(&dir),
         test_key(),
         "chacha20-poly1305".into(),
@@ -662,7 +662,7 @@ fn test_import_chacha20() {
     vault_close(handle).expect("close");
 
     let dest_path = import_dest_path(&dir);
-    let mut imported = vault_import(
+    let mut imported = optin_import(
         epath,
         wrapping_key(),
         dest_path.clone(),
@@ -714,9 +714,9 @@ fn test_export_import_preserves_metadata() {
         .expect("path")
         .to_string();
 
-    vault_import(epath, wrapping_key(), dest.clone(), test_key2(), "aes-256-gcm".into(), 1_048_576).expect("import");
+    optin_import(epath, wrapping_key(), dest.clone(), test_key2(), "aes-256-gcm".into(), 1_048_576).expect("import");
 
-    let mut imported = vault_open(dest, test_key2()).expect("open");
+    let mut imported = optin_open(dest, test_key2()).expect("open");
 
     let result = vault_read(&mut imported, "doc.txt".into()).expect("read doc");
     assert_eq!(result.data, b"hello");

--- a/rust/src/api/evfs/tests/index_cache.rs
+++ b/rust/src/api/evfs/tests/index_cache.rs
@@ -15,10 +15,10 @@ fn test_index_dirty_false_after_open() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = vault_path(&dir);
     let handle =
-        vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
     vault_close(handle).expect("close");
 
-    let handle = vault_open(path, test_key()).expect("open");
+    let handle = optin_open(path, test_key()).expect("open");
     assert!(!handle.index_dirty);
     vault_close(handle).expect("close");
 }
@@ -81,14 +81,14 @@ fn test_vault_flush_persists_and_survives_reopen() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = vault_path(&dir);
     let mut handle =
-        vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
     vault_write(&mut handle, "a.txt".into(), b"hello".to_vec(), None, None).expect("write");
     // Explicit flush then close — data must survive reopen
     vault_flush(&mut handle).expect("flush");
     assert!(!handle.index_dirty);
     vault_close(handle).expect("close");
 
-    let mut reopened = vault_open(path, test_key()).expect("reopen");
+    let mut reopened = optin_open(path, test_key()).expect("reopen");
     assert_eq!(
         vault_read(&mut reopened, "a.txt".into()).expect("read").data,
         b"hello"
@@ -101,14 +101,14 @@ fn test_vault_close_flushes_dirty_and_persists() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = vault_path(&dir);
     let mut handle =
-        vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
     vault_write(&mut handle, "b.txt".into(), b"world".to_vec(), None, None).expect("write");
     // Simulate a dirty handle at close time by manually setting the flag.
     // This exercises the vault_close dirty-flush path.
     handle.index_dirty = true;
     vault_close(handle).expect("close");
 
-    let mut reopened = vault_open(path, test_key()).expect("reopen");
+    let mut reopened = optin_open(path, test_key()).expect("reopen");
     assert_eq!(
         vault_read(&mut reopened, "b.txt".into()).expect("read").data,
         b"world"
@@ -121,7 +121,7 @@ fn test_index_dirty_false_after_rotate_key() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = vault_path(&dir);
     let handle =
-        vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
     let rotated = vault_rotate_key(handle, test_key2()).expect("rotate");
     assert!(!rotated.index_dirty);
     vault_close(rotated).expect("close");

--- a/rust/src/api/evfs/tests/legacy_policy.rs
+++ b/rust/src/api/evfs/tests/legacy_policy.rs
@@ -1,0 +1,741 @@
+//! Default denial for the unauthenticated v1/v2 vault format.
+//!
+//! A denied call has to fail before it opens, creates, locks or recovers
+//! anything, so most of these tests rig the filesystem so that reaching the path
+//! fails loudly, and then show the denial arrives instead of that failure. Each
+//! hostile input is also run with the opt-in, which is what proves the rigging
+//! works and that the oracle has any power at all.
+//!
+//! What the oracles here can see is a changed directory and a propagated I/O
+//! error. A read-only `stat` that is discarded would slip past them, so the
+//! statement that nothing touches the path before the check rests on the
+//! source-order scan in `api::surface`, not on these tests.
+
+use super::*;
+use crate::core::evfs::format::{VAULT_MAGIC, VAULT_VERSION};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+/// One directory entry: name, kind, length, permissions and modification time.
+type Snapshot = BTreeMap<String, String>;
+
+/// Everything the parent directory holds, recorded as text so a mismatch prints
+/// what changed.
+fn snapshot(dir: &Path) -> Snapshot {
+    let mut entries = BTreeMap::new();
+    let listing = fs::read_dir(dir).expect("parent directory is unreadable");
+
+    for entry in listing {
+        let entry = entry.expect("directory entry is unreadable");
+        let name = entry.file_name().to_string_lossy().to_string();
+        let meta = entry
+            .path()
+            .symlink_metadata()
+            .expect("directory entry has no metadata");
+
+        let described = format!(
+            "dir={} file={} link={} len={} readonly={} modified={:?}",
+            meta.is_dir(),
+            meta.is_file(),
+            meta.file_type().is_symlink(),
+            meta.len(),
+            meta.permissions().readonly(),
+            meta.modified().ok()
+        );
+
+        if meta.is_dir() {
+            // A directory this test made unreadable on purpose still has to be
+            // recorded, so its state is compared rather than skipped.
+            match fs::read_dir(entry.path()) {
+                Ok(_) => {
+                    for (nested, described) in snapshot(&entry.path()) {
+                        entries.insert(format!("{name}/{nested}"), described);
+                    }
+                }
+                Err(error) => {
+                    entries.insert(format!("{name}/<unreadable>"), error.to_string());
+                }
+            }
+        }
+        entries.insert(name, described);
+    }
+
+    entries
+}
+
+fn sidecars(vault_path: &str) -> Vec<String> {
+    ["", ".lock", ".wal", ".rotating", ".defrag"]
+        .iter()
+        .map(|suffix| format!("{vault_path}{suffix}"))
+        .filter(|path| Path::new(path).exists())
+        .collect()
+}
+
+fn denied_create(path: &str) -> CryptoError {
+    vault_create(
+        path.to_string(),
+        test_key(),
+        "aes-256-gcm".into(),
+        SIZE_MB,
+        UnsafeLegacyEvfsPolicy::Deny,
+    )
+    .err()
+    .expect("creation was allowed by default")
+}
+
+fn denied_open(path: &str) -> CryptoError {
+    vault_open(path.to_string(), test_key(), UnsafeLegacyEvfsPolicy::Deny)
+        .err()
+        .expect("opening was allowed by default")
+}
+
+fn assert_denied(error: &CryptoError, case: &str) {
+    assert!(
+        matches!(error, CryptoError::UnsafeLegacyFormatDenied),
+        "{case} returned {error:?} instead of a policy denial, so something ran first"
+    );
+}
+
+/// Check that the denial happened without touching the directory, then show the
+/// input really is hostile by running the same call with the opt-in.
+///
+/// The opted-in probe runs after the snapshot comparison on purpose: a failed
+/// opted-in call gets as far as creating the `.lock` sidecar, which is exactly
+/// the effect a denied call must not have.
+fn assert_refused_without_a_trace(
+    dir: &Path,
+    case: &str,
+    denied: impl FnOnce() -> CryptoError,
+    opted_in: impl FnOnce() -> Result<VaultHandle, CryptoError>,
+) {
+    let before = snapshot(dir);
+    let error = denied();
+    let after = snapshot(dir);
+
+    assert_denied(&error, case);
+    assert_eq!(before, after, "{case} changed the directory");
+    assert!(
+        opted_in().is_err(),
+        "{case} is not hostile after all, so it proves nothing"
+    );
+}
+
+// -- Denial before any filesystem work ---------------------------------------
+
+#[test]
+fn creation_is_denied_by_default_and_leaves_the_directory_untouched() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+    let before = snapshot(dir.path());
+
+    let error = vault_create(
+        path.clone(),
+        test_key(),
+        "aes-256-gcm".into(),
+        SIZE_MB,
+        UnsafeLegacyEvfsPolicy::Deny,
+    )
+    .err()
+    .expect("creation was allowed by default");
+
+    assert_denied(&error, "a plain create");
+    assert_eq!(sidecars(&path), Vec::<String>::new());
+    assert_eq!(before, snapshot(dir.path()), "the directory changed");
+}
+
+#[test]
+fn opening_is_denied_by_default_and_leaves_the_vault_untouched() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+    let handle = create_test_vault(&dir, SIZE_MB);
+    vault_close(handle).expect("close");
+
+    let before = snapshot(dir.path());
+
+    let error = vault_open(path.clone(), test_key(), UnsafeLegacyEvfsPolicy::Deny)
+        .err()
+        .expect("opening was allowed by default");
+
+    assert_denied(&error, "opening an existing vault");
+    // Closing released the lock but left the checkpointed WAL, and a denied
+    // open must not add either back.
+    assert_eq!(sidecars(&path), vec![path.clone(), format!("{path}.wal")]);
+    assert_eq!(before, snapshot(dir.path()), "the vault directory changed");
+}
+
+#[test]
+fn a_denied_create_reports_no_io_error_for_a_path_it_cannot_use() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let existing = vault_path(&dir);
+    vault_close(create_test_vault(&dir, SIZE_MB)).expect("close");
+
+    let occupied = dir.path().join("occupied").to_string_lossy().to_string();
+    fs::write(&occupied, b"not a vault").expect("write");
+
+    // Each of these makes reaching the path fail for a different reason, and
+    // none of the reasons depends on the process being unprivileged.
+    let under_a_file = format!("{occupied}/inside.vault");
+    let long_name = dir
+        .path()
+        .join("l".repeat(512))
+        .to_string_lossy()
+        .to_string();
+    let mut cases = vec![
+        ("an existing file", occupied.clone()),
+        ("an existing vault", existing),
+        ("a path under a file", under_a_file),
+        ("an over-long name", long_name),
+    ];
+    #[cfg(unix)]
+    {
+        let loop_path = dir.path().join("loop").to_string_lossy().to_string();
+        std::os::unix::fs::symlink(&loop_path, &loop_path).expect("symlink loop");
+        cases.push(("a symlink loop", loop_path));
+    }
+
+    for (case, path) in cases {
+        assert_refused_without_a_trace(
+            dir.path(),
+            case,
+            || denied_create(&path),
+            || optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB),
+        );
+    }
+}
+
+#[test]
+fn a_denied_open_reports_no_io_error_for_a_path_it_cannot_use() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir
+        .path()
+        .join("absent.vault")
+        .to_string_lossy()
+        .to_string();
+
+    let not_a_vault = dir.path().join("plain.bin").to_string_lossy().to_string();
+    fs::write(&not_a_vault, b"not a vault").expect("write");
+
+    let a_directory = dir.path().join("dir.vault").to_string_lossy().to_string();
+    fs::create_dir(&a_directory).expect("mkdir");
+
+    let mut cases = vec![
+        ("a missing file", missing),
+        ("a file that is not a vault", not_a_vault),
+        ("a directory", a_directory),
+    ];
+    #[cfg(unix)]
+    {
+        let dangling = dir.path().join("dangling").to_string_lossy().to_string();
+        std::os::unix::fs::symlink(dir.path().join("nowhere"), &dangling)
+            .expect("dangling symlink");
+        cases.push(("a dangling symlink", dangling));
+    }
+
+    for (case, path) in cases {
+        assert_refused_without_a_trace(
+            dir.path(),
+            case,
+            || denied_open(&path),
+            || optin_open(path.clone(), test_key()),
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a_denied_open_through_an_alias_of_a_real_vault_touches_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+    vault_close(create_test_vault(&dir, SIZE_MB)).expect("close");
+
+    // Both names reach the same vault, so unlike the cases above these are not
+    // rigged to fail: the opt-in opens them. The denial is the only thing that
+    // stops the default call.
+    let hard_link = dir
+        .path()
+        .join("hard_link.vault")
+        .to_string_lossy()
+        .to_string();
+    fs::hard_link(&path, &hard_link).expect("hard link");
+
+    let symlink = dir
+        .path()
+        .join("symlink.vault")
+        .to_string_lossy()
+        .to_string();
+    std::os::unix::fs::symlink(&path, &symlink).expect("symlink");
+
+    for (case, alias) in [("a hard link", hard_link), ("a symlink", symlink)] {
+        let before = snapshot(dir.path());
+        let error = denied_open(&alias);
+        let after = snapshot(dir.path());
+
+        assert_denied(&error, case);
+        assert_eq!(before, after, "{case} changed the directory");
+        assert_eq!(
+            sidecars(&alias),
+            vec![alias.clone()],
+            "{case} grew a sidecar"
+        );
+
+        let opened = optin_open(alias.clone(), test_key());
+        assert!(opened.is_ok(), "{case} does not reach the vault at all");
+        vault_close(opened.expect("checked above")).expect("close");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a_denied_call_never_reaches_a_permission_trap() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let trap = dir.path().join("trap");
+    fs::create_dir(&trap).expect("mkdir");
+    let path = trap.join("test.vault").to_string_lossy().to_string();
+
+    // Restored even if an assertion below panics, or the temp directory cannot
+    // be cleaned up afterwards.
+    struct RestoreMode<'a>(&'a Path);
+    impl Drop for RestoreMode<'_> {
+        fn drop(&mut self) {
+            let _ = fs::set_permissions(self.0, fs::Permissions::from_mode(0o755));
+        }
+    }
+
+    fs::set_permissions(&trap, fs::Permissions::from_mode(0o000)).expect("chmod");
+    let _restore = RestoreMode(&trap);
+
+    // Root ignores the mode bits, so the trap only proves something when the
+    // test process cannot read through it.
+    if fs::read_dir(&trap).is_err() {
+        assert_refused_without_a_trace(
+            dir.path(),
+            "a create under an unreadable directory",
+            || denied_create(&path),
+            || optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB),
+        );
+        assert_refused_without_a_trace(
+            dir.path(),
+            "an open under an unreadable directory",
+            || denied_open(&path),
+            || optin_open(path.clone(), test_key()),
+        );
+    }
+}
+
+#[test]
+fn a_denied_open_never_acquires_the_lock() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+    vault_close(create_test_vault(&dir, SIZE_MB)).expect("close");
+
+    // Held on a separate descriptor, which is what an opted-in open collides
+    // with. The denial has to arrive without that collision.
+    let held = crate::core::evfs::wal::VaultLock::acquire(&path).expect("hold the lock");
+
+    let error = vault_open(path.clone(), test_key(), UnsafeLegacyEvfsPolicy::Deny)
+        .err()
+        .expect("opening was allowed by default");
+    assert_denied(&error, "an open against a locked vault");
+
+    let collided = optin_open(path.clone(), test_key())
+        .err()
+        .expect("the lock was not held");
+    assert!(
+        matches!(collided, CryptoError::VaultLocked),
+        "the lock oracle is not working: {collided:?}"
+    );
+
+    held.release().expect("release");
+}
+
+#[test]
+fn a_denied_create_never_writes_a_wal_or_lock_sidecar() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    for _ in 0..3 {
+        let error = vault_create(
+            path.clone(),
+            test_key(),
+            "aes-256-gcm".into(),
+            SIZE_MB,
+            UnsafeLegacyEvfsPolicy::Deny,
+        )
+        .err()
+        .expect("creation was allowed by default");
+        assert_denied(&error, "a repeated create");
+    }
+
+    assert_eq!(sidecars(&path), Vec::<String>::new());
+    assert!(
+        snapshot(dir.path()).is_empty(),
+        "the directory is not empty"
+    );
+}
+
+#[test]
+fn denial_wins_over_an_input_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let error = vault_create(
+        vault_path(&dir),
+        Vec::new(),
+        "not-an-algorithm".into(),
+        SIZE_MB,
+        UnsafeLegacyEvfsPolicy::Deny,
+    )
+    .err()
+    .expect("creation was allowed by default");
+
+    // An empty key and an unknown algorithm are both rejected further in, so
+    // seeing the denial proves the check runs before argument validation.
+    assert_denied(&error, "a create with unusable arguments");
+
+    // Both really are rejected, so the case is not vacuous.
+    assert!(
+        optin_create(vault_path(&dir), Vec::new(), "aes-256-gcm".into(), SIZE_MB).is_err(),
+        "an empty key was accepted"
+    );
+    assert!(
+        optin_create(
+            vault_path(&dir),
+            test_key(),
+            "not-an-algorithm".into(),
+            SIZE_MB
+        )
+        .is_err(),
+        "an unknown algorithm was accepted"
+    );
+}
+
+// -- The caller's key -------------------------------------------------------
+
+/// Call the guarded entry point on a key the caller keeps, then read the
+/// allocation back. `Vec::zeroize` clears the length but keeps the buffer, so
+/// this reads live memory rather than freed memory.
+fn observe_key_after(
+    policy: UnsafeLegacyEvfsPolicy,
+    call: impl FnOnce(&mut Vec<u8>, UnsafeLegacyEvfsPolicy) -> Result<VaultHandle, CryptoError>,
+) -> (Result<VaultHandle, CryptoError>, Vec<u8>) {
+    let mut owned = test_key();
+    let len = owned.len();
+    let outcome = call(&mut owned, policy);
+    // SAFETY: the wipe shortened `owned` without releasing its allocation, so
+    // the first `len` bytes are still inside it.
+    let observed = unsafe { std::slice::from_raw_parts(owned.as_ptr(), len) }.to_vec();
+    (outcome, observed)
+}
+
+#[test]
+fn the_denied_call_wipes_the_key_it_was_handed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    let (created, wiped) = observe_key_after(UnsafeLegacyEvfsPolicy::Deny, |key, policy| {
+        vault_create_guarded(path.clone(), key, "aes-256-gcm".into(), SIZE_MB, policy)
+    });
+    assert_denied(
+        &created.err().expect("creation was allowed by default"),
+        "a create",
+    );
+    assert!(wiped.iter().all(|&b| b == 0), "create left {wiped:?}");
+
+    let (opened, wiped) = observe_key_after(UnsafeLegacyEvfsPolicy::Deny, |key, policy| {
+        vault_open_guarded(path.clone(), key, policy)
+    });
+    assert_denied(
+        &opened.err().expect("opening was allowed by default"),
+        "an open",
+    );
+    assert!(wiped.iter().all(|&b| b == 0), "open left {wiped:?}");
+}
+
+#[test]
+fn the_opted_in_call_wipes_the_key_it_was_handed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    let (created, wiped) = observe_key_after(
+        UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2,
+        |key, policy| {
+            vault_create_guarded(path.clone(), key, "aes-256-gcm".into(), SIZE_MB, policy)
+        },
+    );
+    vault_close(created.expect("create")).expect("close");
+    assert!(wiped.iter().all(|&b| b == 0), "create left {wiped:?}");
+
+    let (opened, wiped) = observe_key_after(
+        UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2,
+        |key, policy| vault_open_guarded(path.clone(), key, policy),
+    );
+    vault_close(opened.expect("open")).expect("close");
+    assert!(wiped.iter().all(|&b| b == 0), "open left {wiped:?}");
+}
+
+#[test]
+fn a_refused_rotation_wipes_the_new_key_it_was_handed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+    let handle = create_test_vault(&dir, SIZE_MB);
+
+    // Holding the rotation lock makes the rotation fail after the key has been
+    // derived and before anything is copied.
+    let held = crate::core::evfs::wal::VaultLock::acquire(&format!("{path}.rotating"))
+        .expect("hold the rotation lock");
+
+    let mut owned = test_key2();
+    let len = owned.len();
+    let outcome = vault_rotate_key_guarded(handle, &mut owned);
+    // SAFETY: the wipe shortened `owned` without releasing its allocation, so
+    // the first `len` bytes are still inside it.
+    let observed = unsafe { std::slice::from_raw_parts(owned.as_ptr(), len) }.to_vec();
+
+    assert!(outcome.is_err(), "the rotation lock was not held");
+    assert!(
+        observed.iter().all(|&b| b == 0),
+        "the refused rotation left {observed:?}"
+    );
+
+    held.release().expect("release");
+}
+
+#[test]
+fn a_failing_opted_in_call_still_wipes_the_key() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let missing = dir
+        .path()
+        .join("absent.vault")
+        .to_string_lossy()
+        .to_string();
+
+    let (opened, wiped) = observe_key_after(
+        UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2,
+        |key, policy| vault_open_guarded(missing.clone(), key, policy),
+    );
+
+    assert!(opened.is_err(), "a missing vault opened");
+    assert!(
+        wiped.iter().all(|&b| b == 0),
+        "the failed open left {wiped:?}"
+    );
+}
+
+// -- What the opt-in gets ----------------------------------------------------
+
+#[test]
+fn the_opt_in_round_trips_the_existing_format() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    let mut handle =
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+    vault_write(&mut handle, "note".into(), b"opted in".to_vec(), None, None).expect("write");
+    vault_close(handle).expect("close");
+
+    // Opting in writes the format that is already on disk, not a new one. The
+    // bytes are spelled out rather than compared against the crate's own
+    // constants, so writing a new version cannot keep this green.
+    let header = fs::read(&path).expect("read vault");
+    assert_eq!(&header[0..4], b"MVLT");
+    assert_eq!(header[4], 2);
+    assert_eq!(
+        (VAULT_MAGIC, VAULT_VERSION),
+        (b"MVLT", 2),
+        "the writer's format identity changed under this test"
+    );
+
+    let mut reopened = optin_open(path, test_key()).expect("reopen");
+    assert_eq!(
+        vault_read(&mut reopened, "note".into()).expect("read").data,
+        b"opted in".to_vec()
+    );
+    vault_close(reopened).expect("close");
+}
+
+#[test]
+fn the_decision_carries_through_rotation_and_reopening() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    let mut handle =
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+    vault_write(&mut handle, "note".into(), b"carried".to_vec(), None, None).expect("write");
+
+    let mut rotated = vault_rotate_key(handle, test_key2()).expect("rotate");
+    assert_eq!(
+        vault_read(&mut rotated, "note".into()).expect("read").data,
+        b"carried".to_vec()
+    );
+    vault_close(rotated).expect("close");
+
+    // The rotated file is still the old format, so a default reopen is refused.
+    let error = vault_open(path.clone(), test_key2(), UnsafeLegacyEvfsPolicy::Deny)
+        .err()
+        .expect("opening was allowed by default");
+    assert_denied(&error, "reopening a rotated vault");
+
+    vault_close(optin_open(path, test_key2()).expect("reopen")).expect("close");
+}
+
+// -- No decision leaks between calls ----------------------------------------
+
+#[test]
+fn an_opted_in_call_does_not_authorize_a_later_default_call() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    let handle =
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+    vault_close(handle).expect("close");
+
+    for _ in 0..5 {
+        let error = vault_open(path.clone(), test_key(), UnsafeLegacyEvfsPolicy::Deny)
+            .err()
+            .expect("an earlier opt-in authorized a default open");
+        assert_denied(&error, "an open after an opt-in");
+    }
+
+    // A live opted-in handle is not authority for a default call either.
+    let held = optin_open(path.clone(), test_key()).expect("open");
+    let error = vault_create(
+        dir.path()
+            .join("second.vault")
+            .to_string_lossy()
+            .to_string(),
+        test_key(),
+        "aes-256-gcm".into(),
+        SIZE_MB,
+        UnsafeLegacyEvfsPolicy::Deny,
+    )
+    .err()
+    .expect("a live handle authorized a default create");
+    assert_denied(&error, "a create while a handle is open");
+    vault_close(held).expect("close");
+}
+
+#[test]
+fn interleaved_denied_and_opted_in_calls_keep_their_own_answers() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Each thread works on its own vault, so the only thing they share is the
+    // policy decision - which must not be shared at all.
+    let paths: Vec<String> = (0..8)
+        .map(|i| {
+            dir.path()
+                .join(format!("thread{i}.vault"))
+                .to_string_lossy()
+                .to_string()
+        })
+        .collect();
+
+    let outcomes: Vec<(bool, Result<(), CryptoError>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = paths
+            .iter()
+            .enumerate()
+            .map(|(i, path)| {
+                let opted_in = i % 2 == 0;
+                scope.spawn(move || {
+                    let outcome = if opted_in {
+                        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB)
+                            .and_then(vault_close)
+                    } else {
+                        vault_create(
+                            path.clone(),
+                            test_key(),
+                            "aes-256-gcm".into(),
+                            SIZE_MB,
+                            UnsafeLegacyEvfsPolicy::Deny,
+                        )
+                        .and_then(vault_close)
+                    };
+                    (opted_in, outcome)
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("thread panicked"))
+            .collect()
+    });
+
+    for (i, (opted_in, outcome)) in outcomes.iter().enumerate() {
+        let exists = Path::new(&paths[i]).exists();
+        if *opted_in {
+            assert!(outcome.is_ok(), "opted-in thread {i} failed: {outcome:?}");
+            assert!(exists, "opted-in thread {i} wrote no vault");
+        } else {
+            let error = outcome
+                .as_ref()
+                .expect_err("a denied thread created a vault");
+            assert_denied(error, &format!("thread {i}"));
+            assert!(!exists, "denied thread {i} left a file behind");
+        }
+    }
+}
+
+#[test]
+fn a_denied_call_racing_an_opted_in_one_on_the_same_path_still_denies() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    // Four rounds, so a decision leaking in either direction has room to show.
+    for round in 0..4 {
+        let denied = std::thread::scope(|scope| {
+            let allowed = scope
+                .spawn(|| optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB));
+            let refused = scope.spawn(|| denied_create(&path));
+
+            let refused = refused.join().expect("thread panicked");
+            // Both race for create_new, so either may lose. Only the refusal is
+            // being asserted.
+            if let Ok(handle) = allowed.join().expect("thread panicked") {
+                vault_close(handle).expect("close");
+            }
+            refused
+        });
+
+        assert_denied(&denied, &format!("round {round}"));
+
+        for suffix in ["", ".lock", ".wal"] {
+            let _ = fs::remove_file(format!("{path}{suffix}"));
+        }
+    }
+}
+
+#[test]
+fn repeated_calls_on_one_path_answer_each_on_its_own_policy() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = vault_path(&dir);
+
+    // Deny, allow, deny, deny, allow against the same path in one thread. The
+    // creation in the middle is the only one that may leave a file.
+    let first = vault_create(
+        path.clone(),
+        test_key(),
+        "aes-256-gcm".into(),
+        SIZE_MB,
+        UnsafeLegacyEvfsPolicy::Deny,
+    )
+    .err()
+    .expect("creation was allowed by default");
+    assert_denied(&first, "the first create");
+    assert!(!Path::new(&path).exists());
+
+    vault_close(
+        optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create"),
+    )
+    .expect("close");
+
+    for round in 0..2 {
+        let error = vault_open(path.clone(), test_key(), UnsafeLegacyEvfsPolicy::Deny)
+            .err()
+            .expect("opening was allowed by default");
+        assert_denied(&error, &format!("open round {round}"));
+    }
+
+    vault_close(optin_open(path, test_key()).expect("reopen")).expect("close");
+}

--- a/rust/src/api/evfs/tests/metadata.rs
+++ b/rust/src/api/evfs/tests/metadata.rs
@@ -136,7 +136,7 @@ fn test_metadata_survives_close_reopen() {
 
     {
         let mut handle =
-            vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
+            optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576).expect("create");
         vault_write(
             &mut handle,
             "persist.txt".into(),
@@ -148,7 +148,7 @@ fn test_metadata_survives_close_reopen() {
         vault_close(handle).expect("close");
     }
 
-    let mut handle = vault_open(path, test_key()).expect("reopen");
+    let mut handle = optin_open(path, test_key()).expect("reopen");
     let result = vault_read(&mut handle, "persist.txt".into()).expect("read");
     assert_eq!(result.data, b"durable");
     assert_eq!(result.metadata, meta);

--- a/rust/src/api/evfs/tests/mod.rs
+++ b/rust/src/api/evfs/tests/mod.rs
@@ -13,6 +13,43 @@ pub(super) fn wrong_key() -> Vec<u8> {
     vec![0xBB; 32]
 }
 
+/// The opt-in every test that wants a working vault has to state.
+pub(super) fn legacy_optin() -> UnsafeLegacyEvfsPolicy {
+    UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2
+}
+
+pub(super) fn optin_create(
+    path: String,
+    key: Vec<u8>,
+    algorithm: String,
+    capacity_bytes: u64,
+) -> Result<VaultHandle, CryptoError> {
+    vault_create(path, key, algorithm, capacity_bytes, legacy_optin())
+}
+
+pub(super) fn optin_open(path: String, key: Vec<u8>) -> Result<VaultHandle, CryptoError> {
+    vault_open(path, key, legacy_optin())
+}
+
+pub(super) fn optin_import(
+    archive_path: String,
+    wrapping_key: Vec<u8>,
+    dest_path: String,
+    new_master_key: Vec<u8>,
+    algorithm: String,
+    capacity_bytes: u64,
+) -> Result<VaultHandle, CryptoError> {
+    vault_import(
+        archive_path,
+        wrapping_key,
+        dest_path,
+        new_master_key,
+        algorithm,
+        capacity_bytes,
+        legacy_optin().authorize().expect("opt-in grant"),
+    )
+}
+
 pub(super) fn create_test_vault(dir: &tempfile::TempDir, capacity: u64) -> VaultHandle {
     let path = dir
         .path()
@@ -20,7 +57,7 @@ pub(super) fn create_test_vault(dir: &tempfile::TempDir, capacity: u64) -> Vault
         .to_str()
         .expect("path")
         .to_string();
-    vault_create(path, test_key(), "aes-256-gcm".into(), capacity).expect("create vault")
+    optin_create(path, test_key(), "aes-256-gcm".into(), capacity).expect("create vault")
 }
 
 pub(super) fn vault_path(dir: &tempfile::TempDir) -> String {
@@ -52,6 +89,7 @@ pub(super) fn stream_write_chunks(
 
 mod crud;
 mod compression;
+mod legacy_policy;
 mod allocator;
 mod delete;
 mod resize;

--- a/rust/src/api/evfs/tests/parallel.rs
+++ b/rust/src/api/evfs/tests/parallel.rs
@@ -171,7 +171,7 @@ fn test_parallel_read_chacha20() {
     let path = vault_path(&dir);
 
     let mut handle =
-        vault_create(path, test_key(), "chacha20-poly1305".into(), 4_194_304).expect("create");
+        optin_create(path, test_key(), "chacha20-poly1305".into(), 4_194_304).expect("create");
 
     vault_write(&mut handle, "x".into(), b"chacha-data".to_vec(), None, None).expect("write");
     vault_write(&mut handle, "y".into(), b"poly1305-data".to_vec(), None, None).expect("write");

--- a/rust/src/api/evfs/tests/rename.rs
+++ b/rust/src/api/evfs/tests/rename.rs
@@ -138,7 +138,7 @@ fn test_rename_chacha20() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = vault_path(&dir);
     let mut handle =
-        vault_create(path, test_key(), "chacha20-poly1305".into(), 1_048_576).expect("create");
+        optin_create(path, test_key(), "chacha20-poly1305".into(), 1_048_576).expect("create");
 
     vault_write(
         &mut handle,

--- a/rust/src/api/evfs/tests/resize.rs
+++ b/rust/src/api/evfs/tests/resize.rs
@@ -34,7 +34,7 @@ fn test_resize_shrink_after_consolidation() {
 
     // Create a 2MB vault and write ~500KB of data.
     {
-        let mut handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 2 * SIZE_MB)
+        let mut handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 2 * SIZE_MB)
             .expect("create 2MB");
         let data = vec![0xCC; 500_000];
         vault_write(&mut handle, "doc.bin".into(), data, None, None).expect("write 500KB");
@@ -43,7 +43,7 @@ fn test_resize_shrink_after_consolidation() {
 
     // Reopen, shrink to 1MB. Data is at the beginning so it should fit.
     {
-        let mut handle = vault_open(path.clone(), test_key()).expect("reopen");
+        let mut handle = optin_open(path.clone(), test_key()).expect("reopen");
         vault_resize(&mut handle, SIZE_MB).expect("shrink to 1MB");
 
         // Verify all data is still readable.
@@ -59,7 +59,7 @@ fn test_resize_shrink_after_consolidation() {
 
     // Reopen again to confirm persistence across close/open.
     {
-        let mut handle = vault_open(path, test_key()).expect("reopen again");
+        let mut handle = optin_open(path, test_key()).expect("reopen again");
         let data = vault_read(&mut handle, "doc.bin".into()).expect("read persisted").data;
         assert_eq!(data, vec![0xCC; 500_000]);
         vault_close(handle).expect("close");
@@ -95,7 +95,7 @@ fn test_resize_grow_updates_capacity() {
 
     {
         let mut handle =
-            vault_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+            optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
 
         let cap_before = vault_capacity(&handle);
         assert_eq!(cap_before.total_bytes, SIZE_MB);
@@ -112,7 +112,7 @@ fn test_resize_grow_updates_capacity() {
 
     // Verify persistence: reopen and check capacity.
     {
-        let handle = vault_open(path, test_key()).expect("reopen");
+        let handle = optin_open(path, test_key()).expect("reopen");
         let cap = vault_capacity(&handle);
         assert_eq!(cap.total_bytes, 2 * SIZE_MB);
         vault_close(handle).expect("close");
@@ -127,7 +127,7 @@ fn test_resize_grow_crash_recovery() {
     // Create vault with one segment.
     {
         let mut handle =
-            vault_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+            optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
         vault_write(&mut handle, "a.txt".into(), b"before grow".to_vec(), None, None).expect("write A");
         vault_close(handle).expect("close");
     }
@@ -145,7 +145,7 @@ fn test_resize_grow_crash_recovery() {
 
     // Perform a real grow to 2MB.
     {
-        let mut handle = vault_open(path.clone(), test_key()).expect("open");
+        let mut handle = optin_open(path.clone(), test_key()).expect("open");
         vault_resize(&mut handle, 2 * SIZE_MB).expect("grow");
         vault_write(&mut handle, "b.txt".into(), b"after grow".to_vec(), None, None).expect("write B");
         vault_close(handle).expect("close");
@@ -162,7 +162,7 @@ fn test_resize_grow_crash_recovery() {
     }
 
     // Reopen — WAL recovery should roll back to the A-only / 1MB index.
-    let mut handle = vault_open(path, test_key()).expect("open after recovery");
+    let mut handle = optin_open(path, test_key()).expect("open after recovery");
 
     // A should be readable.
     let data = vault_read(&mut handle, "a.txt".into()).expect("read A").data;
@@ -245,7 +245,7 @@ fn test_resize_grow_crash_midway_recovers() {
     let good_encrypted;
     {
         let mut handle =
-            vault_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
+            optin_create(path.clone(), test_key(), "aes-256-gcm".into(), SIZE_MB).expect("create");
         vault_write(&mut handle, "a.txt".into(), b"safe data".to_vec(), None, None).expect("write A");
         vault_close(handle).expect("close");
     }
@@ -286,7 +286,7 @@ fn test_resize_grow_crash_midway_recovers() {
     }
 
     // Reopen — recovery should restore 1MB index, fix file size, fix shadow
-    let mut handle = vault_open(path.clone(), test_key()).expect("open after crash");
+    let mut handle = optin_open(path.clone(), test_key()).expect("open after crash");
 
     // Capacity should be restored to 1MB
     assert_eq!(vault_capacity(&handle).total_bytes, SIZE_MB);

--- a/rust/src/api/evfs/tests/rotation.rs
+++ b/rust/src/api/evfs/tests/rotation.rs
@@ -30,7 +30,7 @@ fn test_rotate_key_old_key_fails() {
     let path = vault_path(&dir);
 
     {
-        let mut handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let mut handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         vault_write(
             &mut handle,
@@ -45,10 +45,10 @@ fn test_rotate_key_old_key_fails() {
     }
 
     // Old key must be rejected
-    assert!(vault_open(path.clone(), test_key()).is_err());
+    assert!(optin_open(path.clone(), test_key()).is_err());
 
     // New key must still work and data must be intact
-    let mut handle = vault_open(path, test_key2()).expect("open with new key");
+    let mut handle = optin_open(path, test_key2()).expect("open with new key");
     assert_eq!(
         vault_read(&mut handle, "secret.txt".into()).expect("read").data,
         b"top secret"
@@ -126,7 +126,7 @@ fn test_rotate_key_crash_recovery_rotating_cleaned_up() {
     let path = vault_path(&dir);
 
     {
-        let handle = vault_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
+        let handle = optin_create(path.clone(), test_key(), "aes-256-gcm".into(), 1_048_576)
             .expect("create");
         vault_close(handle).expect("close");
     }
@@ -137,7 +137,7 @@ fn test_rotate_key_crash_recovery_rotating_cleaned_up() {
     assert!(std::path::Path::new(&rotating_path).exists());
 
     // vault_open must silently remove the orphan and succeed normally.
-    let handle = vault_open(path, test_key()).expect("open after simulated crash");
+    let handle = optin_open(path, test_key()).expect("open after simulated crash");
     vault_close(handle).expect("close");
 
     assert!(
@@ -173,7 +173,7 @@ fn test_rotate_key_chacha20() {
         .to_string();
 
     let mut handle =
-        vault_create(path, test_key(), "chacha20-poly1305".into(), 1_048_576).expect("create");
+        optin_create(path, test_key(), "chacha20-poly1305".into(), 1_048_576).expect("create");
     vault_write(
         &mut handle,
         "msg.txt".into(),

--- a/rust/src/api/evfs/tests/streaming.rs
+++ b/rust/src/api/evfs/tests/streaming.rs
@@ -319,7 +319,7 @@ fn test_stream_write_persist_reopen() {
 
     let data = vec![0xDD; 150_000];
     {
-        let mut handle = vault_create(
+        let mut handle = optin_create(
             path.clone(),
             test_key(),
             "aes-256-gcm".into(),
@@ -331,7 +331,7 @@ fn test_stream_write_persist_reopen() {
     }
 
     // Reopen and verify
-    let mut handle = vault_open(path, test_key()).expect("open");
+    let mut handle = optin_open(path, test_key()).expect("open");
     let readback = vault_read(&mut handle, "persist.bin".into()).expect("read").data;
     assert_eq!(readback, data);
 
@@ -347,7 +347,7 @@ fn test_stream_write_chacha20() {
         .to_str()
         .expect("path")
         .to_string();
-    let mut handle = vault_create(
+    let mut handle = optin_create(
         path,
         test_key(),
         "chacha20-poly1305".into(),
@@ -682,7 +682,7 @@ fn test_stream_read_chacha20() {
         .to_str()
         .expect("path")
         .to_string();
-    let mut handle = vault_create(
+    let mut handle = optin_create(
         path,
         test_key(),
         "chacha20-poly1305".into(),

--- a/rust/src/api/evfs/types.rs
+++ b/rust/src/api/evfs/types.rs
@@ -9,6 +9,54 @@ use std::collections::HashMap;
 use std::fs::File;
 
 // ---------------------------------------------------------------------------
+// Unsafe legacy format policy
+// ---------------------------------------------------------------------------
+
+/// What a caller wants done about the unauthenticated v1/v2 vault format.
+///
+/// Vaults written by this and every earlier release derive their keys without a
+/// per-vault salt, repeat encryption nonces across vaults and copied files, do
+/// not authenticate their structural metadata and are not crash-atomic. Every
+/// entry point that takes a vault path therefore refuses by default, and a
+/// caller has to name the risk to reach one.
+///
+/// Opting in does not make an existing vault safe and does not change its bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsafeLegacyEvfsPolicy {
+    /// Refuse before the path is opened, created, locked or recovered. Every
+    /// wrapper defaults to this, and it is what a zeroed wire value decodes to.
+    Deny,
+    /// Work against the unauthenticated v1/v2 format anyway.
+    AllowUnauthenticatedV1V2,
+}
+
+mod grant {
+    use super::UnsafeLegacyEvfsPolicy;
+    use crate::core::error::CryptoError;
+
+    /// Evidence that a caller asked for the unauthenticated v1/v2 format.
+    ///
+    /// The field is private to this module and `authorize` is the only thing
+    /// that builds one, so no code anywhere can produce a grant without the
+    /// caller's enum.
+    pub(crate) struct LegacyFormatGrant {
+        _sealed: (),
+    }
+
+    impl UnsafeLegacyEvfsPolicy {
+        /// The one place a policy becomes permission.
+        pub(crate) fn authorize(self) -> Result<LegacyFormatGrant, CryptoError> {
+            match self {
+                Self::AllowUnauthenticatedV1V2 => Ok(LegacyFormatGrant { _sealed: () }),
+                Self::Deny => Err(CryptoError::UnsafeLegacyFormatDenied),
+            }
+        }
+    }
+}
+
+pub(crate) use grant::LegacyFormatGrant;
+
+// ---------------------------------------------------------------------------
 // VaultMmap — read-only memory-mapped view of the vault file
 // ---------------------------------------------------------------------------
 
@@ -104,6 +152,10 @@ pub struct VaultHandle {
     pub(crate) lock: VaultLock,
     /// True when the in-memory index has been modified but not yet flushed to disk.
     pub(crate) index_dirty: bool,
+    /// The caller's opt-in, carried so later access, recovery, reopen and
+    /// rotation stay covered by the decision that opened the vault. Every
+    /// constructor needs one, so a default call cannot produce a handle.
+    pub(crate) grant: LegacyFormatGrant,
 }
 
 impl VaultHandle {

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -7,3 +7,6 @@ pub mod evfs;
 pub mod hashing;
 pub mod kdf;
 pub mod streaming;
+
+#[cfg(test)]
+mod surface;

--- a/rust/src/api/streaming/mod.rs
+++ b/rust/src/api/streaming/mod.rs
@@ -1,43 +1,57 @@
-//! Streaming file encryption, decryption, compression, and hashing API.
+//! Streaming file hashing API, plus the encrypted-stream code kept for tests.
 //!
 //! Core logic uses a progress callback closure so it's testable without FRB.
-//! The public FRB-visible functions are thin wrappers that forward progress
+//! The public FRB-visible function is a thin wrapper that forwards progress
 //! to a `StreamSink`.
 //!
-//! Both encrypt and decrypt write to a temporary file first, then atomically
-//! rename on success. On any error the partial output is deleted — a failed
-//! decryption never leaves plaintext on disk.
+//! The `MSSE` header is unauthenticated and a chunk carries only its index and
+//! finality, so a chunk from another stream encrypted under the same handle
+//! splices in. This release exports no way to write or read that format: the
+//! encrypt, decrypt and compressed variants below are compiled for the
+//! regression tests only, and the Dart methods that used to call them now
+//! return a disabled-format result. Hashing is unaffected.
+//!
+//! The retained encrypt and decrypt code writes to a temporary file first and
+//! renames atomically on success, deleting the partial output on any error, so a
+//! failed decryption leaves no plaintext on disk. That is a property of the test
+//! path only: nothing in the shipped library reaches it.
 
-#[cfg(feature = "compression")]
+#[cfg(all(test, feature = "compression"))]
 mod compress;
+#[cfg(test)]
 mod decrypt;
+#[cfg(test)]
 mod encrypt;
 pub(crate) mod hash;
 
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
 use std::fs::{self, File};
-use std::io::{BufReader, Read};
+#[cfg(test)]
+use std::io::BufReader;
+use std::io::Read;
 
-#[cfg(feature = "compression")]
-use crate::api::compression::CompressionConfig;
-use crate::api::encryption::CipherHandle;
 use crate::api::hashing::HasherHandle;
 use crate::core::error::CryptoError;
+#[cfg(test)]
 use crate::core::streaming::{
     EncryptedChunk, StreamAlgorithm, CHUNK_SIZE, ENCRYPTED_CHUNK_SIZE, NONCE_SIZE,
 };
 
 // Re-export impl functions for internal use and tests
-#[cfg(feature = "compression")]
+#[cfg(all(test, feature = "compression"))]
 pub(crate) use compress::{compress_encrypt_file_impl, decrypt_decompress_file_impl};
+#[cfg(test)]
 pub(crate) use decrypt::decrypt_file_impl;
+#[cfg(test)]
 pub(crate) use encrypt::encrypt_file_impl;
 pub(crate) use hash::hash_file_feed;
 
 // -- Shared helpers -----------------------------------------------------------
 
+#[cfg(test)]
 fn algorithm_from_id(id: &str) -> Result<StreamAlgorithm, CryptoError> {
     match id {
         "aes-256-gcm" => Ok(StreamAlgorithm::AesGcm),
@@ -48,6 +62,7 @@ fn algorithm_from_id(id: &str) -> Result<StreamAlgorithm, CryptoError> {
     }
 }
 
+#[cfg(test)]
 fn parse_encrypted_output(data: &[u8], chunk: &mut EncryptedChunk) -> Result<(), CryptoError> {
     if data.len() != ENCRYPTED_CHUNK_SIZE {
         return Err(CryptoError::InvalidParameter(format!(
@@ -62,6 +77,7 @@ fn parse_encrypted_output(data: &[u8], chunk: &mut EncryptedChunk) -> Result<(),
 }
 
 /// Reassemble nonce || ciphertext || tag into `buf` for decryption.
+#[cfg(test)]
 fn reassemble_into(chunk: &EncryptedChunk, buf: &mut Vec<u8>) {
     buf.clear();
     buf.extend_from_slice(&chunk.nonce);
@@ -88,6 +104,7 @@ fn read_full<R: Read>(reader: &mut R, buf: &mut [u8]) -> Result<usize, CryptoErr
 }
 
 /// Open an input file and return a buffered reader + file size.
+#[cfg(test)]
 fn open_input(path: &str) -> Result<(BufReader<File>, u64), CryptoError> {
     let file = File::open(path)
         .map_err(|e| CryptoError::IoError(format!("Cannot open input '{path}': {e}")))?;
@@ -99,11 +116,13 @@ fn open_input(path: &str) -> Result<(BufReader<File>, u64), CryptoError> {
 }
 
 /// Drop guard that removes a temporary file unless `defuse()` is called.
+#[cfg(test)]
 struct TempFileGuard {
     path: String,
     active: bool,
 }
 
+#[cfg(test)]
 impl TempFileGuard {
     fn new(path: String) -> Self {
         Self { path, active: true }
@@ -114,6 +133,7 @@ impl TempFileGuard {
     }
 }
 
+#[cfg(test)]
 impl Drop for TempFileGuard {
     fn drop(&mut self) {
         if self.active {
@@ -125,53 +145,6 @@ impl Drop for TempFileGuard {
 // -- FRB entry points (thin wrappers) ----------------------------------------
 
 use crate::frb_generated::StreamSink;
-
-pub fn stream_encrypt_file(
-    cipher: &CipherHandle,
-    input_path: String,
-    output_path: String,
-    progress_sink: StreamSink<f64>,
-) -> Result<(), CryptoError> {
-    encrypt_file_impl(cipher, &input_path, &output_path, &|p| {
-        let _ = progress_sink.add(p);
-    })
-}
-
-pub fn stream_decrypt_file(
-    cipher: &CipherHandle,
-    input_path: String,
-    output_path: String,
-    progress_sink: StreamSink<f64>,
-) -> Result<(), CryptoError> {
-    decrypt_file_impl(cipher, &input_path, &output_path, &|p| {
-        let _ = progress_sink.add(p);
-    })
-}
-
-#[cfg(feature = "compression")]
-pub fn stream_compress_encrypt_file(
-    cipher: &CipherHandle,
-    compression: CompressionConfig,
-    input_path: String,
-    output_path: String,
-    progress_sink: StreamSink<f64>,
-) -> Result<(), CryptoError> {
-    compress_encrypt_file_impl(cipher, &compression, &input_path, &output_path, &|p| {
-        let _ = progress_sink.add(p);
-    })
-}
-
-#[cfg(feature = "compression")]
-pub fn stream_decrypt_decompress_file(
-    cipher: &CipherHandle,
-    input_path: String,
-    output_path: String,
-    progress_sink: StreamSink<f64>,
-) -> Result<(), CryptoError> {
-    decrypt_decompress_file_impl(cipher, &input_path, &output_path, &|p| {
-        let _ = progress_sink.add(p);
-    })
-}
 
 pub fn stream_hash_file(
     hasher: &HasherHandle,

--- a/rust/src/api/streaming/tests.rs
+++ b/rust/src/api/streaming/tests.rs
@@ -3,7 +3,7 @@
 use super::*;
 #[cfg(feature = "compression")]
 use crate::api::compression::CompressionAlgorithm;
-use crate::api::encryption::{create_aes256_gcm, generate_aes256_gcm_key};
+use crate::api::encryption::{create_aes256_gcm, generate_aes256_gcm_key, CipherHandle};
 use crate::api::encryption::{create_chacha20_poly1305, generate_chacha20_poly1305_key};
 use crate::core::streaming::{
     ChunkReader, EncryptedChunk, CHUNK_SIZE, ENCRYPTED_CHUNK_SIZE, STREAM_HEADER_SIZE,

--- a/rust/src/api/surface.rs
+++ b/rust/src/api/surface.rs
@@ -1,0 +1,848 @@
+//! Manifest of the bridge surface a consumer can reach, and the checks that
+//! keep it from reaching an unauthenticated vault by accident.
+//!
+//! The generated files are read as text, so what this establishes is a property
+//! of the committed generated code, not of a freshly generated build. Stale
+//! generated files would leave these scans looking at the wrong text; the
+//! repository regenerates and diffs separately.
+//!
+//! Within that limit: an entry added, renamed, moved to a new module, or given a
+//! path or key parameter fails here before anyone has to notice it by hand.
+
+use std::collections::BTreeSet;
+
+use crate::api::evfs::types::UnsafeLegacyEvfsPolicy;
+use crate::frb_generated::CstDecode;
+
+const GENERATED_RUST: &str = include_str!("../frb_generated.rs");
+const GENERATED_DART: &str = include_str!("../../../lib/src/rust/frb_generated.dart");
+const GENERATED_IO_DART: &str = include_str!("../../../lib/src/rust/frb_generated.io.dart");
+const GENERATED_WEB_DART: &str = include_str!("../../../lib/src/rust/frb_generated.web.dart");
+const GENERATED_EVFS_DART: &str = include_str!("../../../lib/src/rust/api/evfs.dart");
+const GENERATED_STREAMING_DART: &str = include_str!("../../../lib/src/rust/api/streaming.dart");
+
+const BARREL_DART: &str = include_str!("../../../lib/m_security.dart");
+const VAULT_SERVICE_DART: &str = include_str!("../../../lib/src/evfs/vault_service.dart");
+const STREAMING_SERVICE_DART: &str =
+    include_str!("../../../lib/src/streaming/streaming_service.dart");
+const COMPRESSION_SERVICE_DART: &str =
+    include_str!("../../../lib/src/compression/compression_service.dart");
+
+/// Every hand-written file in `api::evfs`, so a second policy check or a second
+/// grant cannot hide in a sibling module.
+const EVFS_SOURCES: [(&str, &str); 3] = [
+    ("api/evfs/mod.rs", include_str!("evfs/mod.rs")),
+    ("api/evfs/types.rs", include_str!("evfs/types.rs")),
+    ("api/evfs/helpers.rs", include_str!("evfs/helpers.rs")),
+];
+
+const EVFS_SOURCE: &str = EVFS_SOURCES[0].1;
+const EVFS_TYPES_SOURCE: &str = EVFS_SOURCES[1].1;
+
+/// What keeps one reachable entry away from an unauthenticated vault.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Gate {
+    /// Takes a vault path and a key, so the caller's policy enum decides.
+    Policy,
+    /// Takes the opaque handle, which only an opted-in call can produce, and no
+    /// vault path or key of its own.
+    Handle,
+    /// Takes neither a vault path, a key nor a handle. The one entry using it
+    /// does read a caller-named file, which is why the check below forbids the
+    /// vault-path parameter rather than every path.
+    NoVaultAccess,
+}
+
+struct Entry {
+    /// Suffix of the C symbol and of the wasm entry, minus the module prefix.
+    wire: &'static str,
+    /// Method on the generated `RustLibApi`, which is the only dispatcher route.
+    api_method: &'static str,
+    /// Free function in the per-module Dart file. `None` for a method on an
+    /// opaque type, which the generator puts on the class instead.
+    dart_fn: Option<&'static str>,
+    gate: Gate,
+}
+
+/// Every bridge entry under `api::evfs` and `api::streaming`.
+///
+/// A new entry in either module fails the three set comparisons below, and an
+/// entry smuggled into a *new* module fails the module comparison, so together
+/// they are what proves no converter, archive or encrypted-stream entry came
+/// back under any name.
+const MANIFEST: [Entry; 19] = [
+    Entry {
+        wire: "types__VaultHandle_health",
+        api_method: "crateApiEvfsTypesVaultHandleHealth",
+        dart_fn: None,
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_capacity",
+        api_method: "crateApiEvfsVaultCapacity",
+        dart_fn: Some("vaultCapacity"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_close",
+        api_method: "crateApiEvfsVaultClose",
+        dart_fn: Some("vaultClose"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_create",
+        api_method: "crateApiEvfsVaultCreate",
+        dart_fn: Some("vaultCreate"),
+        gate: Gate::Policy,
+    },
+    Entry {
+        wire: "vault_defragment",
+        api_method: "crateApiEvfsVaultDefragment",
+        dart_fn: Some("vaultDefragment"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_delete",
+        api_method: "crateApiEvfsVaultDelete",
+        dart_fn: Some("vaultDelete"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_flush",
+        api_method: "crateApiEvfsVaultFlush",
+        dart_fn: Some("vaultFlush"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_health",
+        api_method: "crateApiEvfsVaultHealth",
+        dart_fn: Some("vaultHealth"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_list",
+        api_method: "crateApiEvfsVaultList",
+        dart_fn: Some("vaultList"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_open",
+        api_method: "crateApiEvfsVaultOpen",
+        dart_fn: Some("vaultOpen"),
+        gate: Gate::Policy,
+    },
+    Entry {
+        wire: "vault_read",
+        api_method: "crateApiEvfsVaultRead",
+        dart_fn: Some("vaultRead"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_read_parallel",
+        api_method: "crateApiEvfsVaultReadParallel",
+        dart_fn: Some("vaultReadParallel"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_read_stream",
+        api_method: "crateApiEvfsVaultReadStream",
+        dart_fn: Some("vaultReadStream"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_rename_segment",
+        api_method: "crateApiEvfsVaultRenameSegment",
+        dart_fn: Some("vaultRenameSegment"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_resize",
+        api_method: "crateApiEvfsVaultResize",
+        dart_fn: Some("vaultResize"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_rotate_key",
+        api_method: "crateApiEvfsVaultRotateKey",
+        dart_fn: Some("vaultRotateKey"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_write",
+        api_method: "crateApiEvfsVaultWrite",
+        dart_fn: Some("vaultWrite"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "vault_write_file",
+        api_method: "crateApiEvfsVaultWriteFile",
+        dart_fn: Some("vaultWriteFile"),
+        gate: Gate::Handle,
+    },
+    Entry {
+        wire: "stream_hash_file",
+        api_method: "crateApiStreamingStreamHashFile",
+        dart_fn: Some("streamHashFile"),
+        gate: Gate::NoVaultAccess,
+    },
+];
+
+/// Lowercased Rust and Dart spellings of the entries this release removed.
+const REMOVED_NEEDLES: [&str; 12] = [
+    "vault_export",
+    "vaultexport",
+    "vault_import",
+    "vaultimport",
+    "stream_encrypt_file",
+    "streamencryptfile",
+    "stream_decrypt_file",
+    "streamdecryptfile",
+    "stream_compress_encrypt_file",
+    "streamcompressencryptfile",
+    "stream_decrypt_decompress_file",
+    "streamdecryptdecompressfile",
+];
+
+const GENERATED_SOURCES: [(&str, &str); 6] = [
+    ("rust/src/frb_generated.rs", GENERATED_RUST),
+    ("lib/src/rust/frb_generated.dart", GENERATED_DART),
+    ("lib/src/rust/frb_generated.io.dart", GENERATED_IO_DART),
+    ("lib/src/rust/frb_generated.web.dart", GENERATED_WEB_DART),
+    ("lib/src/rust/api/evfs.dart", GENERATED_EVFS_DART),
+    ("lib/src/rust/api/streaming.dart", GENERATED_STREAMING_DART),
+];
+
+/// Files that carry the C symbols and wasm entries, one name per entry.
+const WIRE_SOURCES: [(&str, &str); 3] = [
+    ("rust/src/frb_generated.rs", GENERATED_RUST),
+    ("lib/src/rust/frb_generated.io.dart", GENERATED_IO_DART),
+    ("lib/src/rust/frb_generated.web.dart", GENERATED_WEB_DART),
+];
+
+fn is_name_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_'
+}
+
+/// Collect what follows every `wire__crate__api__<module>__` occurrence.
+///
+/// The generator spells the C symbol, the wasm entry, the internal dispatcher
+/// body and the Dart lookup pointer with the same suffix, so the `_impl` and
+/// `Ptr` tails are dropped to leave one name per entry. Every real entry is
+/// snake_case and none ends in either, and the manifest comparison would catch
+/// one that did.
+fn wire_entries(source: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    for module in ["evfs", "streaming"] {
+        let prefix = format!("wire__crate__api__{module}__");
+        let mut rest = source;
+        while let Some(at) = rest.find(&prefix) {
+            rest = &rest[at + prefix.len()..];
+            let end = rest.find(|c: char| !is_name_char(c)).unwrap_or(rest.len());
+            let name = rest[..end]
+                .trim_end_matches("Ptr")
+                .trim_end_matches("_impl");
+            if !name.is_empty() {
+                found.insert(name.to_string());
+            }
+        }
+    }
+    found
+}
+
+/// Collect the first path segment after `wire__crate__api__`, which is the
+/// module a bridge entry lives in.
+fn wire_modules(source: &str) -> BTreeSet<String> {
+    const PREFIX: &str = "wire__crate__api__";
+    let mut found = BTreeSet::new();
+    let mut rest = source;
+
+    while let Some(at) = rest.find(PREFIX) {
+        rest = &rest[at + PREFIX.len()..];
+        let end = rest.find(|c: char| !is_name_char(c)).unwrap_or(rest.len());
+        if let Some(module) = rest[..end].split("__").next() {
+            if !module.is_empty() {
+                found.insert(module.to_string());
+            }
+        }
+    }
+
+    found
+}
+
+/// Collect every `crateApiEvfs*` / `crateApiStreaming*` dispatcher method.
+fn api_methods(source: &str) -> BTreeSet<String> {
+    all_api_methods(source)
+        .into_iter()
+        .filter(|name| name.starts_with("crateApiEvfs") || name.starts_with("crateApiStreaming"))
+        .collect()
+}
+
+/// Collect every dispatcher method the bridge declares, in any module.
+fn all_api_methods(source: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    for token in source.split(|c: char| !is_name_char(c)) {
+        if token.starts_with("crateApi") {
+            found.insert(token.to_string());
+        }
+    }
+    found
+}
+
+/// Collect the free functions a per-module generated Dart file declares.
+fn dart_functions(source: &str) -> BTreeSet<String> {
+    let mut found = BTreeSet::new();
+    for line in source.lines() {
+        if !(line.starts_with("Future<") || line.starts_with("Stream<")) {
+            continue;
+        }
+        let Some(open) = line.find('(') else { continue };
+        let Some(name) = line[..open].rsplit(' ').next() else {
+            continue;
+        };
+        if !name.is_empty() {
+            found.insert(name.to_string());
+        }
+    }
+    found
+}
+
+/// The parameter text of a generated Dart or Rust declaration.
+///
+/// The parentheses are matched, so a nested one in a parameter type cannot
+/// truncate the text and leave a gate check reading half a signature.
+fn parameters_of(source: &str, name: &str) -> String {
+    let needle = format!(" {name}(");
+    let start = source
+        .find(&needle)
+        .unwrap_or_else(|| panic!("{name} is not declared in the generated source"))
+        + needle.len();
+    let rest = &source[start..];
+
+    let mut depth = 1usize;
+    let mut end = None;
+    for (at, c) in rest.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    end = Some(at);
+                    break;
+                }
+            }
+            _ => (),
+        }
+    }
+
+    let end = end.unwrap_or_else(|| panic!("{name} has no closing parenthesis"));
+    rest[..end].replace('\n', " ")
+}
+
+/// Drop whole-line comments so a scan reads what the file does, not what it
+/// says about itself.
+fn code_only(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The whole body of a function, found by matching braces rather than by
+/// looking for a closing brace in column one, so a nested item cannot hide the
+/// rest of it from a scan.
+fn item_body(source: &str, opening: &str) -> String {
+    let start = source
+        .find(opening)
+        .unwrap_or_else(|| panic!("{opening} is not in the source"));
+    let rest = &source[start..];
+    let open_brace = rest
+        .find('{')
+        .unwrap_or_else(|| panic!("{opening} has no body"));
+
+    let mut depth = 0usize;
+    for (at, c) in rest[open_brace..].char_indices() {
+        match c {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return rest[..open_brace + at].to_string();
+                }
+            }
+            _ => (),
+        }
+    }
+
+    panic!("{opening} does not close");
+}
+
+#[test]
+fn every_generated_source_still_looks_generated() {
+    for (name, source) in GENERATED_SOURCES {
+        let mentions_an_entry = MANIFEST.iter().any(|entry| {
+            source.contains(entry.wire)
+                || source.contains(entry.api_method)
+                || entry.dart_fn.is_some_and(|f| source.contains(f))
+        });
+
+        assert!(
+            mentions_an_entry,
+            "{name} no longer looks like a generated bridge file, so these scans prove nothing"
+        );
+    }
+}
+
+#[test]
+fn the_wire_entries_match_the_manifest() {
+    let expected: BTreeSet<String> = MANIFEST.iter().map(|e| e.wire.to_string()).collect();
+
+    for (name, source) in WIRE_SOURCES {
+        assert_eq!(
+            wire_entries(source),
+            expected,
+            "{name} exposes a different set of vault entries than the manifest"
+        );
+    }
+}
+
+/// A module comparison as well as an entry comparison, because a restored
+/// archive or converter entry in a brand new module would satisfy every
+/// evfs-and-streaming scan on its own.
+#[test]
+fn the_bridge_has_no_module_beyond_the_known_six() {
+    let expected: BTreeSet<String> = [
+        "compression",
+        "encryption",
+        "evfs",
+        "hashing",
+        "kdf",
+        "streaming",
+    ]
+    .iter()
+    .map(|m| (*m).to_string())
+    .collect();
+
+    for (name, source) in WIRE_SOURCES {
+        assert_eq!(
+            wire_modules(source),
+            expected,
+            "{name} carries a bridge module the manifest never considered"
+        );
+    }
+}
+
+#[test]
+fn the_dispatcher_routes_match_the_manifest() {
+    let expected: BTreeSet<String> = MANIFEST.iter().map(|e| e.api_method.to_string()).collect();
+
+    assert_eq!(
+        api_methods(GENERATED_DART),
+        expected,
+        "lib/src/rust/frb_generated.dart routes a different set of vault calls than the manifest"
+    );
+}
+
+#[test]
+fn the_module_dart_exports_match_the_manifest() {
+    let expected: BTreeSet<String> = MANIFEST
+        .iter()
+        .filter_map(|e| e.dart_fn.map(str::to_string))
+        .collect();
+
+    let mut found = dart_functions(GENERATED_EVFS_DART);
+    found.extend(dart_functions(GENERATED_STREAMING_DART));
+
+    assert_eq!(
+        found, expected,
+        "the generated Dart exports differ from the manifest"
+    );
+}
+
+#[test]
+fn every_entry_needs_an_opt_in_created_handle_or_the_policy_enum() {
+    for entry in &MANIFEST {
+        let params = parameters_of(GENERATED_DART, entry.api_method);
+
+        match entry.gate {
+            Gate::Policy => {
+                assert!(
+                    params.contains("UnsafeLegacyEvfsPolicy unsafeLegacyPolicy"),
+                    "{} takes a vault path but no policy: {params}",
+                    entry.api_method
+                );
+                // The C symbol carries the decision too, so a caller cannot
+                // reach the entry point through the raw wire without it.
+                let native = parameters_of(
+                    GENERATED_RUST,
+                    &format!("frbgen_m_security_wire__crate__api__evfs__{}", entry.wire),
+                );
+                assert!(
+                    native.contains("unsafe_legacy_policy: i32"),
+                    "the {} symbol does not take the policy: {native}",
+                    entry.wire
+                );
+            }
+            Gate::Handle => {
+                assert!(
+                    params.contains("VaultHandle handle") || params.contains("VaultHandle that"),
+                    "{} reaches a vault without a handle: {params}",
+                    entry.api_method
+                );
+                // A handle-gated entry that also took a vault path or a master
+                // key would be a second way in, so neither may appear.
+                assert!(
+                    !params.contains("String path"),
+                    "{} takes a vault path as well as a handle: {params}",
+                    entry.api_method
+                );
+                assert!(
+                    !params.contains("List<int> key"),
+                    "{} takes a master key as well as a handle: {params}",
+                    entry.api_method
+                );
+            }
+            Gate::NoVaultAccess => {
+                assert!(
+                    !params.contains("VaultHandle"),
+                    "{} takes a vault handle after all: {params}",
+                    entry.api_method
+                );
+                assert!(
+                    !params.contains("String path"),
+                    "{} takes a vault path after all: {params}",
+                    entry.api_method
+                );
+                assert!(
+                    !params.to_lowercase().contains("key"),
+                    "{} takes a key after all: {params}",
+                    entry.api_method
+                );
+            }
+        }
+    }
+}
+
+/// The whole bridge, not just the vault modules: an entry that takes a path or a
+/// key and is not listed here is one the manifest above never considered.
+#[test]
+fn no_unlisted_bridge_entry_takes_a_path_or_a_key() {
+    // shouldSkipCompression looks at a name's extension and does no I/O, and the
+    // two cipher constructors take a caller buffer, not a vault key. Everything
+    // else here is in the manifest above.
+    const TAKES_A_PATH: [&str; 5] = [
+        "crateApiCompressionShouldSkipCompression",
+        "crateApiEvfsVaultCreate",
+        "crateApiEvfsVaultOpen",
+        "crateApiEvfsVaultWriteFile",
+        "crateApiStreamingStreamHashFile",
+    ];
+    const TAKES_A_KEY: [&str; 5] = [
+        "crateApiEncryptionCreateAes256Gcm",
+        "crateApiEncryptionCreateChacha20Poly1305",
+        "crateApiEvfsVaultCreate",
+        "crateApiEvfsVaultOpen",
+        "crateApiEvfsVaultRotateKey",
+    ];
+
+    // Matched on the parameter's type plus any name ending in Path or Key, so a
+    // returning `vaultExport({..., String exportPath, List<int> wrappingKey})`
+    // is caught as readily as one that reuses the old names.
+    fn parameter_names(params: &str, dart_type: &str) -> Vec<String> {
+        params
+            .split(',')
+            .map(|part| part.trim().trim_start_matches('{').trim())
+            .map(|part| part.strip_prefix("required ").unwrap_or(part))
+            .filter_map(|part| part.strip_prefix(dart_type))
+            .map(|name| name.trim().trim_end_matches('}').trim().to_string())
+            .collect()
+    }
+
+    let mut with_path = Vec::new();
+    let mut with_key = Vec::new();
+    for name in all_api_methods(GENERATED_DART) {
+        let params = parameters_of(GENERATED_DART, &name);
+
+        let paths = parameter_names(&params, "String ");
+        if paths
+            .iter()
+            .any(|p| p == "path" || p.to_lowercase().ends_with("path"))
+        {
+            with_path.push(name.clone());
+        }
+
+        let keys = parameter_names(&params, "List<int> ");
+        if keys
+            .iter()
+            .any(|k| k == "key" || k.to_lowercase().ends_with("key"))
+        {
+            with_key.push(name);
+        }
+    }
+    with_path.sort();
+    with_path.dedup();
+    with_key.sort();
+    with_key.dedup();
+
+    assert_eq!(
+        with_path, TAKES_A_PATH,
+        "a bridge entry takes a filesystem path without being accounted for"
+    );
+    assert_eq!(
+        with_key, TAKES_A_KEY,
+        "a bridge entry takes a key without being accounted for"
+    );
+}
+
+#[test]
+fn the_removed_format_entries_are_absent_from_every_generated_file() {
+    for (name, source) in GENERATED_SOURCES {
+        let lowercased = source.to_lowercase();
+        for needle in REMOVED_NEEDLES {
+            assert!(
+                !lowercased.contains(needle),
+                "{name} still exposes a removed format entry (matched {needle})"
+            );
+        }
+    }
+}
+
+#[test]
+fn the_dart_vault_wrappers_default_to_denial() {
+    // Flipping either default is the regression this catches.
+    let wrapper = code_only(VAULT_SERVICE_DART);
+
+    assert_eq!(
+        wrapper.matches("UnsafeLegacyEvfsPolicy.deny").count(),
+        2,
+        "VaultService.create and VaultService.open must each default to denial"
+    );
+    assert!(
+        !wrapper.contains("UnsafeLegacyEvfsPolicy.allowUnauthenticatedV1V2"),
+        "the wrapper opts in on the caller's behalf"
+    );
+}
+
+#[test]
+fn the_disabled_dart_methods_reach_no_bridge_function() {
+    let services = [
+        ("lib/src/evfs/vault_service.dart", VAULT_SERVICE_DART),
+        (
+            "lib/src/streaming/streaming_service.dart",
+            STREAMING_SERVICE_DART,
+        ),
+        (
+            "lib/src/compression/compression_service.dart",
+            COMPRESSION_SERVICE_DART,
+        ),
+    ];
+
+    for (name, source) in services {
+        let lowercased = source.to_lowercase();
+        for needle in REMOVED_NEEDLES {
+            assert!(
+                !lowercased.contains(needle),
+                "{name} still calls a removed bridge function (matched {needle})"
+            );
+        }
+        assert!(
+            source.contains("CryptoError.disabledFormat"),
+            "{name} has no disabled-format result to return"
+        );
+    }
+}
+
+#[test]
+fn one_policy_check_stands_between_a_caller_and_the_vault() {
+    // Counted over every file in the module and over code only, so a mint added
+    // in a sibling file or hidden in a comment does not slip through.
+    let decisions: usize = EVFS_SOURCES
+        .iter()
+        .map(|(_, source)| code_only(source).matches(".authorize()").count())
+        .sum();
+
+    assert_eq!(
+        decisions, 2,
+        "creation and opening take exactly one policy decision each, and nothing else takes one"
+    );
+
+    let mints: usize = EVFS_SOURCES
+        .iter()
+        .map(|(_, source)| code_only(source).matches("_sealed").count())
+        .sum();
+
+    // Two mentions: the field declaration and the one struct literal that fills
+    // it, both inside `mod grant`.
+    assert_eq!(
+        mints, 2,
+        "the grant's private field is mentioned somewhere other than its own module"
+    );
+    assert_eq!(
+        code_only(EVFS_TYPES_SOURCE).matches("_sealed").count(),
+        2,
+        "the grant is built outside api/evfs/types.rs"
+    );
+
+    for (name, source) in EVFS_SOURCES {
+        let code = code_only(source);
+        for switch in [
+            "env::var",
+            "env::vars",
+            "option_env!",
+            "env!",
+            "var_os",
+            "getenv",
+        ] {
+            assert!(
+                !code.contains(switch),
+                "{name} reads {switch}, so something other than the enum can opt in"
+            );
+        }
+    }
+}
+
+/// The public barrel is the surface a consumer actually imports, so it has to
+/// name the policy enum and must not re-export the raw bridge modules.
+#[test]
+fn the_barrel_exports_the_policy_and_not_the_bridge() {
+    let barrel = code_only(BARREL_DART);
+
+    assert!(
+        barrel.contains("UnsafeLegacyEvfsPolicy"),
+        "a consumer cannot name the policy through the barrel"
+    );
+    for module in [
+        "src/rust/api/evfs.dart",
+        "src/rust/api/streaming.dart",
+        "src/rust/frb_generated.io.dart",
+    ] {
+        assert!(
+            !barrel.contains(module),
+            "the barrel re-exports {module}, which bypasses the wrappers"
+        );
+    }
+}
+
+#[test]
+fn the_policy_check_precedes_every_filesystem_call() {
+    for opening in [
+        "fn vault_create_guarded(",
+        "fn vault_open_guarded(",
+        "fn vault_create(",
+        "fn vault_open(",
+    ] {
+        let body = item_body(EVFS_SOURCE, opening);
+        // Broad on purpose: the runtime oracles cannot see a discarded
+        // read-only lookup, so this list is what stands behind the claim that
+        // nothing reaches the path before the decision.
+        for io in [
+            "OpenOptions",
+            "File::",
+            "VaultLock",
+            "WriteAheadLog",
+            "VaultMmap",
+            "Mmap",
+            "fs::",
+            "fs4",
+            "libc::",
+            "Path",
+            "metadata",
+            "canonicalize",
+            "exists",
+            "read_dir",
+            "read_to_string",
+            "create_dir",
+            "remove_file",
+            "rename",
+            ".open(",
+        ] {
+            assert!(
+                !body.contains(io),
+                "{opening} mentions {io} before handing the decision on"
+            );
+        }
+    }
+
+    // The guard has to come first: an early return before it leaves the
+    // caller's key unwiped.
+    for opening in ["fn vault_create_guarded(", "fn vault_open_guarded("] {
+        let body = item_body(EVFS_SOURCE, opening);
+        let guard = body
+            .find("KeyGuard::new")
+            .expect("the guarded entry point does not guard the key");
+        let check = body
+            .find(".authorize()")
+            .expect("the guarded entry point does not check the policy");
+        assert!(guard < check, "{opening} checks the policy before guarding");
+    }
+}
+
+#[test]
+fn a_zero_policy_discriminant_decodes_to_denial() {
+    // Zero is what a zero-filled wire field carries, and denial is the variant
+    // the generator maps it to because `Deny` is declared first.
+    let decoded: UnsafeLegacyEvfsPolicy = CstDecode::cst_decode(0i32);
+
+    assert_eq!(decoded, UnsafeLegacyEvfsPolicy::Deny);
+}
+
+#[test]
+fn an_out_of_range_policy_discriminant_never_decodes_to_the_opt_in() {
+    for raw in [-1i32, 2, 7, i32::MAX, i32::MIN] {
+        let decoded =
+            std::panic::catch_unwind(|| -> UnsafeLegacyEvfsPolicy { CstDecode::cst_decode(raw) });
+
+        match decoded {
+            // The generated decoder panics rather than returning a typed error,
+            // which the release profile turns into an abort. That is a crash,
+            // not a denial: what it establishes is only that no value outside
+            // 0 and 1 reaches vault code, and it is what the generator already
+            // does for every other enum on this bridge.
+            Err(_) => (),
+            Ok(policy) => assert_eq!(
+                policy,
+                UnsafeLegacyEvfsPolicy::Deny,
+                "discriminant {raw} decoded to something other than denial"
+            ),
+        }
+    }
+}
+
+/// The malformed-discriminant path has to leave the filesystem alone too, which
+/// the decode test above cannot see on its own.
+#[test]
+fn a_malformed_policy_discriminant_touches_no_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir
+        .path()
+        .join("malformed.vault")
+        .to_string_lossy()
+        .to_string();
+    let before = std::fs::read_dir(dir.path()).expect("read tempdir").count();
+
+    for raw in [-1i32, 2, 7, i32::MAX] {
+        let attempt = std::panic::catch_unwind(|| {
+            let policy: UnsafeLegacyEvfsPolicy = CstDecode::cst_decode(raw);
+            crate::api::evfs::vault_create(
+                path.clone(),
+                vec![0xAA; 32],
+                "aes-256-gcm".into(),
+                1024 * 1024,
+                policy,
+            )
+            .map(|_| ())
+        });
+
+        assert!(
+            attempt.is_err() || attempt.is_ok_and(|outcome| outcome.is_err()),
+            "discriminant {raw} created a vault"
+        );
+    }
+
+    assert!(!std::path::Path::new(&path).exists(), "a vault was written");
+    assert_eq!(
+        std::fs::read_dir(dir.path()).expect("read tempdir").count(),
+        before,
+        "a malformed discriminant left something behind"
+    );
+}

--- a/rust/src/core/error.rs
+++ b/rust/src/core/error.rs
@@ -64,6 +64,14 @@ pub enum CryptoError {
 
     #[error("Another Argon2 verification is already in progress")]
     Argon2VerificationBusy,
+
+    #[error("Unauthenticated v1/v2 vault format denied: explicit opt-in required")]
+    UnsafeLegacyFormatDenied,
+
+    // Carried for the Dart compatibility stubs. Their native entry points are
+    // gone, so nothing in this crate returns it.
+    #[error("Format disabled in this release: {0}")]
+    DisabledFormat(String),
 }
 
 impl From<std::io::Error> for CryptoError {

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -40,7 +40,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueNom,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1392838074;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = -1545310340;
 
 // Section: executor
 
@@ -846,209 +846,6 @@ fn wire__crate__api__compression__should_skip_compression_impl(
         },
     )
 }
-fn wire__crate__api__streaming__stream_compress_encrypt_file_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    cipher: impl CstDecode<
-        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
-    >,
-    compression: impl CstDecode<crate::api::compression::CompressionConfig>,
-    input_path: impl CstDecode<String>,
-    output_path: impl CstDecode<String>,
-    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "stream_compress_encrypt_file",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_cipher = cipher.cst_decode();
-            let api_compression = compression.cst_decode();
-            let api_input_path = input_path.cst_decode();
-            let api_output_path = output_path.cst_decode();
-            let api_progress_sink = progress_sink.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let mut api_cipher_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_cipher,
-                                0,
-                                false,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_cipher_guard = Some(api_cipher.lockable_decode_sync_ref()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let api_cipher_guard = api_cipher_guard.unwrap();
-                    let output_ok = crate::api::streaming::stream_compress_encrypt_file(
-                        &*api_cipher_guard,
-                        api_compression,
-                        api_input_path,
-                        api_output_path,
-                        api_progress_sink,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    cipher: impl CstDecode<
-        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
-    >,
-    input_path: impl CstDecode<String>,
-    output_path: impl CstDecode<String>,
-    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "stream_decrypt_decompress_file",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_cipher = cipher.cst_decode();
-            let api_input_path = input_path.cst_decode();
-            let api_output_path = output_path.cst_decode();
-            let api_progress_sink = progress_sink.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let mut api_cipher_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_cipher,
-                                0,
-                                false,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_cipher_guard = Some(api_cipher.lockable_decode_sync_ref()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let api_cipher_guard = api_cipher_guard.unwrap();
-                    let output_ok = crate::api::streaming::stream_decrypt_decompress_file(
-                        &*api_cipher_guard,
-                        api_input_path,
-                        api_output_path,
-                        api_progress_sink,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__streaming__stream_decrypt_file_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    cipher: impl CstDecode<
-        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
-    >,
-    input_path: impl CstDecode<String>,
-    output_path: impl CstDecode<String>,
-    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "stream_decrypt_file",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_cipher = cipher.cst_decode();
-            let api_input_path = input_path.cst_decode();
-            let api_output_path = output_path.cst_decode();
-            let api_progress_sink = progress_sink.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let mut api_cipher_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_cipher,
-                                0,
-                                false,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_cipher_guard = Some(api_cipher.lockable_decode_sync_ref()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let api_cipher_guard = api_cipher_guard.unwrap();
-                    let output_ok = crate::api::streaming::stream_decrypt_file(
-                        &*api_cipher_guard,
-                        api_input_path,
-                        api_output_path,
-                        api_progress_sink,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
-fn wire__crate__api__streaming__stream_encrypt_file_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    cipher: impl CstDecode<
-        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<CipherHandle>>,
-    >,
-    input_path: impl CstDecode<String>,
-    output_path: impl CstDecode<String>,
-    progress_sink: impl CstDecode<StreamSink<f64, flutter_rust_bridge::for_generated::DcoCodec>>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "stream_encrypt_file",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_cipher = cipher.cst_decode();
-            let api_input_path = input_path.cst_decode();
-            let api_output_path = output_path.cst_decode();
-            let api_progress_sink = progress_sink.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let mut api_cipher_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_cipher,
-                                0,
-                                false,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_cipher_guard = Some(api_cipher.lockable_decode_sync_ref()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let api_cipher_guard = api_cipher_guard.unwrap();
-                    let output_ok = crate::api::streaming::stream_encrypt_file(
-                        &*api_cipher_guard,
-                        api_input_path,
-                        api_output_path,
-                        api_progress_sink,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__streaming__stream_hash_file_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     hasher: impl CstDecode<
@@ -1163,6 +960,7 @@ fn wire__crate__api__evfs__vault_create_impl(
     key: impl CstDecode<Vec<u8>>,
     algorithm: impl CstDecode<String>,
     capacity_bytes: impl CstDecode<u64>,
+    unsafe_legacy_policy: impl CstDecode<crate::api::evfs::types::UnsafeLegacyEvfsPolicy>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1175,6 +973,7 @@ fn wire__crate__api__evfs__vault_create_impl(
             let api_key = key.cst_decode();
             let api_algorithm = algorithm.cst_decode();
             let api_capacity_bytes = capacity_bytes.cst_decode();
+            let api_unsafe_legacy_policy = unsafe_legacy_policy.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
                     let output_ok = crate::api::evfs::vault_create(
@@ -1182,6 +981,7 @@ fn wire__crate__api__evfs__vault_create_impl(
                         api_key,
                         api_algorithm,
                         api_capacity_bytes,
+                        api_unsafe_legacy_policy,
                     )?;
                     Ok(output_ok)
                 })())
@@ -1270,53 +1070,6 @@ fn wire__crate__api__evfs__vault_delete_impl(
         },
     )
 }
-fn wire__crate__api__evfs__vault_export_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    handle: impl CstDecode<
-        RustOpaqueNom<flutter_rust_bridge::for_generated::RustAutoOpaqueInner<VaultHandle>>,
-    >,
-    wrapping_key: impl CstDecode<Vec<u8>>,
-    export_path: impl CstDecode<String>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "vault_export",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_handle = handle.cst_decode();
-            let api_wrapping_key = wrapping_key.cst_decode();
-            let api_export_path = export_path.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let mut api_handle_guard = None;
-                    let decode_indices_ =
-                        flutter_rust_bridge::for_generated::lockable_compute_decode_order(vec![
-                            flutter_rust_bridge::for_generated::LockableOrderInfo::new(
-                                &api_handle,
-                                0,
-                                true,
-                            ),
-                        ]);
-                    for i in decode_indices_ {
-                        match i {
-                            0 => api_handle_guard = Some(api_handle.lockable_decode_sync_ref_mut()),
-                            _ => unreachable!(),
-                        }
-                    }
-                    let mut api_handle_guard = api_handle_guard.unwrap();
-                    let output_ok = crate::api::evfs::vault_export(
-                        &mut *api_handle_guard,
-                        api_wrapping_key,
-                        api_export_path,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__evfs__vault_flush_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     handle: impl CstDecode<
@@ -1396,44 +1149,6 @@ fn wire__crate__api__evfs__vault_health_impl(
         },
     )
 }
-fn wire__crate__api__evfs__vault_import_impl(
-    port_: flutter_rust_bridge::for_generated::MessagePort,
-    archive_path: impl CstDecode<String>,
-    wrapping_key: impl CstDecode<Vec<u8>>,
-    dest_path: impl CstDecode<String>,
-    new_master_key: impl CstDecode<Vec<u8>>,
-    algorithm: impl CstDecode<String>,
-    capacity_bytes: impl CstDecode<u64>,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
-        flutter_rust_bridge::for_generated::TaskInfo {
-            debug_name: "vault_import",
-            port: Some(port_),
-            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
-        },
-        move || {
-            let api_archive_path = archive_path.cst_decode();
-            let api_wrapping_key = wrapping_key.cst_decode();
-            let api_dest_path = dest_path.cst_decode();
-            let api_new_master_key = new_master_key.cst_decode();
-            let api_algorithm = algorithm.cst_decode();
-            let api_capacity_bytes = capacity_bytes.cst_decode();
-            move |context| {
-                transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let output_ok = crate::api::evfs::vault_import(
-                        api_archive_path,
-                        api_wrapping_key,
-                        api_dest_path,
-                        api_new_master_key,
-                        api_algorithm,
-                        api_capacity_bytes,
-                    )?;
-                    Ok(output_ok)
-                })())
-            }
-        },
-    )
-}
 fn wire__crate__api__evfs__vault_list_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     handle: impl CstDecode<
@@ -1478,6 +1193,7 @@ fn wire__crate__api__evfs__vault_open_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     path: impl CstDecode<String>,
     key: impl CstDecode<Vec<u8>>,
+    unsafe_legacy_policy: impl CstDecode<crate::api::evfs::types::UnsafeLegacyEvfsPolicy>,
 ) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap_normal::<flutter_rust_bridge::for_generated::DcoCodec, _, _>(
         flutter_rust_bridge::for_generated::TaskInfo {
@@ -1488,9 +1204,11 @@ fn wire__crate__api__evfs__vault_open_impl(
         move || {
             let api_path = path.cst_decode();
             let api_key = key.cst_decode();
+            let api_unsafe_legacy_policy = unsafe_legacy_policy.cst_decode();
             move |context| {
                 transform_result_dco::<_, _, crate::core::error::CryptoError>((move || {
-                    let output_ok = crate::api::evfs::vault_open(api_path, api_key)?;
+                    let output_ok =
+                        crate::api::evfs::vault_open(api_path, api_key, api_unsafe_legacy_policy)?;
                     Ok(output_ok)
                 })())
             }
@@ -1913,6 +1631,16 @@ impl CstDecode<u8> for u8 {
         self
     }
 }
+impl CstDecode<crate::api::evfs::types::UnsafeLegacyEvfsPolicy> for i32 {
+    // Codec=Cst (C-struct based), see doc to use other codecs
+    fn cst_decode(self) -> crate::api::evfs::types::UnsafeLegacyEvfsPolicy {
+        match self {
+            0 => crate::api::evfs::types::UnsafeLegacyEvfsPolicy::Deny,
+            1 => crate::api::evfs::types::UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2,
+            _ => unreachable!("Invalid variant for UnsafeLegacyEvfsPolicy: {}", self),
+        }
+    }
+}
 impl CstDecode<usize> for usize {
     // Codec=Cst (C-struct based), see doc to use other codecs
     fn cst_decode(self) -> usize {
@@ -2152,6 +1880,13 @@ impl SseDecode for crate::core::error::CryptoError {
             19 => {
                 return crate::core::error::CryptoError::Argon2VerificationBusy;
             }
+            20 => {
+                return crate::core::error::CryptoError::UnsafeLegacyFormatDenied;
+            }
+            21 => {
+                let mut var_field0 = <String>::sse_decode(deserializer);
+                return crate::core::error::CryptoError::DisabledFormat(var_field0);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -2356,6 +2091,18 @@ impl SseDecode for u8 {
 impl SseDecode for () {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {}
+}
+
+impl SseDecode for crate::api::evfs::types::UnsafeLegacyEvfsPolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut inner = <i32>::sse_decode(deserializer);
+        return match inner {
+            0 => crate::api::evfs::types::UnsafeLegacyEvfsPolicy::Deny,
+            1 => crate::api::evfs::types::UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2,
+            _ => unreachable!("Invalid variant for UnsafeLegacyEvfsPolicy: {}", inner),
+        };
+    }
 }
 
 impl SseDecode for usize {
@@ -2605,6 +2352,12 @@ impl flutter_rust_bridge::IntoDart for crate::core::error::CryptoError {
                 [18.into_dart(), field0.into_into_dart().into_dart()].into_dart()
             }
             crate::core::error::CryptoError::Argon2VerificationBusy => [19.into_dart()].into_dart(),
+            crate::core::error::CryptoError::UnsafeLegacyFormatDenied => {
+                [20.into_dart()].into_dart()
+            }
+            crate::core::error::CryptoError::DisabledFormat(field0) => {
+                [21.into_dart(), field0.into_into_dart().into_dart()].into_dart()
+            }
             _ => {
                 unimplemented!("");
             }
@@ -2684,6 +2437,27 @@ impl flutter_rust_bridge::IntoIntoDart<crate::api::evfs::types::SegmentResult>
     for crate::api::evfs::types::SegmentResult
 {
     fn into_into_dart(self) -> crate::api::evfs::types::SegmentResult {
+        self
+    }
+}
+// Codec=Dco (DartCObject based), see doc to use other codecs
+impl flutter_rust_bridge::IntoDart for crate::api::evfs::types::UnsafeLegacyEvfsPolicy {
+    fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
+        match self {
+            Self::Deny => 0.into_dart(),
+            Self::AllowUnauthenticatedV1V2 => 1.into_dart(),
+            _ => unreachable!(),
+        }
+    }
+}
+impl flutter_rust_bridge::for_generated::IntoDartExceptPrimitive
+    for crate::api::evfs::types::UnsafeLegacyEvfsPolicy
+{
+}
+impl flutter_rust_bridge::IntoIntoDart<crate::api::evfs::types::UnsafeLegacyEvfsPolicy>
+    for crate::api::evfs::types::UnsafeLegacyEvfsPolicy
+{
+    fn into_into_dart(self) -> crate::api::evfs::types::UnsafeLegacyEvfsPolicy {
         self
     }
 }
@@ -2958,6 +2732,13 @@ impl SseEncode for crate::core::error::CryptoError {
             crate::core::error::CryptoError::Argon2VerificationBusy => {
                 <i32>::sse_encode(19, serializer);
             }
+            crate::core::error::CryptoError::UnsafeLegacyFormatDenied => {
+                <i32>::sse_encode(20, serializer);
+            }
+            crate::core::error::CryptoError::DisabledFormat(field0) => {
+                <i32>::sse_encode(21, serializer);
+                <String>::sse_encode(field0, serializer);
+            }
             _ => {
                 unimplemented!("");
             }
@@ -3127,6 +2908,22 @@ impl SseEncode for u8 {
 impl SseEncode for () {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {}
+}
+
+impl SseEncode for crate::api::evfs::types::UnsafeLegacyEvfsPolicy {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(
+            match self {
+                crate::api::evfs::types::UnsafeLegacyEvfsPolicy::Deny => 0,
+                crate::api::evfs::types::UnsafeLegacyEvfsPolicy::AllowUnauthenticatedV1V2 => 1,
+                _ => {
+                    unimplemented!("");
+                }
+            },
+            serializer,
+        );
+    }
 }
 
 impl SseEncode for usize {
@@ -3400,6 +3197,11 @@ mod io {
                     crate::core::error::CryptoError::Argon2PolicyViolation(ans.field0.cst_decode())
                 }
                 19 => crate::core::error::CryptoError::Argon2VerificationBusy,
+                20 => crate::core::error::CryptoError::UnsafeLegacyFormatDenied,
+                21 => {
+                    let ans = unsafe { self.kind.DisabledFormat };
+                    crate::core::error::CryptoError::DisabledFormat(ans.field0.cst_decode())
+                }
                 _ => unreachable!(),
             }
         }
@@ -3872,76 +3674,6 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_compress_encrypt_file(
-        port_: i64,
-        cipher: usize,
-        compression: *mut wire_cst_compression_config,
-        input_path: *mut wire_cst_list_prim_u_8_strict,
-        output_path: *mut wire_cst_list_prim_u_8_strict,
-        progress_sink: *mut wire_cst_list_prim_u_8_strict,
-    ) {
-        wire__crate__api__streaming__stream_compress_encrypt_file_impl(
-            port_,
-            cipher,
-            compression,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_decrypt_decompress_file(
-        port_: i64,
-        cipher: usize,
-        input_path: *mut wire_cst_list_prim_u_8_strict,
-        output_path: *mut wire_cst_list_prim_u_8_strict,
-        progress_sink: *mut wire_cst_list_prim_u_8_strict,
-    ) {
-        wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
-            port_,
-            cipher,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_decrypt_file(
-        port_: i64,
-        cipher: usize,
-        input_path: *mut wire_cst_list_prim_u_8_strict,
-        output_path: *mut wire_cst_list_prim_u_8_strict,
-        progress_sink: *mut wire_cst_list_prim_u_8_strict,
-    ) {
-        wire__crate__api__streaming__stream_decrypt_file_impl(
-            port_,
-            cipher,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_encrypt_file(
-        port_: i64,
-        cipher: usize,
-        input_path: *mut wire_cst_list_prim_u_8_strict,
-        output_path: *mut wire_cst_list_prim_u_8_strict,
-        progress_sink: *mut wire_cst_list_prim_u_8_strict,
-    ) {
-        wire__crate__api__streaming__stream_encrypt_file_impl(
-            port_,
-            cipher,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_wire__crate__api__streaming__stream_hash_file(
         port_: i64,
         hasher: usize,
@@ -3974,8 +3706,16 @@ mod io {
         key: *mut wire_cst_list_prim_u_8_loose,
         algorithm: *mut wire_cst_list_prim_u_8_strict,
         capacity_bytes: u64,
+        unsafe_legacy_policy: i32,
     ) {
-        wire__crate__api__evfs__vault_create_impl(port_, path, key, algorithm, capacity_bytes)
+        wire__crate__api__evfs__vault_create_impl(
+            port_,
+            path,
+            key,
+            algorithm,
+            capacity_bytes,
+            unsafe_legacy_policy,
+        )
     }
 
     #[unsafe(no_mangle)]
@@ -3996,16 +3736,6 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_export(
-        port_: i64,
-        handle: usize,
-        wrapping_key: *mut wire_cst_list_prim_u_8_loose,
-        export_path: *mut wire_cst_list_prim_u_8_strict,
-    ) {
-        wire__crate__api__evfs__vault_export_impl(port_, handle, wrapping_key, export_path)
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_flush(
         port_: i64,
         handle: usize,
@@ -4022,27 +3752,6 @@ mod io {
     }
 
     #[unsafe(no_mangle)]
-    pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_import(
-        port_: i64,
-        archive_path: *mut wire_cst_list_prim_u_8_strict,
-        wrapping_key: *mut wire_cst_list_prim_u_8_loose,
-        dest_path: *mut wire_cst_list_prim_u_8_strict,
-        new_master_key: *mut wire_cst_list_prim_u_8_loose,
-        algorithm: *mut wire_cst_list_prim_u_8_strict,
-        capacity_bytes: u64,
-    ) {
-        wire__crate__api__evfs__vault_import_impl(
-            port_,
-            archive_path,
-            wrapping_key,
-            dest_path,
-            new_master_key,
-            algorithm,
-            capacity_bytes,
-        )
-    }
-
-    #[unsafe(no_mangle)]
     pub extern "C" fn frbgen_m_security_wire__crate__api__evfs__vault_list(
         port_: i64,
         handle: usize,
@@ -4055,8 +3764,9 @@ mod io {
         port_: i64,
         path: *mut wire_cst_list_prim_u_8_strict,
         key: *mut wire_cst_list_prim_u_8_loose,
+        unsafe_legacy_policy: i32,
     ) {
-        wire__crate__api__evfs__vault_open_impl(port_, path, key)
+        wire__crate__api__evfs__vault_open_impl(port_, path, key, unsafe_legacy_policy)
     }
 
     #[unsafe(no_mangle)]
@@ -4314,6 +4024,7 @@ mod io {
         ExportFailed: wire_cst_CryptoError_ExportFailed,
         ImportFailed: wire_cst_CryptoError_ImportFailed,
         Argon2PolicyViolation: wire_cst_CryptoError_Argon2PolicyViolation,
+        DisabledFormat: wire_cst_CryptoError_DisabledFormat,
         nil__: (),
     }
     #[repr(C)]
@@ -4391,6 +4102,11 @@ mod io {
     #[repr(C)]
     #[derive(Clone, Copy)]
     pub struct wire_cst_CryptoError_Argon2PolicyViolation {
+        field0: *mut wire_cst_list_prim_u_8_strict,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct wire_cst_CryptoError_DisabledFormat {
         field0: *mut wire_cst_list_prim_u_8_strict,
     }
     #[repr(C)]
@@ -4580,6 +4296,8 @@ mod web {
                     self_.get(1).cst_decode(),
                 ),
                 19 => crate::core::error::CryptoError::Argon2VerificationBusy,
+                20 => crate::core::error::CryptoError::UnsafeLegacyFormatDenied,
+                21 => crate::core::error::CryptoError::DisabledFormat(self_.get(1).cst_decode()),
                 _ => unreachable!(),
             }
         }
@@ -4947,6 +4665,14 @@ mod web {
             self.unchecked_into_f64() as _
         }
     }
+    impl CstDecode<crate::api::evfs::types::UnsafeLegacyEvfsPolicy>
+        for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue
+    {
+        // Codec=Cst (C-struct based), see doc to use other codecs
+        fn cst_decode(self) -> crate::api::evfs::types::UnsafeLegacyEvfsPolicy {
+            (self.unchecked_into_f64() as i32).cst_decode()
+        }
+    }
     impl CstDecode<usize> for flutter_rust_bridge::for_generated::wasm_bindgen::JsValue {
         // Codec=Cst (C-struct based), see doc to use other codecs
         fn cst_decode(self) -> usize {
@@ -5198,76 +4924,6 @@ mod web {
     }
 
     #[wasm_bindgen]
-    pub fn wire__crate__api__streaming__stream_compress_encrypt_file(
-        port_: flutter_rust_bridge::for_generated::MessagePort,
-        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-        compression: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-        input_path: String,
-        output_path: String,
-        progress_sink: String,
-    ) {
-        wire__crate__api__streaming__stream_compress_encrypt_file_impl(
-            port_,
-            cipher,
-            compression,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[wasm_bindgen]
-    pub fn wire__crate__api__streaming__stream_decrypt_decompress_file(
-        port_: flutter_rust_bridge::for_generated::MessagePort,
-        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-        input_path: String,
-        output_path: String,
-        progress_sink: String,
-    ) {
-        wire__crate__api__streaming__stream_decrypt_decompress_file_impl(
-            port_,
-            cipher,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[wasm_bindgen]
-    pub fn wire__crate__api__streaming__stream_decrypt_file(
-        port_: flutter_rust_bridge::for_generated::MessagePort,
-        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-        input_path: String,
-        output_path: String,
-        progress_sink: String,
-    ) {
-        wire__crate__api__streaming__stream_decrypt_file_impl(
-            port_,
-            cipher,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[wasm_bindgen]
-    pub fn wire__crate__api__streaming__stream_encrypt_file(
-        port_: flutter_rust_bridge::for_generated::MessagePort,
-        cipher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-        input_path: String,
-        output_path: String,
-        progress_sink: String,
-    ) {
-        wire__crate__api__streaming__stream_encrypt_file_impl(
-            port_,
-            cipher,
-            input_path,
-            output_path,
-            progress_sink,
-        )
-    }
-
-    #[wasm_bindgen]
     pub fn wire__crate__api__streaming__stream_hash_file(
         port_: flutter_rust_bridge::for_generated::MessagePort,
         hasher: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
@@ -5300,8 +4956,16 @@ mod web {
         key: Box<[u8]>,
         algorithm: String,
         capacity_bytes: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
+        unsafe_legacy_policy: i32,
     ) {
-        wire__crate__api__evfs__vault_create_impl(port_, path, key, algorithm, capacity_bytes)
+        wire__crate__api__evfs__vault_create_impl(
+            port_,
+            path,
+            key,
+            algorithm,
+            capacity_bytes,
+            unsafe_legacy_policy,
+        )
     }
 
     #[wasm_bindgen]
@@ -5322,16 +4986,6 @@ mod web {
     }
 
     #[wasm_bindgen]
-    pub fn wire__crate__api__evfs__vault_export(
-        port_: flutter_rust_bridge::for_generated::MessagePort,
-        handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-        wrapping_key: Box<[u8]>,
-        export_path: String,
-    ) {
-        wire__crate__api__evfs__vault_export_impl(port_, handle, wrapping_key, export_path)
-    }
-
-    #[wasm_bindgen]
     pub fn wire__crate__api__evfs__vault_flush(
         port_: flutter_rust_bridge::for_generated::MessagePort,
         handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
@@ -5348,27 +5002,6 @@ mod web {
     }
 
     #[wasm_bindgen]
-    pub fn wire__crate__api__evfs__vault_import(
-        port_: flutter_rust_bridge::for_generated::MessagePort,
-        archive_path: String,
-        wrapping_key: Box<[u8]>,
-        dest_path: String,
-        new_master_key: Box<[u8]>,
-        algorithm: String,
-        capacity_bytes: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
-    ) {
-        wire__crate__api__evfs__vault_import_impl(
-            port_,
-            archive_path,
-            wrapping_key,
-            dest_path,
-            new_master_key,
-            algorithm,
-            capacity_bytes,
-        )
-    }
-
-    #[wasm_bindgen]
     pub fn wire__crate__api__evfs__vault_list(
         port_: flutter_rust_bridge::for_generated::MessagePort,
         handle: flutter_rust_bridge::for_generated::wasm_bindgen::JsValue,
@@ -5381,8 +5014,9 @@ mod web {
         port_: flutter_rust_bridge::for_generated::MessagePort,
         path: String,
         key: Box<[u8]>,
+        unsafe_legacy_policy: i32,
     ) {
-        wire__crate__api__evfs__vault_open_impl(port_, path, key)
+        wire__crate__api__evfs__vault_open_impl(port_, path, key, unsafe_legacy_policy)
     }
 
     #[wasm_bindgen]

--- a/test/disabled_format_test.dart
+++ b/test/disabled_format_test.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:m_security/src/compression/compression_service.dart';
+import 'package:m_security/src/evfs/vault_service.dart';
+import 'package:m_security/src/rust/api/compression.dart';
+import 'package:m_security/src/rust/api/encryption.dart';
+import 'package:m_security/src/rust/api/evfs/types.dart';
+import 'package:m_security/src/rust/core/error.dart';
+import 'package:m_security/src/streaming/streaming_service.dart';
+
+/// Stand-in for a real handle. Nothing reaches native, so it is never used.
+class _NeverUsedCipher implements CipherHandle {
+  @override
+  void dispose() {}
+
+  @override
+  bool get isDisposed => false;
+}
+
+class _NeverUsedVault implements VaultHandle {
+  @override
+  void dispose() {}
+
+  @override
+  bool get isDisposed => false;
+
+  @override
+  Future<VaultHealthInfo> health() => throw UnimplementedError();
+}
+
+Future<Object?> errorFrom(Future<void> call) async {
+  try {
+    await call;
+  } catch (error) {
+    return error;
+  }
+  return null;
+}
+
+Future<({List<double> values, List<Object> errors})> drain(
+  Stream<double> progress,
+) async {
+  final values = <double>[];
+  final errors = <Object>[];
+  final done = Completer<void>();
+
+  progress.listen(
+    values.add,
+    onError: errors.add,
+    onDone: done.complete,
+    cancelOnError: false,
+  );
+  await done.future;
+
+  return (values: values, errors: errors);
+}
+
+void main() {
+  // RustLib is deliberately never initialised. The archive and encrypted-stream
+  // methods have to refuse before they reach the bridge, so these pass without
+  // a native library. Anything that did reach the bridge would fail differently.
+  final cipher = _NeverUsedCipher();
+  final vault = _NeverUsedVault();
+
+  group('archive methods', () {
+    test('export returns one disabled-format error', () async {
+      final error = await errorFrom(
+        VaultService.export(
+          handle: vault,
+          wrappingKey: Uint8List(32),
+          exportPath: '/definitely/not/writable/out.mvex',
+        ),
+      );
+
+      expect(error, isA<CryptoError_DisabledFormat>());
+      expect(
+        (error as CryptoError_DisabledFormat).field0,
+        contains('.mvex archive export'),
+      );
+    });
+
+    test('import returns one disabled-format error', () async {
+      final error = await errorFrom(
+        VaultService.importVault(
+          archivePath: '/definitely/not/there/in.mvex',
+          wrappingKey: Uint8List(32),
+          destPath: '/definitely/not/writable/out.vault',
+          newMasterKey: Uint8List(32),
+          algorithm: 'aes-256-gcm',
+          capacityBytes: 1024 * 1024,
+        ),
+      );
+
+      expect(error, isA<CryptoError_DisabledFormat>());
+      expect(
+        (error as CryptoError_DisabledFormat).field0,
+        contains('.mvex archive import'),
+      );
+    });
+  });
+
+  group('encrypted stream methods', () {
+    final calls = <String, Stream<double> Function()>{
+      'encryptFile': () => StreamingService.encryptFile(
+        inputPath: '/definitely/not/there/in.bin',
+        outputPath: '/definitely/not/writable/out.bin',
+        cipher: cipher,
+      ),
+      'decryptFile': () => StreamingService.decryptFile(
+        inputPath: '/definitely/not/there/in.bin',
+        outputPath: '/definitely/not/writable/out.bin',
+        cipher: cipher,
+      ),
+      'compressAndEncryptFile': () => CompressionService.compressAndEncryptFile(
+        inputPath: '/definitely/not/there/in.bin',
+        outputPath: '/definitely/not/writable/out.bin',
+        cipher: cipher,
+        config: const CompressionConfig(algorithm: CompressionAlgorithm.zstd),
+      ),
+      'decryptAndDecompressFile': () =>
+          CompressionService.decryptAndDecompressFile(
+            inputPath: '/definitely/not/there/in.bin',
+            outputPath: '/definitely/not/writable/out.bin',
+            cipher: cipher,
+          ),
+    };
+
+    for (final entry in calls.entries) {
+      test('${entry.key} emits exactly one disabled-format error', () async {
+        final outcome = await drain(entry.value());
+
+        expect(outcome.values, isEmpty);
+        expect(outcome.errors, hasLength(1));
+        expect(outcome.errors.single, isA<CryptoError_DisabledFormat>());
+      });
+    }
+  });
+
+  group('the policy enum', () {
+    // A Dart function type carries no default values, so nothing here can see
+    // which value `create` and `open` fall back to. That default is pinned by
+    // the source scan in the Rust suite and by the device tests, which are the
+    // only two places a flip is caught.
+    test('denial is the first variant, so a zeroed wire value denies', () {
+      expect(UnsafeLegacyEvfsPolicy.values.first, UnsafeLegacyEvfsPolicy.deny);
+      expect(UnsafeLegacyEvfsPolicy.deny.index, 0);
+      expect(UnsafeLegacyEvfsPolicy.values, hasLength(2));
+    });
+  });
+}


### PR DESCRIPTION
Creating or opening a vault now fails by default. You get a typed error until you pass `unsafeLegacyPolicy` and say you accept the format as it is.

The `.vault` container this library writes derives keys with no per-vault salt, and repeats AEAD nonces across separate vaults and across copies of the same file. Its structural metadata is unauthenticated, and it isn't crash atomic. `.mvex`, the portable export archive, keeps segment names, user metadata and content checksums in the clear behind a trailer anyone can recompute. The standalone encrypted stream binds a chunk to nothing but its index and finality, so a chunk from another stream under the same key splices in. Fixing any of that means a new format, and that isn't this patch.

`create` and `open` take an optional `unsafeLegacyPolicy` and deny before they open, create, lock or recover anything. Existing code still compiles. The archive and encrypted-stream methods keep their signatures and return one `disabledFormat` result, and their Rust entries are no longer `pub`, so the wire entries and exported symbols go with them. Stream hashing and every handle-based vault method are untouched, and the parsers stay in the tree for the fixtures.

Nothing on disk changes. Opting in isn't a claim that the format is safe, only that the caller knows what it is.

One thing the diff hides: the caller's key now gets wiped before the lock and the preallocation instead of after. The same pass turned up an older leak, where rotation dropped the new master key unwiped if it couldn't take the rotation lock.
